### PR TITLE
datamodel: add non-issue fields based on zenodo/datacite

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -107,7 +107,7 @@ RECORDS_REST_DEFAULT_SORT = dict(
 
 # Records Permissions
 
-RECORDS_PERMISSIONS_RECORD_FACTORY = (
+RECORDS_PERMISSIONS_RECORD_POLICY = (
     'invenio_rdm_records.permissions.RDMRecordPermissionPolicy'
 )
 """PermissionPolicy used by permission factories above."""

--- a/invenio_rdm_records/data/objecttypes.json
+++ b/invenio_rdm_records/data/objecttypes.json
@@ -1,0 +1,678 @@
+[{
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication",
+    "id": "https://zenodo.org/objecttypes/publication#",
+    "title": {
+      "en": "Publication"
+    },
+    "title_plural": {
+      "en": "Publications"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "children": [
+      {"$ref": "https://zenodo.org/objecttypes/publication/book"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/section"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/conferencepaper"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/article"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/patent"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/preprint"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/report"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/softwaredocumentation"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/thesis"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/technicalnote"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/workingpaper"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/other"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/datamanagementplan"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/annotationcollection"},
+      {"$ref": "https://zenodo.org/objecttypes/publication/taxonomictreatment"}
+    ],
+    "openaire": {
+      "resourceType": "0001",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "poster",
+    "id": "https://zenodo.org/objecttypes/poster#",
+    "title": {
+      "en": "Poster"
+    },
+    "title_plural": {
+      "en": "Posters"
+    },
+    "datacite": {"general": "Text", "type": "Poster"},
+    "eurepo": "info:eu-repo/semantics/conferencePoster",
+    "schema.org": "https://schema.org/CreativeWork",
+    "openaire": {
+      "resourceType": "0004",
+      "type": "publication"
+    },
+    "csl": "graphic"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "presentation",
+    "id": "https://zenodo.org/objecttypes/presentation#",
+    "title": {
+      "en": "Presentation"
+    },
+    "title_plural": {
+      "en": "Presentations"
+    },
+    "datacite": {"general": "Text", "type": "Presentation"},
+    "eurepo": "info:eu-repo/semantics/lecture",
+    "schema.org": "https://schema.org/PresentationDigitalDocument",
+    "openaire": {
+      "resourceType": "0004",
+      "type": "publication"
+    },
+    "csl": "speech"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "dataset",
+    "id": "https://zenodo.org/objecttypes/dataset#",
+    "title": {
+      "en": "Dataset"
+    },
+    "title_plural": {
+      "en": "Datasets"
+    },
+    "datacite": {"general": "Dataset"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "schema.org": "https://schema.org/Dataset",
+    "openaire": {
+      "resourceType": "0021",
+      "type": "dataset"
+    },
+    "csl": "dataset"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image",
+    "id": "https://zenodo.org/objecttypes/image#",
+    "title": {
+      "en": "Image"
+    },
+    "title_plural": {
+      "en": "Images"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "children": [
+      {"$ref": "https://zenodo.org/objecttypes/image/figure"},
+      {"$ref": "https://zenodo.org/objecttypes/image/plot"},
+      {"$ref": "https://zenodo.org/objecttypes/image/drawing"},
+      {"$ref": "https://zenodo.org/objecttypes/image/diagram"},
+      {"$ref": "https://zenodo.org/objecttypes/image/photo"},
+      {"$ref": "https://zenodo.org/objecttypes/image/other"}
+    ],
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "graphic"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "video",
+    "id": "https://zenodo.org/objecttypes/video",
+    "title": {
+      "en": "Video/Audio"
+    },
+    "title_plural": {
+      "en": "Videos/Audio"
+    },
+    "datacite": {"general": "Audiovisual"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "schema.org": "https://schema.org/MediaObject",
+    "openaire": {
+      "resourceType": "0033",
+      "type": "dataset"
+    },
+    "csl": "motion_picture"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "software",
+    "id": "https://zenodo.org/objecttypes/software#",
+    "title": {
+      "en": "Software"
+    },
+    "title_plural": {
+      "en": "Software"
+    },
+    "datacite": {"general": "Software"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "openaire": {
+      "resourceType": "0029",
+      "type": "software"
+    },
+    "schema.org": "https://schema.org/SoftwareSourceCode",
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "lesson",
+    "id": "https://zenodo.org/objecttypes/lesson#",
+    "title": {
+      "en": "Lesson"
+    },
+    "title_plural": {
+      "en": "Lessons"
+    },
+    "datacite": {"general": "InteractiveResource"},
+    "eurepo": "info:eu-repo/semantics/lecture",
+    "schema.org": "https://schema.org/CreativeWork",
+    "openaire": {
+      "resourceType": "0010",
+      "type": "other"
+    },
+    "csl": "speech"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "other",
+    "id": "https://zenodo.org/objecttypes/other#",
+    "title": {
+      "en": "Other"
+    },
+    "title_plural": {
+      "en": "Other"
+    },
+    "datacite": {"general": "Other"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "schema.org": "https://schema.org/CreativeWork",
+    "openaire": {
+      "resourceType": "0020",
+      "type": "other"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-book",
+    "id": "https://zenodo.org/objecttypes/publication/book#",
+    "title": {
+      "en": "Book"
+    },
+    "title_plural": {
+      "en": "Books"
+    },
+    "schema.org": "https://schema.org/Book",
+    "datacite": {"general": "Text", "type": "Book"},
+    "eurepo": "info:eu-repo/semantics/book",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0002",
+      "type": "publication"
+    },
+    "csl": "book"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-section",
+    "id": "https://zenodo.org/objecttypes/publication/section#",
+    "title": {
+      "en": "Book section"
+    },
+    "title_plural": {
+      "en": "Book sections"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Book section"},
+    "eurepo": "info:eu-repo/semantics/bookPart",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0013",
+      "type": "publication"
+    },
+    "csl": "chapter"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-conferencepaper",
+    "id": "https://zenodo.org/objecttypes/publication/conferencepaper#",
+    "title": {
+      "en": "Conference paper"
+    },
+    "title_plural": {
+      "en": "Conference papers"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Conference paper"},
+    "eurepo": "info:eu-repo/semantics/conferencePaper",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0004",
+      "type": "publication"
+    },
+    "csl": "paper-conference"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-article",
+    "id": "https://zenodo.org/objecttypes/publication/article#",
+    "title": {
+      "en": "Journal article"
+    },
+    "title_plural": {
+      "en": "Journal articles"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Journal article"},
+    "eurepo": "info:eu-repo/semantics/article",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0001",
+      "type": "publication"
+    },
+    "csl": "article-journal"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-patent",
+    "id": "https://zenodo.org/objecttypes/publication/patent#",
+    "title": {
+      "en": "Patent"
+    },
+    "title_plural": {
+      "en": "Patents"
+    },
+    "datacite": {"general": "Text", "type": "Patent"},
+    "eurepo": "info:eu-repo/semantics/patent",
+    "schema.org": "https://schema.org/CreativeWork",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0019",
+      "type": "publication"
+    },
+    "csl": "patent"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-preprint",
+    "id": "https://zenodo.org/objecttypes/publication/preprint#",
+    "title": {
+      "en": "Preprint"
+    },
+    "title_plural": {
+      "en": "Preprints"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Preprint"},
+    "eurepo": "info:eu-repo/semantics/preprint",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0016",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-report",
+    "id": "https://zenodo.org/objecttypes/publication/report#",
+    "title": {
+      "en": "Report"
+    },
+    "title_plural": {
+      "en": "Reports"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Report"},
+    "eurepo": "info:eu-repo/semantics/report",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0017",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-softwaredocumentation",
+    "id": "https://zenodo.org/objecttypes/publication/softwaredocumentation#",
+    "title": {
+      "en": "Software documentation"
+    },
+    "title_plural": {
+      "en": "Software documentation"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Software documentation"},
+    "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0009",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-thesis",
+    "id": "https://zenodo.org/objecttypes/publication/thesis#",
+    "title": {
+      "en": "Thesis"
+    },
+    "title_plural": {
+      "en": "Theses"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Thesis"},
+    "eurepo": "info:eu-repo/semantics/doctoralThesis",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0006",
+      "type": "publication"
+    },
+    "csl": "thesis"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-technicalnote",
+    "id": "https://zenodo.org/objecttypes/publication/technicalnote#",
+    "title": {
+      "en": "Technical note"
+    },
+    "title_plural": {
+      "en": "Technical notes"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Technical note"},
+    "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0009",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-workingpaper",
+    "id": "https://zenodo.org/objecttypes/publication/workingpaper#",
+    "title": {
+      "en": "Working paper"
+    },
+    "title_plural": {
+      "en": "Working papers"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Working paper"},
+    "eurepo": "info:eu-repo/semantics/workingPaper",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0014",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-proposal",
+    "id": "https://zenodo.org/objecttypes/publication/proposal#",
+    "title": {
+      "en": "Proposal"
+    },
+    "title_plural": {
+      "en": "Proposals"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Proposal"},
+    "eurepo": "info:eu-repo/semantics/researchProposal",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0036",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-deliverable",
+    "id": "https://zenodo.org/objecttypes/publication/deliverable#",
+    "title": {
+      "en": "Project deliverable"
+    },
+    "title_plural": {
+      "en": "Project deliverable"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Project deliverable"},
+    "eurepo": "info:eu-repo/semantics/report",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0034",
+      "type": "publication"
+    },
+    "csl": "report"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-milestone",
+    "id": "https://zenodo.org/objecttypes/publication/milestone#",
+    "title": {
+      "en": "Project milestone"
+    },
+    "title_plural": {
+      "en": "Project milestone"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Project milestone"},
+    "eurepo": "info:eu-repo/semantics/report",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0035",
+      "type": "publication"
+    },
+    "csl": "report"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-other",
+    "id": "https://zenodo.org/objecttypes/publication/other#",
+    "title": {
+      "en": "Other"
+    },
+    "title_plural": {
+      "en": "Other"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Other"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0020",
+      "type": "publication"
+    },
+    "csl": "article"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-figure",
+    "id": "https://zenodo.org/objecttypes/image/figure#",
+    "title": {
+      "en": "Figure"
+    },
+    "title_plural": {
+      "en": "Figures"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image", "type": "Figure"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image#"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "figure"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-plot",
+    "id": "https://zenodo.org/objecttypes/image/plot#",
+    "title": {
+      "en": "Plot"
+    },
+    "title_plural": {
+      "en": "Plots"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image", "type": "Plot"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "figure"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-drawing",
+    "id": "https://zenodo.org/objecttypes/image/drawing#",
+    "title": {
+      "en": "Drawing"
+    },
+    "title_plural": {
+      "en": "Drawings"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image", "type": "Drawing"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "graphic"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-diagram",
+    "id": "https://zenodo.org/objecttypes/image/diagram#",
+    "title": {
+      "en": "Diagram"
+    },
+    "title_plural": {
+      "en": "Diagrams"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image", "type": "Diagram"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "figure"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-photo",
+    "id": "https://zenodo.org/objecttypes/image/photo#",
+    "title": {
+      "en": "Photo"
+    },
+    "title_plural": {
+      "en": "Photos"
+    },
+    "schema.org": "https://schema.org/Photograph",
+    "datacite": {"general": "Image", "type": "Photo"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "graphic"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "image-other",
+    "id": "https://zenodo.org/objecttypes/image/other#",
+    "title": {
+      "en": "Other"
+    },
+    "title_plural": {
+      "en": "Other"
+    },
+    "schema.org": "https://schema.org/ImageObject",
+    "datacite": {"general": "Image", "type": "Other"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/image"},
+    "openaire": {
+      "resourceType": "0025",
+      "type": "dataset"
+    },
+    "csl": "graphic"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-datamanagementplan",
+    "id": "https://zenodo.org/objecttypes/publication/datamanagementplan#",
+    "title": {
+      "en": "Data management plan"
+    },
+    "title_plural": {
+      "en": "Data management plans"
+    },
+    "schema.org": "https://schema.org/CreativeWork",
+    "datacite": {"general": "Text", "type": "Data Management Plan"},
+    "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0009",
+      "type": "publication"
+    },
+    "csl": "report"
+  },
+  
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-annotationcollection",
+    "id": "https://zenodo.org/objecttypes/publication/annotationcollection#",
+    "title": {
+      "en": "Annotation collection"
+    },
+    "title_plural": {
+      "en": "Annotation collections"
+    },
+    "schema.org": "https://schema.org/Collection",
+    "datacite": {"general": "Collection"},
+    "eurepo": "info:eu-repo/semantics/technicalDocumentation",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0009",
+      "type": "publication"
+    },
+    "csl": "report"
+  },
+  {
+    "$schema": "https://zenodo.org/schemas/records/objecttype-v1.0.0.json",
+    "internal_id": "publication-taxonomictreatment",
+    "id": "https://zenodo.org/objecttypes/publication/taxonomictreatment#",
+    "title": {
+      "en": "Taxonomic treatment"
+    },
+    "title_plural": {
+      "en": "Taxonomic treatments"
+    },
+    "schema.org": "https://schema.org/ScholarlyArticle",
+    "datacite": {"general": "Text", "type": "Taxonomic treatment"},
+    "eurepo": "info:eu-repo/semantics/other",
+    "parent": {"$ref": "https://zenodo.org/objecttypes/publication"},
+    "openaire": {
+      "resourceType": "0020",
+      "type": "publication"
+    },
+    "csl": "article"
+  }]
+  

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -155,7 +155,7 @@
       "type": "array"
     },
     "description": {
-      "description": "Description/abstract for record.",
+      "description": "Description for record.",
       "type": "string"
     },
     "embargo_date": {

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -254,6 +254,42 @@
       ],
       "type": "object"
     },
+    "rights": {
+      "description": "Any rights information for this resource.",
+      "type": "array",
+      "items": {
+          "type": "object",
+          "properties": {
+              "rights": {
+                "description": "The right itself. Free text.",
+                "type": "string"
+              },
+              "uri": {
+                "description": "The URI of the license.",
+                "type": "string",
+                "format": "uri"
+              },
+              "identifier": {
+                "description": "A short, standardized version of the license name.",
+                "type": "string"
+              },
+              "identifier_scheme": {
+                "description": "The name of the scheme.",
+                "type": "string"
+              },
+              "scheme_uri": {
+                "description": "The URI of the identifier_scheme.",
+                "type": "string",
+                "format": "uri"
+              },
+              "lang": {
+                "description": "Language of the right information",
+                "type": "string"
+              }
+          }
+      },
+      "uniqueItems": true
+    },
     "title": {
       "description": "Record title.",
       "type": "string"

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -209,6 +209,10 @@
       },
       "type": "array"
     },
+    "language": {
+      "description": "Primary language of the resource. ISO 639-3 language code.",
+      "type": "string"
+    },
     "owners": {
       "description": "List of user IDs that are owners of the record.",
       "items": {

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -122,7 +122,6 @@
         "required": [
           "name"
         ]
-
       }
     },
     "dates": {
@@ -161,7 +160,6 @@
     },
     "embargo_date": {
       "description": "Embargo date of record (ISO8601 formatted date).",
-      "title": "Embargo Date",
       "type": "string",
       "format": "date-time"
     },
@@ -192,17 +190,13 @@
       "format": "date-time"
     },
     "recid": {
-      "description": "Invenio record identifier (integer).",
-      "type": "number"
+      "description": "Invenio record identifier (alphanumeric).",
+      "type": "string"
     },
     "resource_type": {
       "additionalProperties": false,
       "description": "Record resource type.",
       "properties": {
-        "openaire_subtype": {
-          "description": "OpenAIRE-specific resource type.",
-          "type": "string"
-        },
         "subtype": {
           "description": "Specific resource type.",
           "type": "string"
@@ -214,7 +208,8 @@
         }
       },
       "required": [
-        "type"
+        "type",
+        "subtype"
       ],
       "type": "object"
     },

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -12,6 +12,17 @@
           "TranslatedTitle",
           "Other"
       ]
+    },
+    "description_type": {
+      "type": "string",
+      "enum": [
+          "Abstract",
+          "Methods",
+          "SeriesInformation",
+          "TableOfContents",
+          "TechnicalInfo",
+          "Other"
+      ]
     }
   },
   "type": "object",
@@ -43,6 +54,28 @@
         "closed"
       ],
       "type": "string"
+    },
+    "additional_descriptions": {
+      "type": "array",
+      "items": {
+          "type": "object",
+          "properties": {
+              "description": {
+                "description": "Description/abstract for record.",
+                "type": "string"
+              },
+              "description_type": {
+                "description": "Type of description.",
+                "$ref": "#/definitions/description_type"
+              },
+              "lang": {
+                "description": "Language of the description.",
+                "type": "string"
+              }
+          },
+          "required": ["description", "description_type"]
+      },
+      "uniqueItems": true
     },
     "additional_titles": {
       "type": "array",

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -2,29 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "id": "http://localhost/schemas/records/record-v1.0.0.json",
   "title": "Invenio Datacite based Record Schema v1.0.0",
-  "definitions": {
-    "title_type": {
-      "description": "Alternative titles types.",
-      "type": "string",
-      "enum": [
-          "AlternativeTitle",
-          "Subtitle",
-          "TranslatedTitle",
-          "Other"
-      ]
-    },
-    "description_type": {
-      "type": "string",
-      "enum": [
-          "Abstract",
-          "Methods",
-          "SeriesInformation",
-          "TableOfContents",
-          "TechnicalInfo",
-          "Other"
-      ]
-    }
-  },
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -47,12 +24,6 @@
     "access_right": {
       "default": "open",
       "description": "Access right for record.",
-      "enum": [
-        "open",
-        "embargoed",
-        "restricted",
-        "closed"
-      ],
       "type": "string"
     },
     "additional_descriptions": {
@@ -66,7 +37,7 @@
               },
               "description_type": {
                 "description": "Type of description.",
-                "$ref": "#/definitions/description_type"
+                "type": "string"
               },
               "lang": {
                 "description": "Language of the description. ISO 639-3 language code.",
@@ -88,7 +59,7 @@
             },
             "title_type": {
               "description": "Type of title.",
-              "$ref": "#/definitions/title_type"
+              "type": "string"
             },
             "lang": {
               "description": "Language of the title. ISO 639-3 language code.",
@@ -143,12 +114,7 @@
           },
           "role": {
             "description": "",
-            "type": "string",
-            "enum": [
-              "ContactPerson",
-              "Researcher",
-              "Other"
-            ]
+            "type": "string"
           }
         },
         "required": [
@@ -177,12 +143,7 @@
             "format": "date-time"
           },
           "type": {
-            "description": "Type of the date interval.",
-            "enum": [
-              "Collected",
-              "Valid",
-              "Withdrawn"
-            ]
+            "description": "Type of the date interval."
           }
         },
         "required": [

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -53,7 +53,7 @@
               "description": "Title of the record.",
               "type": "string"
             },
-            "type": {
+            "title_type": {
               "description": "Type of title.",
               "$ref": "#/definitions/title_type"
             },

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -157,9 +157,50 @@
 
       }
     },
+    "dates": {
+      "description": "Date interval.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "description": "Description of the date interval.",
+            "type": "string"
+          },
+          "end": {
+            "description": "End date.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "start": {
+            "description": "Start date.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "description": "Type of the date interval.",
+            "enum": [
+              "Collected",
+              "Valid",
+              "Withdrawn"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "description": {
       "description": "Description/abstract for record.",
       "type": "string"
+    },
+    "embargo_date": {
+      "description": "Embargo date of record (ISO8601 formatted date).",
+      "title": "Embargo Date",
+      "type": "string",
+      "format": "date-time"
     },
     "keywords": {
       "description": "Free text keywords.",
@@ -178,7 +219,7 @@
       "uniqueItems": true
     },
     "publication_date": {
-      "description": "When the record is published",
+      "description": "Record publication date (IS8601-formatted). EDTF support to be added for field.",
       "type": "string",
       "format": "date-time"
     },
@@ -218,7 +259,9 @@
     "_access",
     "access_right",
     "contributors",
+    "description",
     "owners",
+    "publication_date",
     "resource_type",
     "title"
   ]

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -32,39 +32,6 @@
       ],
       "type": "string"
     },
-    "recid": {
-      "description": "Invenio record identifier (integer).",
-      "type": "number"
-    },
-    "title": {
-      "description": "Record title.",
-      "type": "string"
-    },
-    "description": {
-      "description": "Description/abstract for record.",
-      "type": "string"
-    },
-    "owners": {
-      "description": "List of user IDs that are owners of the record.",
-      "items": {
-        "type": "number"
-      },
-      "type": "array",
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "keywords": {
-      "description": "Free text keywords.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "publication_date": {
-      "description": "When the record is published",
-      "type": "string",
-      "format": "date-time"
-    },
     "contributors": {
       "description": "Contributors in order of importance.",
       "minItems": 1,
@@ -123,19 +90,70 @@
 
       }
     },
-    "_created": {
+    "description": {
+      "description": "Description/abstract for record.",
       "type": "string"
     },
-    "_updated": {
+    "keywords": {
+      "description": "Free text keywords.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "owners": {
+      "description": "List of user IDs that are owners of the record.",
+      "items": {
+        "type": "number"
+      },
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "publication_date": {
+      "description": "When the record is published",
+      "type": "string",
+      "format": "date-time"
+    },
+    "recid": {
+      "description": "Invenio record identifier (integer).",
+      "type": "number"
+    },
+    "resource_type": {
+      "additionalProperties": false,
+      "description": "Record resource type.",
+      "properties": {
+        "openaire_subtype": {
+          "description": "OpenAIRE-specific resource type.",
+          "type": "string"
+        },
+        "subtype": {
+          "description": "Specific resource type.",
+          "type": "string"
+        },
+        "type": {
+          "default": "publication",
+          "description": "General resource type.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "title": {
+      "description": "Record title.",
       "type": "string"
     }
   },
   "required": [
-    "access_right",
     "_access",
+    "access_right",
     "contributors",
-    "title",
-    "owners"
+    "owners",
+    "resource_type",
+    "title"
   ]
 }
 

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -69,7 +69,7 @@
                 "$ref": "#/definitions/description_type"
               },
               "lang": {
-                "description": "Language of the description.",
+                "description": "Language of the description. ISO 639-3 language code.",
                 "type": "string"
               }
           },
@@ -91,7 +91,7 @@
               "$ref": "#/definitions/title_type"
             },
             "lang": {
-              "description": "Language of the title.",
+              "description": "Language of the title. ISO 639-3 language code.",
               "type": "string"
             }
         },
@@ -283,7 +283,7 @@
                 "format": "uri"
               },
               "lang": {
-                "description": "Language of the right information",
+                "description": "Language of the right information. ISO 639-3 language code.",
                 "type": "string"
               }
           }

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -41,7 +41,8 @@
               },
               "lang": {
                 "description": "Language of the description. ISO 639-3 language code.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 3
               }
           },
           "required": ["description", "description_type"]
@@ -63,7 +64,8 @@
             },
             "lang": {
               "description": "Language of the title. ISO 639-3 language code.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 3
             }
         },
         "required": ["title"]
@@ -172,7 +174,8 @@
     },
     "language": {
       "description": "Primary language of the resource. ISO 639-3 language code.",
-      "type": "string"
+      "type": "string",
+      "maxLength": 3
     },
     "owners": {
       "description": "List of user IDs that are owners of the record.",
@@ -245,7 +248,8 @@
               },
               "lang": {
                 "description": "Language of the right information. ISO 639-3 language code.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 3
               }
           }
       },

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -2,6 +2,18 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "id": "http://localhost/schemas/records/record-v1.0.0.json",
   "title": "Invenio Datacite based Record Schema v1.0.0",
+  "definitions": {
+    "title_type": {
+      "description": "Alternative titles types.",
+      "type": "string",
+      "enum": [
+          "AlternativeTitle",
+          "Subtitle",
+          "TranslatedTitle",
+          "Other"
+      ]
+    }
+  },
   "type": "object",
   "additionalProperties": false,
   "properties": {
@@ -31,6 +43,28 @@
         "closed"
       ],
       "type": "string"
+    },
+    "additional_titles": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+            "title": {
+              "description": "Title of the record.",
+              "type": "string"
+            },
+            "type": {
+              "description": "Type of title.",
+              "$ref": "#/definitions/title_type"
+            },
+            "lang": {
+              "description": "Language of the title.",
+              "type": "string"
+            }
+        },
+        "required": ["title"]
+      },
+      "uniqueItems": true
     },
     "contributors": {
       "description": "Contributors in order of importance.",

--- a/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/jsonschemas/records/record-v1.0.0.json
@@ -257,6 +257,10 @@
     "title": {
       "description": "Record title.",
       "type": "string"
+    },
+    "version": {
+      "description": "Record version tag.",
+      "type": "string"
     }
   },
   "required": [

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -21,6 +21,20 @@
         "access_right": {
           "type": "keyword"
         },
+        "additional_descriptions": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "text"
+            },
+            "description_type": {
+              "type": "keyword"
+            },
+            "lang": {
+              "type": "keyword"
+            }
+          }
+        },
         "additional_titles": {
           "type": "object",
           "properties": {

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -22,7 +22,7 @@
           "type": "keyword"
         },
         "additional_descriptions": {
-          "type": "object",
+          "type": "nested",
           "properties": {
             "description": {
               "type": "text"
@@ -36,7 +36,7 @@
           }
         },
         "additional_titles": {
-          "type": "object",
+          "type": "nested",
           "properties": {
             "title": {
               "type": "text",
@@ -122,7 +122,7 @@
           "type": "keyword"
         },
         "resource_type": {
-          "type": "object",
+          "type": "nested",
           "properties": {
             "type": {
               "type": "keyword"
@@ -133,7 +133,7 @@
           }
         },
         "rights": {
-          "type": "object",
+          "type": "nested",
           "properties": {
             "rights": {
               "type": "text"

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -21,33 +21,6 @@
         "access_right": {
           "type": "keyword"
         },
-        "$schema": {
-          "type": "keyword",
-          "index": false
-        },
-        "recid": {
-          "type": "keyword"
-        },
-        "title": {
-          "type": "text",
-          "copy_to": "suggest_title"
-        },
-        "suggest_title": {
-          "type": "completion"
-        },
-        "description": {
-          "type": "text"
-        },
-        "owners": {
-          "type": "integer"
-        },
-        "keywords": {
-          "type": "keyword"
-        },
-        "publication_date": {
-          "type": "date",
-          "format": "date"
-        },
         "contributors": {
           "type": "object",
           "properties": {
@@ -81,11 +54,52 @@
             }
           }
         },
+        "description": {
+          "type": "text"
+        },
+        "keywords": {
+          "type": "keyword"
+        },
+        "owners": {
+          "type": "integer"
+        },
+        "publication_date": {
+          "type": "date",
+          "format": "date"
+        },
+        "recid": {
+          "type": "keyword"
+        },
+        "resource_type": {
+          "type": "object",
+          "properties": {
+            "openaire_subtype": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "subtype": {
+              "type": "keyword"
+            }
+          }
+        },
+        "suggest_title": {
+          "type": "completion"
+        },
+        "title": {
+          "type": "text",
+          "copy_to": "suggest_title"
+        },
         "_created": {
           "type": "date"
         },
         "_updated": {
           "type": "date"
+        },
+        "$schema": {
+          "type": "text",
+          "index": false
         }
       }
     }

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -109,6 +109,9 @@
         "keywords": {
           "type": "keyword"
         },
+        "language": {
+          "type": "keyword"
+        },
         "owners": {
           "type": "integer"
         },

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -152,7 +152,7 @@
           "type": "date"
         },
         "$schema": {
-          "type": "text",
+          "type": "keyword",
           "index": false
         }
       }

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -142,6 +142,9 @@
           "type": "text",
           "copy_to": "suggest_title"
         },
+        "version": {
+          "type": "keyword"
+        },
         "_created": {
           "type": "date"
         },

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -21,6 +21,21 @@
         "access_right": {
           "type": "keyword"
         },
+        "additional_titles": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "text",
+              "copy_to": "suggest_title"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "lang": {
+              "type": "keyword"
+            }
+          }
+        },
         "contributors": {
           "type": "object",
           "properties": {

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -28,7 +28,7 @@
               "type": "text",
               "copy_to": "suggest_title"
             },
-            "type": {
+            "title_type": {
               "type": "keyword"
             },
             "lang": {

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -135,6 +135,29 @@
             }
           }
         },
+        "rights": {
+          "type": "object",
+          "properties": {
+            "rights": {
+              "type": "text"
+            },
+            "uri": {
+              "type": "keyword"
+            },
+            "identifier": {
+              "type": "keyword"
+            },
+            "identifier_scheme": {
+              "type": "keyword"
+            },
+            "scheme_uri": {
+              "type": "keyword"
+            },
+            "lang": {
+              "type": "keyword"
+            }
+          }
+        },
         "suggest_title": {
           "type": "completion"
         },

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -83,8 +83,28 @@
             }
           }
         },
+        "dates": {
+          "type": "object",
+          "properties": {
+            "start": {
+              "type": "date"
+            },
+            "end": {
+              "type": "date"
+            },
+            "type": {
+              "type": "keyword"
+            },
+            "description": {
+              "type": "text"
+            }
+          }
+        },
         "description": {
           "type": "text"
+        },
+        "embargo_date": {
+          "type": "date"
         },
         "keywords": {
           "type": "keyword"
@@ -93,8 +113,7 @@
           "type": "integer"
         },
         "publication_date": {
-          "type": "date",
-          "format": "date"
+          "type": "date"
         },
         "recid": {
           "type": "keyword"

--- a/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v6/records/record-v1.0.0.json
@@ -124,9 +124,6 @@
         "resource_type": {
           "type": "object",
           "properties": {
-            "openaire_subtype": {
-              "type": "keyword"
-            },
             "type": {
               "type": "keyword"
             },

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -20,6 +20,21 @@
       "access_right": {
         "type": "keyword"
       },
+      "additional_titles": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "text",
+            "copy_to": "suggest_title"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
       "$schema": {
         "type": "keyword",
         "index": false

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -20,6 +20,20 @@
       "access_right": {
         "type": "keyword"
       },
+      "additional_descriptions": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "text"
+          },
+          "description_type": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
       "additional_titles": {
         "type": "object",
         "properties": {

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -123,9 +123,6 @@
       "resource_type": {
         "type": "object",
         "properties": {
-          "openaire_subtype": {
-            "type": "keyword"
-          },
           "type": {
             "type": "keyword"
           },

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -49,6 +49,26 @@
           }
         }
       },
+      "dates": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "date"
+          },
+          "end": {
+            "type": "date"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "description": {
+            "type": "text"
+          }
+        }
+      },
+      "embargo_date": {
+        "type": "date"
+      },
       "$schema": {
         "type": "keyword",
         "index": false
@@ -73,8 +93,7 @@
         "type": "keyword"
       },
       "publication_date": {
-        "type": "date",
-        "format": "date"
+        "type": "date"
       },
       "contributors": {
         "type": "object",

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -49,58 +49,6 @@
           }
         }
       },
-      "dates": {
-        "type": "object",
-        "properties": {
-          "start": {
-            "type": "date"
-          },
-          "end": {
-            "type": "date"
-          },
-          "type": {
-            "type": "keyword"
-          },
-          "description": {
-            "type": "text"
-          }
-        }
-      },
-      "embargo_date": {
-        "type": "date"
-      },
-      "language": {
-        "type": "keyword"
-      },
-      "version": {
-        "type": "keyword"
-      },
-      "$schema": {
-        "type": "keyword",
-        "index": false
-      },
-      "recid": {
-        "type": "keyword"
-      },
-      "title": {
-        "type": "text",
-        "copy_to": "suggest_title"
-      },
-      "suggest_title": {
-        "type": "completion"
-      },
-      "description": {
-        "type": "text"
-      },
-      "owners": {
-        "type": "integer"
-      },
-      "keywords": {
-        "type": "keyword"
-      },
-      "publication_date": {
-        "type": "date"
-      },
       "contributors": {
         "type": "object",
         "properties": {
@@ -134,11 +82,77 @@
           }
         }
       },
+      "dates": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "date"
+          },
+          "end": {
+            "type": "date"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "description": {
+            "type": "text"
+          }
+        }
+      },
+      "description": {
+        "type": "text"
+      },
+      "embargo_date": {
+        "type": "date"
+      },
+      "keywords": {
+        "type": "keyword"
+      },
+      "language": {
+        "type": "keyword"
+      },
+      "owners": {
+        "type": "integer"
+      },
+      "publication_date": {
+        "type": "date"
+      },
+      "recid": {
+        "type": "keyword"
+      },
+      "resource_type": {
+        "type": "object",
+        "properties": {
+          "openaire_subtype": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "subtype": {
+            "type": "keyword"
+          }
+        }
+      },
+      "suggest_title": {
+        "type": "completion"
+      },
+      "title": {
+        "type": "text",
+        "copy_to": "suggest_title"
+      },
+      "version": {
+        "type": "keyword"
+      },
       "_created": {
         "type": "date"
       },
       "_updated": {
         "type": "date"
+      },
+      "$schema": {
+        "type": "keyword",
+        "index": false
       }
     }
   }

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -21,7 +21,7 @@
         "type": "keyword"
       },
       "additional_descriptions": {
-        "type": "object",
+        "type": "nested",
         "properties": {
           "description": {
             "type": "text"
@@ -35,7 +35,7 @@
         }
       },
       "additional_titles": {
-        "type": "object",
+        "type": "nested",
         "properties": {
           "title": {
             "type": "text",
@@ -121,7 +121,7 @@
         "type": "keyword"
       },
       "resource_type": {
-        "type": "object",
+        "type": "nested",
         "properties": {
           "type": {
             "type": "keyword"
@@ -132,7 +132,7 @@
         }
       },
       "rights": {
-        "type": "object",
+        "type": "nested",
         "properties": {
           "rights": {
             "type": "text"

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -134,6 +134,29 @@
           }
         }
       },
+      "rights": {
+        "type": "object",
+        "properties": {
+          "rights": {
+            "type": "text"
+          },
+          "uri": {
+            "type": "keyword"
+          },
+          "identifier": {
+            "type": "keyword"
+          },
+          "identifier_scheme": {
+            "type": "keyword"
+          },
+          "scheme_uri": {
+            "type": "keyword"
+          },
+          "lang": {
+            "type": "keyword"
+          }
+        }
+      },
       "suggest_title": {
         "type": "completion"
       },

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -72,6 +72,9 @@
       "language": {
         "type": "keyword"
       },
+      "version": {
+        "type": "keyword"
+      },
       "$schema": {
         "type": "keyword",
         "index": false

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -69,6 +69,9 @@
       "embargo_date": {
         "type": "date"
       },
+      "language": {
+        "type": "keyword"
+      },
       "$schema": {
         "type": "keyword",
         "index": false

--- a/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
+++ b/invenio_rdm_records/mappings/v7/records/record-v1.0.0.json
@@ -27,7 +27,7 @@
             "type": "text",
             "copy_to": "suggest_title"
           },
-          "type": {
+          "title_type": {
             "type": "keyword"
           },
           "lang": {

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -132,6 +132,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     publication_date = DateString()
     contributors = Nested(ContributorSchemaV1, many=True, required=True)
     resource_type = fields.Nested(ResourceTypeSchemaV1)
+    version = SanitizedUnicode()
 
     @pre_load()
     def preload_publicationdate(self, data):

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -110,6 +110,17 @@ class DateSchemaV1(StrictKeysMixin):
     description = fields.Str()
 
 
+class RightSchemaV1(StrictKeysMixin):
+    """Schema for rights."""
+
+    rights = SanitizedUnicode()
+    uri = SanitizedUnicode()
+    identifier = SanitizedUnicode()
+    identifier_scheme = SanitizedUnicode()
+    scheme_uri = SanitizedUnicode()
+    lang = SanitizedUnicode()
+
+
 class MetadataSchemaV1(StrictKeysMixin):
     """Schema for the record metadata."""
 
@@ -131,6 +142,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     publication_date = DateString()
     recid = PersistentIdentifier()
     resource_type = fields.Nested(ResourceTypeSchemaV1)
+    rights = fields.List(fields.Nested(RightSchemaV1))
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     version = SanitizedUnicode()
 

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -89,12 +89,23 @@ class TitleSchemaV1(StrictKeysMixin):
     lang = SanitizedUnicode()
 
 
+class DescriptionSchemaV1(StrictKeysMixin):
+    """Schema for the additional descriptions."""
+
+    description = SanitizedUnicode(required=True,
+                                   validate=validate.Length(min=3))
+    # TODO: Shall it be checked against the enum?
+    description_type = SanitizedUnicode()
+    lang = SanitizedUnicode()
+
+
 class MetadataSchemaV1(StrictKeysMixin):
     """Schema for the record metadata."""
 
     # TODO: Check enumeration (i.e. only open/embargoed/... accepted)
     access_right = SanitizedUnicode(required=True)
     access = fields.Nested(AccessSchemaV1)
+    additional_descriptions = fields.List(fields.Nested(DescriptionSchemaV1))
     additional_titles = fields.List(fields.Nested(TitleSchemaV1))
     recid = PersistentIdentifier()
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -50,19 +50,13 @@ class ContributorSchemaV1(StrictKeysMixin):
 
     ids = fields.Nested(PersonIdsSchemaV1, many=True)
     name = SanitizedUnicode(required=True)
-    role = SanitizedUnicode()
+    role = SanitizedUnicode(
+        validate=validate.OneOf(
+            choices=ROLES,
+            error=_('Invalid role. {input} not one of {choices}.')
+        ))
     affiliations = fields.List(SanitizedUnicode())
     email = fields.Email()
-
-    @validates('role')
-    def validate_role(self, value):
-        """Validate that the role is one of the allowed ones."""
-        if value not in self.ROLES:
-            raise ValidationError(
-                _('Invalid role. Not one of {allowed}.'.format(
-                                                        allowed=self.ROLES)),
-                field_names=['contributor']
-            )
 
 
 class ResourceTypeSchemaV1(StrictKeysMixin):
@@ -109,23 +103,11 @@ class TitleSchemaV1(StrictKeysMixin):
     ]
 
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
-    title_type = SanitizedUnicode()
-    lang = SanitizedUnicode()
-
-    @validates('lang')
-    def validate_language(self, value):
-        """Validate that language is ISO 639-3 value."""
-        validate_iso639_3(value)
-
-    @validates('title_type')
-    def validate_title_type(self, value):
-        """Validate that the title type is one of the allowed ones."""
-        if value not in self.TITLE_TYPES:
-            raise ValidationError(
-                _('Invalid title type. Not one of {allowed}.'.format(
-                                                    allowed=self.TITLE_TYPES)),
-                field_names=['additional_titles']
-            )
+    title_type = SanitizedUnicode(validate=validate.OneOf(
+            choices=TITLE_TYPES,
+            error=_('Invalid title type. {input} not one of {choices}.')
+        ))
+    lang = SanitizedUnicode(validate=validate_iso639_3)
 
 
 class DescriptionSchemaV1(StrictKeysMixin):
@@ -141,23 +123,11 @@ class DescriptionSchemaV1(StrictKeysMixin):
     ]
     description = SanitizedUnicode(required=True,
                                    validate=validate.Length(min=3))
-    description_type = SanitizedUnicode()
-    lang = SanitizedUnicode()
-
-    @validates('lang')
-    def validate_language(self, value):
-        """Validate that language is ISO 639-3 value."""
-        validate_iso639_3(value)
-
-    @validates('description_type')
-    def validate_description_type(self, value):
-        """Validate that the description type is one of the allowed ones."""
-        if value not in self.DESCRIPTION_TYPES:
-            raise ValidationError(
-                _('Invalid description type. Not one of {allowed}.'.format(
-                                            allowed=self.DESCRIPTION_TYPES)),
-                field_names=['additional_descriptions']
-            )
+    description_type = SanitizedUnicode(validate=validate.OneOf(
+            choices=DESCRIPTION_TYPES,
+            error=_('Invalid description type. {input} not one of {choices}.')
+        ))
+    lang = SanitizedUnicode(validate=validate_iso639_3)
 
 
 class DateSchemaV1(StrictKeysMixin):
@@ -171,18 +141,11 @@ class DateSchemaV1(StrictKeysMixin):
 
     start = DateString()
     end = DateString()
-    type = fields.Str(required=True)
+    type = fields.Str(required=True, validate=validate.OneOf(
+            choices=DATE_TYPES,
+            error=_('Invalid date type. {input} not one of {choices}.')
+        ))
     description = fields.Str()
-
-    @validates('type')
-    def validate_type(self, value):
-        """Validate that the type is one of the allowed ones."""
-        if value not in self.DATE_TYPES:
-            raise ValidationError(
-                _('Invalid date type. Not one of {allowed}.'.format(
-                                            allowed=self.DATE_TYPES)),
-                field_names=['dates']
-            )
 
 
 class RightSchemaV1(StrictKeysMixin):
@@ -193,12 +156,7 @@ class RightSchemaV1(StrictKeysMixin):
     identifier = SanitizedUnicode()
     identifier_scheme = SanitizedUnicode()
     scheme_uri = SanitizedUnicode()
-    lang = SanitizedUnicode()
-
-    @validates('lang')
-    def validate_language(self, value):
-        """Validate that language is ISO 639-3 value."""
-        validate_iso639_3(value)
+    lang = SanitizedUnicode(validate=validate_iso639_3)
 
 
 class MetadataSchemaV1(StrictKeysMixin):
@@ -215,7 +173,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     description = SanitizedUnicode()
     embargo_date = DateString()
     keywords = fields.List(SanitizedUnicode(), many=True)
-    language = SanitizedUnicode()
+    language = SanitizedUnicode(validate=validate_iso639_3)
     owners = fields.List(fields.Integer(),
                          validate=validate.Length(min=1),
                          required=True)
@@ -260,11 +218,6 @@ class MetadataSchemaV1(StrictKeysMixin):
                 _('Embargo date must be in the future.'),
                 field_names=['embargo_date']
             )
-
-    @validates('language')
-    def validate_language(self, value):
-        """Validate that language is ISO 639-3 value."""
-        validate_iso639_3(value)
 
 
 class RecordSchemaV1(StrictKeysMixin):

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -16,10 +16,10 @@ from flask_babelex import lazy_gettext as _
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import DateString, \
     PersistentIdentifier, SanitizedUnicode
-from marshmallow import ValidationError, fields, missing, pre_load, validate, \
+from marshmallow import ValidationError, fields, pre_load, validate, \
     validates, validates_schema
 
-from ..models import AccessRight, ObjectType
+from ..models import ObjectType
 from .utils import validate_iso639_3
 
 
@@ -69,13 +69,6 @@ class ResourceTypeSchemaV1(StrictKeysMixin):
         ),
     )
     subtype = fields.Str()
-    openaire_subtype = fields.Str()
-    title = fields.Method('get_title', dump_only=True)
-
-    def get_title(self, obj):
-        """Get title."""
-        obj = ObjectType.get_by_dict(obj)
-        return obj['title']['en'] if obj else missing
 
     @validates_schema
     def validate_data(self, data):
@@ -83,13 +76,6 @@ class ResourceTypeSchemaV1(StrictKeysMixin):
         obj = ObjectType.get_by_dict(data)
         if obj is None:
             raise ValidationError(_('Invalid resource type.'))
-
-    def dump_openaire_type(self, obj):
-        """Get OpenAIRE subtype."""
-        acc = obj.get('access_right')
-        if acc:
-            return AccessRight.as_category(acc)
-        return missing
 
 
 class TitleSchemaV1(StrictKeysMixin):

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -12,7 +12,6 @@
 from __future__ import absolute_import, print_function
 
 import arrow
-import pycountry
 from flask_babelex import lazy_gettext as _
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import DateString, \
@@ -21,6 +20,7 @@ from marshmallow import ValidationError, fields, missing, pre_load, validate, \
     validates, validates_schema
 
 from ..models import AccessRight, ObjectType
+from .utils import validate_iso639_3
 
 
 class AccessSchemaV1(StrictKeysMixin):
@@ -90,6 +90,11 @@ class TitleSchemaV1(StrictKeysMixin):
     title_type = SanitizedUnicode()
     lang = SanitizedUnicode()
 
+    @validates('lang')
+    def validate_language(self, value):
+        """Validate that language is ISO 639-3 value."""
+        validate_iso639_3(value)
+
 
 class DescriptionSchemaV1(StrictKeysMixin):
     """Schema for the additional descriptions."""
@@ -99,6 +104,11 @@ class DescriptionSchemaV1(StrictKeysMixin):
     # TODO: Shall it be checked against the enum?
     description_type = SanitizedUnicode()
     lang = SanitizedUnicode()
+
+    @validates('lang')
+    def validate_language(self, value):
+        """Validate that language is ISO 639-3 value."""
+        validate_iso639_3(value)
 
 
 class DateSchemaV1(StrictKeysMixin):
@@ -119,6 +129,11 @@ class RightSchemaV1(StrictKeysMixin):
     identifier_scheme = SanitizedUnicode()
     scheme_uri = SanitizedUnicode()
     lang = SanitizedUnicode()
+
+    @validates('lang')
+    def validate_language(self, value):
+        """Validate that language is ISO 639-3 value."""
+        validate_iso639_3(value)
 
 
 class MetadataSchemaV1(StrictKeysMixin):
@@ -184,11 +199,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     @validates('language')
     def validate_language(self, value):
         """Validate that language is ISO 639-3 value."""
-        if not pycountry.languages.get(alpha_3=value):
-            raise ValidationError(
-                _('Language must be a lower-cased 3-letter ISO 639-3 string.'),
-                field_name=['language']
-            )
+        validate_iso639_3(value)
 
 
 class RecordSchemaV1(StrictKeysMixin):

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -12,6 +12,7 @@
 from __future__ import absolute_import, print_function
 
 import arrow
+import pycountry
 from flask_babelex import lazy_gettext as _
 from invenio_records_rest.schemas import Nested, StrictKeysMixin
 from invenio_records_rest.schemas.fields import DateString, \
@@ -120,6 +121,7 @@ class MetadataSchemaV1(StrictKeysMixin):
     dates = fields.List(
         fields.Nested(DateSchemaV1), validate=validate.Length(min=1))
     embargo_date = DateString()
+    language = SanitizedUnicode()
     recid = PersistentIdentifier()
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     description = SanitizedUnicode()
@@ -164,6 +166,15 @@ class MetadataSchemaV1(StrictKeysMixin):
             raise ValidationError(
                 _('Embargo date must be in the future.'),
                 field_names=['embargo_date']
+            )
+
+    @validates('language')
+    def validate_language(self, value):
+        """Validate that language is ISO 639-3 value."""
+        if not pycountry.languages.get(alpha_3=value):
+            raise ValidationError(
+                _('Language must be a lower-cased 3-letter ISO 639-3 string.'),
+                field_name=['language']
             )
 
 

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -42,11 +42,27 @@ class PersonIdsSchemaV1(StrictKeysMixin):
 class ContributorSchemaV1(StrictKeysMixin):
     """Contributor schema."""
 
+    ROLES = [
+        "ContactPerson",
+        "Researcher",
+        "Other"
+    ]
+
     ids = fields.Nested(PersonIdsSchemaV1, many=True)
     name = SanitizedUnicode(required=True)
     role = SanitizedUnicode()
     affiliations = fields.List(SanitizedUnicode())
     email = fields.Email()
+
+    @validates('role')
+    def validate_role(self, value):
+        """Validate that the role is one of the allowed ones."""
+        if value not in self.ROLES:
+            raise ValidationError(
+                _('Invalid role. Not one of {allowed}.'.format(
+                                                        allowed=self.ROLES)),
+                field_names=['contributor']
+            )
 
 
 class ResourceTypeSchemaV1(StrictKeysMixin):
@@ -85,8 +101,14 @@ class ResourceTypeSchemaV1(StrictKeysMixin):
 class TitleSchemaV1(StrictKeysMixin):
     """Schema for the additional title."""
 
+    TITLE_TYPES = [
+          "AlternativeTitle",
+          "Subtitle",
+          "TranslatedTitle",
+          "Other"
+    ]
+
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
-    # TODO: Shall it be checked against the enum?
     title_type = SanitizedUnicode()
     lang = SanitizedUnicode()
 
@@ -95,13 +117,30 @@ class TitleSchemaV1(StrictKeysMixin):
         """Validate that language is ISO 639-3 value."""
         validate_iso639_3(value)
 
+    @validates('title_type')
+    def validate_title_type(self, value):
+        """Validate that the title type is one of the allowed ones."""
+        if value not in self.TITLE_TYPES:
+            raise ValidationError(
+                _('Invalid title type. Not one of {allowed}.'.format(
+                                                    allowed=self.TITLE_TYPES)),
+                field_names=['additional_titles']
+            )
+
 
 class DescriptionSchemaV1(StrictKeysMixin):
     """Schema for the additional descriptions."""
 
+    DESCRIPTION_TYPES = [
+          "Abstract",
+          "Methods",
+          "SeriesInformation",
+          "TableOfContents",
+          "TechnicalInfo",
+          "Other"
+    ]
     description = SanitizedUnicode(required=True,
                                    validate=validate.Length(min=3))
-    # TODO: Shall it be checked against the enum?
     description_type = SanitizedUnicode()
     lang = SanitizedUnicode()
 
@@ -110,14 +149,40 @@ class DescriptionSchemaV1(StrictKeysMixin):
         """Validate that language is ISO 639-3 value."""
         validate_iso639_3(value)
 
+    @validates('description_type')
+    def validate_description_type(self, value):
+        """Validate that the description type is one of the allowed ones."""
+        if value not in self.DESCRIPTION_TYPES:
+            raise ValidationError(
+                _('Invalid description type. Not one of {allowed}.'.format(
+                                            allowed=self.DESCRIPTION_TYPES)),
+                field_names=['additional_descriptions']
+            )
+
 
 class DateSchemaV1(StrictKeysMixin):
     """Schema for date intervals."""
+
+    DATE_TYPES = [
+        "Collected",
+        "Valid",
+        "Withdrawn"
+    ]
 
     start = DateString()
     end = DateString()
     type = fields.Str(required=True)
     description = fields.Str()
+
+    @validates('type')
+    def validate_type(self, value):
+        """Validate that the type is one of the allowed ones."""
+        if value not in self.DATE_TYPES:
+            raise ValidationError(
+                _('Invalid date type. Not one of {allowed}.'.format(
+                                            allowed=self.DATE_TYPES)),
+                field_names=['dates']
+            )
 
 
 class RightSchemaV1(StrictKeysMixin):

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -118,20 +118,20 @@ class MetadataSchemaV1(StrictKeysMixin):
     access = fields.Nested(AccessSchemaV1)
     additional_descriptions = fields.List(fields.Nested(DescriptionSchemaV1))
     additional_titles = fields.List(fields.Nested(TitleSchemaV1))
+    contributors = Nested(ContributorSchemaV1, many=True, required=True)
     dates = fields.List(
         fields.Nested(DateSchemaV1), validate=validate.Length(min=1))
-    embargo_date = DateString()
-    language = SanitizedUnicode()
-    recid = PersistentIdentifier()
-    title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     description = SanitizedUnicode()
+    embargo_date = DateString()
+    keywords = fields.List(SanitizedUnicode(), many=True)
+    language = SanitizedUnicode()
     owners = fields.List(fields.Integer(),
                          validate=validate.Length(min=1),
                          required=True)
-    keywords = fields.List(SanitizedUnicode(), many=True)
     publication_date = DateString()
-    contributors = Nested(ContributorSchemaV1, many=True, required=True)
+    recid = PersistentIdentifier()
     resource_type = fields.Nested(ResourceTypeSchemaV1)
+    title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     version = SanitizedUnicode()
 
     @pre_load()

--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -80,12 +80,22 @@ class ResourceTypeSchemaV1(StrictKeysMixin):
         return missing
 
 
+class TitleSchemaV1(StrictKeysMixin):
+    """Schema for the additional title."""
+
+    title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
+    # TODO: Shall it be checked against the enum?
+    title_type = SanitizedUnicode()
+    lang = SanitizedUnicode()
+
+
 class MetadataSchemaV1(StrictKeysMixin):
     """Schema for the record metadata."""
 
     # TODO: Check enumeration (i.e. only open/embargoed/... accepted)
     access_right = SanitizedUnicode(required=True)
     access = fields.Nested(AccessSchemaV1)
+    additional_titles = fields.List(fields.Nested(TitleSchemaV1))
     recid = PersistentIdentifier()
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     description = SanitizedUnicode()

--- a/invenio_rdm_records/marshmallow/utils.py
+++ b/invenio_rdm_records/marshmallow/utils.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2019 Northwestern University,
+#                    Galter Health Sciences Library & Learning Center.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marshmallow utility functions."""
+
+import pycountry
+from flask_babelex import lazy_gettext as _
+from marshmallow import ValidationError
+
+
+def validate_iso639_3(value):
+    """Validate that language is ISO 639-3 value."""
+    if not pycountry.languages.get(alpha_3=value):
+        raise ValidationError(
+            _('Language must be a lower-cased 3-letter ISO 639-3 string.'),
+            field_name=['language']
+        )

--- a/invenio_rdm_records/models.py
+++ b/invenio_rdm_records/models.py
@@ -19,6 +19,10 @@ from jsonref import JsonRef
 class AccessRight(object):
     """Class defining access right status."""
 
+    # TODO This seems like a Jinja2 filter because it is really
+    #      all about the frontend. Could be moved to views.py
+    #      and adapted.
+
     OPEN = 'open'
 
     EMBARGOED = 'embargoed'

--- a/invenio_rdm_records/models.py
+++ b/invenio_rdm_records/models.py
@@ -16,35 +16,6 @@ from elasticsearch_dsl.utils import AttrDict
 from jsonref import JsonRef
 
 
-class AccessRight(object):
-    """Class defining access right status."""
-
-    # TODO This seems like a Jinja2 filter because it is really
-    #      all about the frontend. Could be moved to views.py
-    #      and adapted.
-
-    OPEN = 'open'
-
-    EMBARGOED = 'embargoed'
-
-    RESTRICTED = 'restricted'
-
-    CLOSED = 'closed'
-
-    _category = {
-        OPEN: 'success',
-        EMBARGOED: 'warning',
-        RESTRICTED: 'danger',
-        CLOSED: 'danger',
-    }
-
-    @classmethod
-    def as_category(cls, value, **kwargs):
-        """Get title for a specific status."""
-        cat = cls._category[value]
-        return kwargs[cat] if cat in kwargs else cat
-
-
 class ObjectType(object):
     """Class to load object types data."""
 

--- a/invenio_rdm_records/models.py
+++ b/invenio_rdm_records/models.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2019 Northwestern University,
+#                    Galter Health Sciences Library & Learning Center.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Models for Invenio RDM Records."""
+
+import json
+from os.path import dirname, join
+
+from elasticsearch_dsl.utils import AttrDict
+from jsonref import JsonRef
+
+
+class AccessRight(object):
+    """Class defining access right status."""
+
+    OPEN = 'open'
+
+    EMBARGOED = 'embargoed'
+
+    RESTRICTED = 'restricted'
+
+    CLOSED = 'closed'
+
+    _category = {
+        OPEN: 'success',
+        EMBARGOED: 'warning',
+        RESTRICTED: 'danger',
+        CLOSED: 'danger',
+    }
+
+    @classmethod
+    def as_category(cls, value, **kwargs):
+        """Get title for a specific status."""
+        cat = cls._category[value]
+        return kwargs[cat] if cat in kwargs else cat
+
+
+class ObjectType(object):
+    """Class to load object types data."""
+
+    index_id = None
+    index_internal_id = None
+    types = None
+    subtypes = None
+
+    @classmethod
+    def _load_data(cls):
+        """Load object types for JSON data."""
+        if cls.index_id is None:
+            with open(join(dirname(__file__), "data", "objecttypes.json")) \
+                    as fp:
+                data = json.load(fp)
+
+            cls.index_internal_id = {}
+            cls.index_id = {}
+            cls.types = set()
+            cls.subtypes = {}
+            for objtype in data:
+                cls.index_internal_id[objtype['internal_id']] = objtype
+                cls.index_id[objtype['id'][:-1]] = objtype
+                if '-' in objtype['internal_id']:
+                    type_, subtype = objtype['internal_id'].split('-')
+                    cls.types.add(type_)
+                    if type_ not in cls.subtypes:
+                        cls.subtypes[type_] = set()
+                    cls.subtypes[type_].add(subtype)
+                else:
+                    cls.types.add(objtype['internal_id'])
+
+    @classmethod
+    def validate_internal_id(cls, id):
+        """Check if the provided ID corresponds to the internal ones."""
+        cls._load_data()
+        return id in cls.index_internal_id
+
+    @classmethod
+    def _jsonloader(cls, uri, **dummy_kwargs):
+        """Local JSON loader for JsonRef."""
+        cls._load_data()
+        return cls.index_id[uri]
+
+    @classmethod
+    def get(cls, value):
+        """Get object type value."""
+        cls._load_data()
+        try:
+            return JsonRef.replace_refs(
+                cls.index_internal_id[value],
+                jsonschema=True,
+                loader=cls._jsonloader)
+        except KeyError:
+            return None
+
+    @classmethod
+    def get_types(cls):
+        """Get object type value."""
+        cls._load_data()
+        return cls.types
+
+    @classmethod
+    def get_subtypes(cls, type_):
+        """Get object type value."""
+        cls._load_data()
+        return cls.subtypes[type_]
+
+    @classmethod
+    def get_by_dict(cls, value):
+        """Get object type dict with type and subtype key."""
+        if not value:
+            return None
+        if 'subtype' in value:
+            if isinstance(value, AttrDict):
+                value = value.to_dict()
+            internal_id = "{0}-{1}".format(
+                value.get('type', ''),
+                value.get('subtype', '')
+            )
+        else:
+            internal_id = value['type']
+        return cls.get(internal_id)

--- a/invenio_rdm_records/permissions.py
+++ b/invenio_rdm_records/permissions.py
@@ -19,11 +19,11 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     Note that even if the array is empty, the invenio_access Permission class
     always adds the ``superuser-access``, so admins will always be allowed.
 
-    - Create action given to everyone. NOTE: just for testing purposes.
+    - Create action given to everyone for now.
     - Read access given to everyone if public record and given to owners
       always. (inherited)
     - Update access given to record owners. (inherited)
     - Delete access given to admins only. (inherited)
     """
 
-    can_create = [AnyUser()]
+    can_create = [AnyUser()]  # TODO: Change when deposit permissions done

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     'invenio-records-rest>=1.5.0,<1.6.0',
     'invenio-records>=1.3.0,<1.4.0',
     'invenio-records-files>=1.1.1,<1.2.0',
-    'invenio-records-permissions>=1.0.0a1',
+    'invenio-records-permissions>=1.0.0a3',
     'marshmallow>=2.20.5,<3',
     'pycountry>=18.12.8',
 ]

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'arrow>=0.13.0',
     'Flask-BabelEx>=0.9.3',
     'invenio-jsonschemas>=1.0.0,<1.1.0',
     'invenio-records-rest>=1.5.0,<1.6.0',
@@ -73,6 +74,7 @@ install_requires = [
     'invenio-records-files>=1.1.1,<1.2.0',
     'invenio-records-permissions>=1.0.0a1',
     'marshmallow>=2.20.5,<3',
+    'pycountry>=18.12.8',
 ]
 
 packages = find_packages()

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -164,7 +164,6 @@ def test_dates():
     data, errors = schema.load({'dates': [{}]})
     assert 'required field' in errors['dates'][0]['type'][0]
     data, errors = schema.load({'dates': [{'type': 'Valid'}]})
-    print(errors)
     assert 'at least one date' in errors['dates'][0]
     data, errors = schema.load({'dates': [{'type': 'Valid', 'start': None}]})
     assert 'not be null' in errors['dates'][0]['start'][0]
@@ -205,3 +204,26 @@ def test_language():
     assert 'language' in errors
     data, errors = msv1.load(dict())
     assert 'language' not in errors
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
+    ([dict(rights='Full rights schema',
+           uri='http://creativecommons.org/l',
+           identifier='CC-BY-3.0',
+           identifier_scheme='SPDX',
+           scheme_uri='https://spdx.org/licenses',
+           lang='en')], None),
+    ([dict(rights='Random rights with only free text')], None),
+    ([dict()], None)
+])
+def test_valid_rights(val, expected):
+    """Test rights."""
+    data, errors = MetadataSchemaV1(partial=['rights']).load(
+        dict(rights=val))
+
+    assert data['rights'] == val if expected is None else expected
+
+    data, errors = MetadataSchemaV1(partial=['rights']).load(
+        {'rights': [{'lang': 'english'}]}
+    )
+    assert 'lang' not in errors

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -39,3 +39,43 @@ def test_invalid_resource_type(val):
     data, errors = MetadataSchemaV1(partial=['resource_type']).load(
         dict(resource_type=val))
     assert 'resource_type' in errors
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
+    ('Test', 'Test',),
+    (' Test ', 'Test'),
+    ('', None),
+    ('  ', None),
+])
+def test_title(val, expected):
+    """Test title."""
+    data, errors = MetadataSchemaV1(partial=['title']).load(
+        dict(title=val))
+    if expected is not None:
+        assert data['title'] == expected
+    else:
+        assert 'title' in errors
+        assert 'title' not in data
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
+    ([dict(title='Full additional title',
+           title_type='Title type',
+           lang='en')], None),
+    ([dict(title='Only required field')], None),
+])
+def test_valid_additional_titles(val, expected):
+    """Test additional titles."""
+    data, errors = MetadataSchemaV1(partial=['additional_titles']).load(
+        dict(additional_titles=val))
+    assert data['additional_titles'] == val if expected is None else expected
+
+
+@pytest.mark.parametrize('val', [
+    ([dict(title_type='Invalid title type', lang='en')], None),
+])
+def test_invalid_additional_titles(val):
+    """Test additional titles."""
+    data, errors = MetadataSchemaV1(partial=['additional_titles']).load(
+        dict(additional_titles=val))
+    assert 'additional_titles' in errors

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -193,3 +193,15 @@ def test_dates():
                     'start': '2019-01-01', 'end': '2019-01-31',
                     'description': 'Some description'}]})
     assert 'dates' not in errors
+
+
+def test_language():
+    """Test resource type."""
+    msv1 = MetadataSchemaV1(partial=['language'])
+    data, errors = msv1.load(dict(language='eng'))
+    assert data['language'] == 'eng'
+    assert 'language' not in errors
+    data, errors = msv1.load(dict(language='English'))
+    assert 'language' in errors
+    data, errors = msv1.load(dict())
+    assert 'language' not in errors

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -206,7 +206,7 @@ def test_dates():
 
 
 def test_language():
-    """Test resource type."""
+    """Test language."""
     msv1 = MetadataSchemaV1(partial=['language'])
     data, errors = msv1.load(dict(language='eng'))
     assert data['language'] == 'eng'

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 CERN.
+# Copyright (C) 2019 Northwestern University,
+#                    Galter Health Sciences Library & Learning Center.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for Invenio RDM Records JSON Schemas."""
+
+import pytest
+
+from invenio_rdm_records.marshmallow.json import MetadataSchemaV1
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
+    (dict(type='publication', subtype='preprint'), None),
+    (dict(type='image', subtype='photo'), None),
+    (dict(type='dataset'), None),
+    (dict(type='dataset', title='Dataset'), dict(type='dataset')),
+])
+def test_valid_resource_type(val, expected):
+    """Test resource type."""
+    data, errors = MetadataSchemaV1(partial=['resource_type']).load(
+        dict(resource_type=val))
+    assert data['resource_type'] == val if expected is None else expected
+
+
+@pytest.mark.parametrize('val', [
+    dict(type='image', subtype='preprint'),
+    dict(subtype='photo'),
+    dict(type='invalid'),
+    dict(title='Dataset'),
+    dict(),
+])
+def test_invalid_resource_type(val):
+    """Test resource type."""
+    data, errors = MetadataSchemaV1(partial=['resource_type']).load(
+        dict(resource_type=val))
+    assert 'resource_type' in errors

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -9,6 +9,8 @@
 
 """Tests for Invenio RDM Records JSON Schemas."""
 
+from datetime import datetime
+
 import pytest
 
 from invenio_rdm_records.marshmallow.json import MetadataSchemaV1
@@ -79,3 +81,29 @@ def test_invalid_additional_titles(val):
     data, errors = MetadataSchemaV1(partial=['additional_titles']).load(
         dict(additional_titles=val))
     assert 'additional_titles' in errors
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
+    ('2016-01-02', '2016-01-02'),
+    (' 2016-01-02 ', '2016-01-02'),
+    ('0001-01-01', '0001-01-01'),
+    (None, datetime.utcnow().date().isoformat()),
+    ('2016', datetime.utcnow().date().isoformat()),
+])
+def test_valid_publication_date(val, expected):
+    """Test publication date."""
+    data, errors = MetadataSchemaV1(partial=['publication_date']).load(
+        dict(publication_date=val) if val is not None else dict())
+    assert data['publication_date'] == val if expected is None else expected
+
+
+@pytest.mark.parametrize('val', [
+    '2016-02-32',
+    ' invalid',
+])
+def test_invalid_publication_date(val):
+    """Test publication date."""
+    data, errors = MetadataSchemaV1(partial=['publication_date']).load(
+        dict(publication_date=val))
+    assert 'publication_date' in errors
+    assert 'publication_date' not in data

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -84,6 +84,36 @@ def test_invalid_additional_titles(val):
 
 
 @pytest.mark.parametrize(('val', 'expected'), [
+    ([dict(description='Full additional description',
+           description_type='Description type',
+           lang='en')], None),
+    ([dict(description='Only required fields',
+           description_type='Description type')], None),
+])
+def test_valid_additional_descriptions(val, expected):
+    """Test additional descriptions."""
+    data, errors = MetadataSchemaV1(partial=['additional_descriptions']).load(
+        dict(additional_descriptions=val))
+
+    if expected is not None:
+        assert data['additional_descriptions'] == expected
+    else:
+        assert data['additional_descriptions'] == val
+
+
+@pytest.mark.parametrize('val', [
+    ([dict(description_type='Invalid no description', lang='en')], None),
+    ([dict(description='Invalid no description type', lang='en')], None),
+    ([dict(lang='en')], None),
+])
+def test_invalid_additional_descriptions(val):
+    """Test additional descriptions."""
+    data, errors = MetadataSchemaV1(partial=['additional_descriptions']).load(
+        dict(additional_descriptions=val))
+    assert 'additional_descriptions' in errors
+
+
+@pytest.mark.parametrize(('val', 'expected'), [
     ('2016-01-02', '2016-01-02'),
     (' 2016-01-02 ', '2016-01-02'),
     ('0001-01-01', '0001-01-01'),

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -62,7 +62,7 @@ def test_title(val, expected):
 
 @pytest.mark.parametrize(('val', 'expected'), [
     ([dict(title='Full additional title',
-           title_type='Title type',
+           title_type='Other',
            lang='eng')], None),
     ([dict(title='Only required field')], None),
 ])
@@ -75,6 +75,8 @@ def test_valid_additional_titles(val, expected):
 
 @pytest.mark.parametrize('val', [
     ([dict(title_type='Invalid title type', lang='eng')], None),
+    ([dict(title_type='Other', lang='eng')], None),
+    ([dict(title='Invalid lang', title_type='Other', lang='en')], None),
 ])
 def test_invalid_additional_titles(val):
     """Test additional titles."""
@@ -85,10 +87,10 @@ def test_invalid_additional_titles(val):
 
 @pytest.mark.parametrize(('val', 'expected'), [
     ([dict(description='Full additional description',
-           description_type='Description type',
+           description_type='Other',
            lang='eng')], None),
     ([dict(description='Only required fields',
-           description_type='Description type')], None),
+           description_type='Other')], None),
 ])
 def test_valid_additional_descriptions(val, expected):
     """Test additional descriptions."""
@@ -102,9 +104,13 @@ def test_valid_additional_descriptions(val, expected):
 
 
 @pytest.mark.parametrize('val', [
-    ([dict(description_type='Invalid no description', lang='eng')], None),
+    ([dict(description_type='Other', lang='eng')], None),
     ([dict(description='Invalid no description type', lang='eng')], None),
     ([dict(lang='eng')], None),
+    ([dict(description='Invalid type',
+           description_type='Invalid Type', lang='eng')], None),
+    ([dict(description='Invalid lang',
+           description_type='Other', lang='en')], None),
 ])
 def test_invalid_additional_descriptions(val):
     """Test additional descriptions."""
@@ -169,6 +175,11 @@ def test_dates():
     assert 'not be null' in errors['dates'][0]['start'][0]
     data, errors = schema.load({'dates': [{'type': 'Valid', 'start': ''}]})
     assert 'Not a valid date' in errors['dates'][0]['start'][0]
+    data, errors = schema.load(
+        {'dates': [{'type': 'Invalid',
+                    'start': '2019-01-01', 'end': '2019-01-31',
+                    'description': 'Some description'}]})
+    assert 'Invalid date type' in errors['dates'][0]['type'][0]
 
     # "start" date after "end"
     data, errors = schema.load(

--- a/tests/unit/test_schemas_json_load.py
+++ b/tests/unit/test_schemas_json_load.py
@@ -63,7 +63,7 @@ def test_title(val, expected):
 @pytest.mark.parametrize(('val', 'expected'), [
     ([dict(title='Full additional title',
            title_type='Title type',
-           lang='en')], None),
+           lang='eng')], None),
     ([dict(title='Only required field')], None),
 ])
 def test_valid_additional_titles(val, expected):
@@ -74,7 +74,7 @@ def test_valid_additional_titles(val, expected):
 
 
 @pytest.mark.parametrize('val', [
-    ([dict(title_type='Invalid title type', lang='en')], None),
+    ([dict(title_type='Invalid title type', lang='eng')], None),
 ])
 def test_invalid_additional_titles(val):
     """Test additional titles."""
@@ -86,7 +86,7 @@ def test_invalid_additional_titles(val):
 @pytest.mark.parametrize(('val', 'expected'), [
     ([dict(description='Full additional description',
            description_type='Description type',
-           lang='en')], None),
+           lang='eng')], None),
     ([dict(description='Only required fields',
            description_type='Description type')], None),
 ])
@@ -102,9 +102,9 @@ def test_valid_additional_descriptions(val, expected):
 
 
 @pytest.mark.parametrize('val', [
-    ([dict(description_type='Invalid no description', lang='en')], None),
-    ([dict(description='Invalid no description type', lang='en')], None),
-    ([dict(lang='en')], None),
+    ([dict(description_type='Invalid no description', lang='eng')], None),
+    ([dict(description='Invalid no description type', lang='eng')], None),
+    ([dict(lang='eng')], None),
 ])
 def test_invalid_additional_descriptions(val):
     """Test additional descriptions."""
@@ -212,7 +212,7 @@ def test_language():
            identifier='CC-BY-3.0',
            identifier_scheme='SPDX',
            scheme_uri='https://spdx.org/licenses',
-           lang='en')], None),
+           lang='eng')], None),
     ([dict(rights='Random rights with only free text')], None),
     ([dict()], None)
 ])
@@ -224,6 +224,6 @@ def test_valid_rights(val, expected):
     assert data['rights'] == val if expected is None else expected
 
     data, errors = MetadataSchemaV1(partial=['rights']).load(
-        {'rights': [{'lang': 'english'}]}
+        {'rights': [{'lang': 'en'}]}
     )
     assert 'lang' not in errors


### PR DESCRIPTION
**Fields**:
- Resource type
- additional titles
- additional descriptions
- dates (Following Zenodo implementation, not DataCite)
- publication date
- embargo date
- language: Using ISO 639-3 (as Zenodo) instead of 639-1 (as DataCite). It's newer and uses 3 letters instead of 2.
- version
- rights_list

**Validation**:
- All *lang* attributes be validated and follow the ISO 639-3
- All *enums* are validated against their list of values in Marshmallow instead of the JSON Schema. This allows to define configurable control vocabularies.

Addreses part of https://github.com/inveniosoftware/invenio-rdm-records/issues/18