### PR TITLE
global: new versioning scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
     - REQUIREMENTS=devel EXTRAS=all,postgresql,elasticsearch7 ES_URL=$ES7_DOWNLOAD_URL
 
 python:
-  - "3.5"
+  - "3.6"
 
 before_install:
   - "mkdir /tmp/elasticsearch"
@@ -80,6 +80,6 @@ deploy:
   distributions: "compile_catalog sdist bdist_wheel"
   on:
     tags: true
-    python: "3.5"
+    python: "3.6"
     repo: inveniosoftware/invenio-rdm-records
     condition: $DEPLOY = true

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.0.0a8'
+__version__ = '0.9.0'

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Development Status :: 3 - Alpha',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -146,8 +146,6 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Changes:

* Remove support for Python 2
* Bump Python 3 version
* Bump some dependencies due to Werkzeug imports, and remove the latter
* Release with new versioning scheme

Requires: https://github.com/inveniosoftware/invenio-rdm-records/pull/55
Closes: https://github.com/inveniosoftware/invenio-rdm-records/issues/48
Closes: https://github.com/inveniosoftware/invenio-rdm-records/issues/13