### PR TITLE
views: fix template filters

### DIFF
--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
@@ -86,7 +86,7 @@
           <a href="{{ url_for('invenio_records_ui.recid', pid_value=record.pid) }}">{{ record.version }}</a>
           <small class="text-muted">{{ record.identifiers|doi_identifier }}</small>
       </td>
-      <td align="right"><small class="text-muted">{{ record.publication_date|to_date|dateformat(format='medium')}}</small></td>
+      <td align="right"><small class="text-muted">{{ record.publication_date|to_date|format_date(format='medium')}}</small></td>
     </tr>
   </tbody></table>
   <small>

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
@@ -20,7 +20,7 @@
   <div class="row">
     <div class="col-sm-8 col-md-8 col-left">
       {%- block record_body %}
-      <span class="label label-info" title="Publication date">{{ record.publication_date|to_date|dateformat(format='long') }}</span>
+      <span class="label label-info" title="Publication date">{{ record.publication_date|to_date|format_date(format='long') }}</span>
       <span class="label record-version"> | Version {{ record.version }}</span>
       <div class="pull-right">
         <span class="label label-default">{{ record.resource_type.type if record.resource_type else "resource type" }}</span>


### PR DESCRIPTION
* Fix `doi_identifier` template filter
* Create a template filter called `format_date`
  to accept date strings without formatting them.
  This is needed to handle edtf dates for now.

closes #80, #81