### PR TITLE
datamodel: dump 'extensions'

### DIFF
--- a/invenio_rdm_records/marshmallow/json.py
+++ b/invenio_rdm_records/marshmallow/json.py
@@ -459,13 +459,13 @@ class MetadataSchemaV1(BaseSchema):
     def dump_extensions(self, obj):
         """Dumps the extensions value.
 
-        :params obj: content of the object's 'extensions' field
+        :params obj: invenio_records_files.api.Record instance
         """
         current_app_metadata_extensions = (
             current_app.extensions['invenio-rdm-records'].metadata_extensions
         )
         ExtensionSchema = current_app_metadata_extensions.to_schema()
-        return ExtensionSchema().dump(obj)
+        return ExtensionSchema().dump(obj.get('extensions', {}))
 
     def load_extensions(self, value):
         """Loads the 'extensions' field.

--- a/tests/api/test_elasticsearch_mapping.py
+++ b/tests/api/test_elasticsearch_mapping.py
@@ -11,9 +11,10 @@
 import pytest
 from invenio_indexer.api import RecordIndexer
 from invenio_jsonschemas import current_jsonschemas
+# TODO: use from invenio_records_files.api import Record
 from invenio_records.api import Record
 from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
-from marshmallow.fields import Bool, Float, Integer, List
+from marshmallow.fields import Bool, Integer, List
 
 from invenio_rdm_records.metadata_extensions import add_es_metadata_extensions
 

--- a/tests/api/test_serializers.py
+++ b/tests/api/test_serializers.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+# Copyright (C) 2020 Northwestern University.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test serializers."""
+
+import pytest
+from invenio_pidstore.models import PersistentIdentifier
+# TODO: use from invenio_records_files.api import Record
+from invenio_records.api import Record
+from invenio_records_rest.schemas.fields import SanitizedUnicode
+from marshmallow.fields import Bool
+
+from invenio_rdm_records.marshmallow.json import MetadataSchemaV1
+
+# TODO: Figure out at what level to test... The higher the level, the more
+#       layers we can cover, but the slower and more cumbersome to setup are
+#       the tests. The lower the level, the less layers we cover, but the
+#       the tests are quicker and typically easier to setup...
+# We could test
+# - at the MetadataSchemaV1.dump(ob) level OR
+# - at the json_v1.transform_record(pid, record) level OR
+# - at the client.get(url) level
+#
+# Long term, json_v1.transform_record(pid, record) seems a good compromise, but
+# it still requires more setup/implemented code than we currently have.
+
+
+@pytest.fixture(scope='module')
+def app_config(app_config):
+    """Override conftest.py's app_config
+    """
+    # Added custom configuration
+    app_config['RDM_RECORDS_METADATA_NAMESPACES'] = {
+        'dwc': {
+            '@context': 'https://example.com/dwc/terms'
+        },
+        'nubiomed': {
+            '@context': 'https://example.com/nubiomed/terms'
+        }
+    }
+
+    app_config['RDM_RECORDS_METADATA_EXTENSIONS'] = {
+        'dwc:family': {
+            'elasticsearch': 'keyword',
+            'marshmallow': SanitizedUnicode(required=True)
+        },
+        'dwc:behavior': {
+            'elasticsearch': 'text',
+            'marshmallow': SanitizedUnicode()
+        },
+        'nubiomed:right_or_wrong': {
+            'elasticsearch': 'boolean',
+            'marshmallow': Bool()
+        }
+    }
+
+    return app_config
+
+
+def test_extensions(db, minimal_record):
+    """Test MetadataSchemaV1 dump() for 'extensions' field.
+
+    Right now we are going for a schema level test which turns out to still be
+    heavy, so something fundamental is lacking.
+    """
+    data = {
+        'extensions': {
+            'dwc:family': 'Felidae',
+            'dwc:behavior': 'Plays with yarn, sleeps in cardboard box.',
+            'nubiomed:right_or_wrong': True,
+        }
+    }
+    minimal_record.update(data)
+    record = Record.create(minimal_record)
+    db.session.commit()
+
+    serialized_record = MetadataSchemaV1().dump(record)  # returns MarshmalDict
+
+    assert serialized_record['extensions'] == data['extensions']


### PR DESCRIPTION
Fixes issue with `'extensions'` showing up empty in serialization.

A discussion point this brought on is what layer to test... and as I am writing this I think this complexity is because the serialization output is controlled by the schema and the serializer class/mixin (per record and per overall response). The serializer uses the schema, but it's easier (right now) to setup schema level tests... Like the `test_jsonschema.py` file which is now obsoleted by `test_elasticsearch_mapping.py`, I think we might be able to obsolete schema-level tests when we move to testing `json_v1.transform_record` . I didn't use it directly because it needs a PersistentIdentifier object and there wasn't one linked in the record yet.