### PR TITLE
ui: dump empty record for formik [more]

### DIFF
--- a/invenio_rdm_records/metadata_extensions.py
+++ b/invenio_rdm_records/metadata_extensions.py
@@ -70,13 +70,10 @@ class MetadataExtensions(object):
     def _validate_marshmallow_type(self, field_cfg):
         """Make sure the Marshmallow type is one we support."""
         def validate_basic_marshmallow_type(_type):
-            allowed_types = [
+            allowed_types = (
                 Bool, DateString, Integer, SanitizedUnicode
-            ]
-            assert any([
-                isinstance(_type, allowed_type) for allowed_type
-                in allowed_types
-            ])
+            )
+            assert isinstance(_type, allowed_types)
 
         marshmallow_type = field_cfg['marshmallow']
         if isinstance(marshmallow_type, List):

--- a/tests/api/test_schemas_json_dump.py
+++ b/tests/api/test_schemas_json_dump.py
@@ -1,0 +1,137 @@
+from invenio_rdm_records.marshmallow.json import MetadataSchemaV1, dump_empty
+
+
+def test_dumping_empty_record():
+    empty_record = dump_empty(MetadataSchemaV1())
+
+    assert empty_record == {
+        '_access': {'files_restricted': None, 'metadata_restricted': None},
+        '_default_preview': None,
+        '_community': {'primary': None, 'secondary': [None]},
+        '_contact': None,
+        '_created_by': None,
+        '_embargo_date': None,
+        '_files': [
+            {
+                'bucket': None,
+                'checksum': None,
+                'key': None,
+                'links': None,
+                'size': None,
+                'type': None
+            }
+        ],
+        '_internal_notes': [
+            {
+                'user': None,
+                'timestamp': None,
+                'note': None
+            }
+        ],
+        '_owners': [None],
+        'access_right': None,
+        'contributors': [
+            {
+                'affiliations': [
+                    {
+                        'name': None,
+                        'identifier': None,
+                        'scheme': None
+                    }
+                ],
+                'family_name': None,
+                'given_name': None,
+                'identifiers': None,
+                'name': None,
+                'role': None,
+                'type': None,
+            }
+        ],
+        'creators': [
+            {
+                'affiliations': [
+                    {
+                        'name': None,
+                        'identifier': None,
+                        'scheme': None
+                    }
+                ],
+                'family_name': None,
+                'given_name': None,
+                'identifiers': None,
+                'name': None,
+                'type': None,
+            }
+        ],
+        'dates': [
+            {
+                'type': None,
+                'end': None,
+                'description': None,
+                'start': None
+            }
+        ],
+        'extensions': None,
+        'descriptions': [
+            {
+                'type': None,
+                'lang': None,
+                'description': None
+            }
+        ],
+        'language': None,
+        'locations': [
+            {
+                'description': None,
+                'point': {
+                    'lon': None,
+                    'lat': None
+                },
+                'place': None
+            }
+        ],
+        'licenses': [
+            {
+                'identifier': None,
+                'scheme': None,
+                'uri': None,
+                'license': None
+            }
+        ],
+        'version': None,
+        'publication_date': None,
+        'references': [
+            {
+                'scheme': None,
+                'reference_string': None,
+                'identifier': None
+            }
+        ],
+        'related_identifiers': [
+            {
+                'resource_type': {
+                    'subtype': None,
+                    'type': None
+                },
+                'scheme': None,
+                'relation_type': None,
+                'identifier': None
+            }
+        ],
+        'resource_type': {
+            'subtype': None,
+            'type': None
+        },
+        'subjects': [{'subject': None, 'identifier': None, 'scheme': None}],
+        'titles': [
+            {
+                'type': None,
+                'lang': None,
+                'title': None
+            }
+        ],
+        # TODO: Investigate the impact of these 2 fields on
+        #       frontend to backend to frontend flow
+        'identifiers': None,
+        'recid': None
+    }


### PR DESCRIPTION
This commit is a step in the right direction (should be merged), but we will likely face a problem down the road. Problem is below with potential solutions.

Formik requires at least a full record skeleton in initialValues
(structure required but empty field) for validation (and potentially form filling) to work.
AND
react-invenio-forms' ArrayFields requires an empty array item to
be able to display empty arrays' first item.

Combined those constraints made us generate an empty record.

However, the frontend sends all those empty fields back:
some fields that are empty might cause a validation error on the backend
even though they were untouched by the user
      -> bad user experience

We will need a solution for this either:
  * only send non-null fields from the frontend, OR
  * change ArrayField to not need an empty entry to display AND
    check that Formik can add array elements dynamically

This commit also makes some things uniform:
- refactors allowed controlled vocab Marshmallow test
- uses Nested from invenio-record-rest only
- passes classes to Nested