### PR TITLE
release: v0.11.0

### DIFF
--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.10.1'
+__version__ = '0.11.0'


### PR DESCRIPTION
How is the registration of the resources going @ppanero?  Let's only bump the version after you have done that or if you deem it too intertwined and would rather wait.

This is blocking merging of invenio-app-rdm since it depends on functionality provided by invenio-rdm-records. 