### PR TITLE
update dependencies according to invenio 3.4.0a1 bundles

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,20 +16,13 @@ readme = open('README.rst').read()
 history = open('CHANGES.rst').read()
 
 tests_require = [
-    'check-manifest>=0.25',
-    'coverage>=4.0',
-    'isort>=4.3.3',
-    'pydocstyle>=2.0.0',
-    'pytest-cov>=2.5.1',
-    'pytest-pep8>=1.0.6',
-    'pytest-invenio>=1.2.0',
-    'pytest>=4.0.0,<5.3.0',
-    'invenio_app>=1.2.3,<1.3.0'
+    'pytest-invenio>=1.3.2,<2.0.0',
+    'invenio-app>=1.3.0,<2.0.0'
 ]
 
 # Should follow inveniosoftware/invenio versions
-invenio_db_version = '>=1.0.4,<1.1.0'
-invenio_search_version = '>=1.2.0,<1.3.0'
+invenio_db_version = '>=1.0.4,<2.0.0'
+invenio_search_version = '>=1.2.0,<2.0.0'
 
 extras_require = {
     'docs': [
@@ -74,15 +67,15 @@ install_requires = [
     'Faker>=2.0.3',
     'Flask-BabelEx>=0.9.4',
     'idutils>=1.1.3',
-    'invenio-formatter[badges]>=1.0.2,<1.1.0',
-    'invenio-jsonschemas>=1.0.1,<1.1.0',
-    'invenio-pidstore>=1.1.0,<1.3.0',
-    'invenio-records-rest>=1.6.4,<1.7.0',
-    'invenio-records>=1.3.0,<1.4.0',
-    'invenio-records-files>=1.2.1,<1.3.0',
-    'invenio-records-permissions>=0.7.0',
-    'invenio-records-ui>=1.0.1,<1.2.0',
-    'invenio-previewer>=1.1.0,<1.2.0',
+    'invenio-formatter[badges]>=1.1.0a1,<2.0.0',
+    'invenio-jsonschemas>=1.1.0,<2.0.0',
+    'invenio-pidstore>=1.2.0,<2.0.0',
+    'invenio-records-rest>=1.7.1,<2.0.0',
+    'invenio-records>=1.3.1,<2.0.0',
+    'invenio-records-files>=1.2.1,<2.0.0',
+    'invenio-records-permissions>=0.7.0,<2.0.0',
+    'invenio-records-ui>=1.2.0a1,<2.0.0',
+    'invenio-previewer>=1.2.1,<2.0.0',
     'marshmallow>=3.3.0,<4.0.0',
     'pycountry>=18.12.8',
 ]


### PR DESCRIPTION
I had to remove the upper limits because they were blocking the integration. When things were more "beta" it was nice to restrict. However, I think now we should do things as they are in Invenio in order to avoid extra work. This means:

- Upper bounds are only set in bundles. In our case, this is set by the `invenio_version` in `invenio-app-rdm` setup.py.
- In modules (i.e. `invenio-rdm-records` and `invenio-records-permissions`) upper bounds are not set, unless they cause troubles (e.g. in Travis). If setting an upper bound we should try to address it because it is an incompatibility with a full Invenio version.


*Why this change?*

I was working on updating InvenioRDM to the v3.4.0a1, Semantic-UI, when the only part of the work in order to integrate it should be done in `cookiecutter-invenio-rdm` and `invenio-app-rdm` I got conflict because other modules. If keeping upper bound would mean that we would have to release every single time we have to update a specific module. When in reality they are compatible.

- Less commits
- Less blockings
- Less time consumed

Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/102