### PR TITLE
Fix displayed access right

### DIFF
--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
@@ -32,13 +32,13 @@
               <span class="ui label grey">{{ record.resource_type | vocabulary_title('resource_type') }}</span>
               {% if record.access_right in ["embargoed", "closed"] %}
               <span class="ui label red">
-                {% elif record.access_right == "restricted" %}
-                <span class="ui label yellow">
-                  {% else %}
-                  <span class="ui label green">
-                    {% endif %}
-                    {{ record.access_right }} Access
-                  </span>
+              {% elif record.access_right == "restricted" %}
+              <span class="ui label yellow">
+              {% else %}
+              <span class="ui label green">
+              {% endif %}
+                {{ record | vocabulary_title('access_right') }}
+              </span>
             </div>
           </div>
         </div>

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,4 +11,4 @@ pydocstyle invenio_rdm_records tests docs && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-python setup.py test
+pytest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,4 +11,4 @@ pydocstyle invenio_rdm_records tests docs && \
 isort -rc -c -df && \
 check-manifest --ignore ".travis-*" && \
 sphinx-build -qnNW docs docs/_build/html && \
-pytest
+python setup.py test


### PR DESCRIPTION
Display access right on landing page using vocab. 

Closes `record landing page: title-ize the access right. Now is "open Access", but should be "Open Access` from https://github.com/inveniosoftware/invenio-app-rdm/issues/154