### PR TITLE
config: define config_names [more]

### DIFF
--- a/invenio_rdm_records/resources.py
+++ b/invenio_rdm_records/resources.py
@@ -35,6 +35,7 @@ class BibliographicRecordResourceConfig(RecordResourceConfig):
 class BibliographicRecordResource(RecordResource):
     """Record resource."""
 
+    config_name = "RDM_RECORDS_BIBLIOGRAPHIC_RECORD_CONFIG"
     default_config = BibliographicRecordResourceConfig
 
 
@@ -52,6 +53,7 @@ class BibliographicDraftResourceConfig(DraftResourceConfig):
 class BibliographicDraftResource(DraftResource):
     """Record resource."""
 
+    config_name = "RDM_RECORDS_BIBLIOGRAPHIC_DRAFT_CONFIG"
     default_config = BibliographicDraftResourceConfig
 
 
@@ -73,4 +75,5 @@ class BibliographicDraftActionResourceConfig(DraftActionResourceConfig):
 class BibliographicDraftActionResource(DraftActionResource):
     """Bibliographic record draft action  resource."""
 
+    config_name = "RDM_RECORDS_BIBLIOGRAPHIC_DRAFT_ACTION_CONFIG"
     default_config = BibliographicDraftActionResourceConfig

--- a/invenio_rdm_records/services.py
+++ b/invenio_rdm_records/services.py
@@ -46,4 +46,5 @@ class BibliographicRecordServiceConfig(RecordDraftServiceConfig):
 class BibliographicRecordService(RecordDraftService):
     """Bibliographic record service."""
 
+    config_name = "RDM_RECORDS_BIBLIOGRAPHIC_SERVICE_CONFIG"
     default_config = BibliographicRecordServiceConfig


### PR DESCRIPTION
These are the names of the config.py variables
that can be used to override the BibliogaphicResourceConfigs
and BibliographicServiceConfig.

- closes https://github.com/inveniosoftware/invenio-records-resources/issues/67
(needs https://github.com/inveniosoftware/invenio-records-resources/pull/76 but not for tests to pass)