### PR TITLE
WIP records: jsonschema metadata update

### DIFF
--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -7,12 +7,6 @@
 
   "definitions": {
 
-    "lang": {
-      "description": "ISO 639-3 language code.",
-      "type": "string",
-      "maxLength": 3
-    },
-
     "nameType": {
       "description": "Type of name.",
       "type": "string",
@@ -89,10 +83,6 @@
       "additionalProperties": false,
       "required": ["pk", "pid_type", "obj_type", "status"],
       "properties": {
-        "id": {
-          "description": "TODO: The value of the persistent identifier.",
-          "type": "string"
-        },
         "pk": {
           "description": "Primary key of the PID object.",
           "type": "integer"
@@ -125,7 +115,7 @@
       "additionalProperties": false,
       "required": ["id", "provider"],
       "properties": {
-        "id": {
+        "identifier": {
           "description": "The value of the persistent identifier.",
           "type": "string"
         },
@@ -143,7 +133,12 @@
     "identifiers": {
       "description": "Identifiers object (keys being scheme, value being the identifier).",
       "type": "object",
-      "additionalProperties": {"type": "string"}
+      "additionalProperties": {"$ref": "#/definitions/identifier"}
+    },
+
+    "identifier": {
+      "description": "An identifier.",
+      "type": "string",
     },
 
     "resource_type": {
@@ -223,8 +218,9 @@
       }
     },
 
-    "agent-user": {
+    "user": {
       "type": "object",
+      "description": "..",
       "additionalProperties": false,
       "properties": {
         "user": {
@@ -234,9 +230,9 @@
     },
 
     "agent": {
-      "description": "An agent.",
+      "description": "An agent (user, software process, community, ...).",
       "oneOf": [
-        {"$ref": "#/definitions/agent-user"}
+        {"$ref": "#/definitions/user"}
       ]
     }
   },
@@ -260,7 +256,8 @@
     "conceptpid": {"$ref": "#/definitions/internal-pid"},
 
     "pids": {
-      "additionalProperties": {"$ref": "#/definitions/external-pid"}
+      "additionalProperties": {"$ref": "#/definitions/external-pid"},
+      "description": "Managed persistent identifiers for a record including e.g. OAI-PMH identifier, minted DOIs and more. Managed PIDs are registered in the PIDStore"
     },
 
     "metadata": {
@@ -306,7 +303,6 @@
                   "type": "string"
                 },
                 "type": {"$ref": "#/definitions/titleType"},
-                "lang": {"$ref": "#/definitions/lang"}
             },
             "required": ["title"]
           }
@@ -471,7 +467,6 @@
                   "type": "string"
                 },
                 "type": {"$ref": "#/definitions/descriptionType"},
-                "lang": {"$ref": "#/definitions/lang"}
             }
           }
         },
@@ -539,7 +534,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "reference_string": {"type": "string"},
+              "reference": {
+                "type": "string",
+                "description": "A reference string."
+              },
               "identifier": {"type": "string"},
               "scheme": {"type": "string"}
             }

--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -1,402 +1,714 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "http://localhost/schemas/records/record-v1.0.0.json",
-  "title": "Invenio Datacite based Record Schema v1.0.0",
+  "id": "https://inveniosoftware.org/schemas/rdm/records/record-v1.0.0.json",
+  "title": "InvenioRDM Record Schema v1.0.0",
   "type": "object",
   "additionalProperties": false,
 
-  "properties": {
-    "$schema": {
-      "description": "This record's jsonschema.",
+  "definitions": {
+
+    "lang": {
+      "description": "ISO 639-3 language code.",
+      "type": "string",
+      "maxLength": 3
+    },
+
+    "nameType": {
+      "description": "Type of name.",
+      "type": "string",
+      "enum": [
+          "organizational",
+          "personal"
+      ]
+    },
+
+    "titleType": {
+      "description": "Type of title.",
+      "type": "string",
+      "enum": [
+          "alternative_title",
+          "subtitle",
+          "translated_title",
+          "other"
+      ]
+    },
+
+    "contributorType": {
       "type": "string"
     },
-    "conceptid": {
-      "description": "Invenio record identifier (alphanumeric).",
+
+    "dateType": {
+      "description": "Type of the date.",
+      "type": "string",
+      "enum": [
+        "accepted",
+        "available",
+        "copyrighted",
+        "collected",
+        "created",
+        "issued",
+        "submitted",
+        "updated",
+        "valid",
+        "withdrawn",
+        "other"
+      ]
+    },
+
+    "relationType": {
       "type": "string"
     },
-    "id": {
-      "description": "Invenio record identifier (alphanumeric).",
-      "type": "string"
+
+    "descriptionType": {
+      "type": "string",
+      "enum": [
+        "abstract",
+        "methods",
+        "seriesinformation",
+        "tableofcontents",
+        "technicalinfo",
+        "other"
+      ]
     },
-    "access": {
-      "access_right": {
-        "default": "open",
-        "description": "Access right for record.",
-        "type": "string"
-      },
-      "created_by": {
-        "description": "ID of user that created the deposit.",
-        "type": "integer"
-      },
-      "metadata_restricted": {
-        "default": false,
-        "description": "Record metadata accesibility. Public by default (False).",
-        "type": "boolean"
-      },
-      "files_restricted": {
-        "default": false,
-        "description": "Record associated files accesibility. Public by default (False).",
-        "type": "boolean"
-      },
-      "owners": {
-        "description": "List of user IDs that are owners of the record.",
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": {
-          "type": "number"
+
+    "longitude": {
+      "type": "number",
+      "minimum": -180,
+      "maximum": 180
+    },
+
+    "latitude": {
+      "type": "number",
+      "minimum": -90,
+      "maximum": 90
+    },
+
+    "internal-pid": {
+      "type": "object",
+      "description": "An internal persistent identifier object.",
+      "additionalProperties": false,
+      "required": ["pk", "pid_type", "obj_type", "status"],
+      "properties": {
+        "id": {
+          "description": "TODO: The value of the persistent identifier.",
+          "type": "string"
+        },
+        "pk": {
+          "description": "Primary key of the PID object.",
+          "type": "integer"
+        },
+        "pid_type": {
+          "description": "The persistent identifier type (e.g. doi or recid).",
+          "type": "string"
+        },
+        "obj_type": {
+          "description": "The type of the assigned object (e.g. rec).",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status of the PID (from Invenio-PIDStore).",
+          "type": "string",
+          "enum": [
+            "N",
+            "K",
+            "R",
+            "M",
+            "D"
+          ]
         }
       }
     },
+
+    "external-pid": {
+      "type": "object",
+      "description": "An external persistent identifier object.",
+      "additionalProperties": false,
+      "required": ["id", "provider"],
+      "properties": {
+        "id": {
+          "description": "The value of the persistent identifier.",
+          "type": "string"
+        },
+        "provider": {
+          "description": "The provider of the persistent identifier.",
+          "type": "string"
+        },
+        "client": {
+          "description": "Client identifier for the specific PID.",
+          "type": "string"
+        }
+      }
+    },
+
+    "identifiers": {
+      "description": "Identifiers object (keys being scheme, value being the identifier).",
+      "type": "object",
+      "additionalProperties": {"type": "string"}
+    },
+
+    "resource_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A resource type.",
+      "properties": {
+        "type": {
+          "description": "The general resource type identifier.",
+          "type": "string"
+        },
+        "subtype": {
+          "description": "The specific resource type identifier.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+
+    "affiliations": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {"type": "string"},
+            "identifiers": {"$ref": "#/definitions/identifiers"}
+          },
+          "required": ["name", "identifiers"]
+      }
+    },
+
+    "file": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "A file object.",
+      "properties": {
+        "checksum": {
+          "description": "Checksum of the file.",
+          "type": "string"
+        },
+        "size": {
+          "description": "Size of the file in bytes.",
+          "type": "number"
+        },
+        "key": {
+          "description": "Key (filename) of the file.",
+          "type": "string"
+        },
+        "ext": {
+          "description": "File extension.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description for file.",
+          "type": "string"
+        },
+        "order": {
+          "description": "Value to sort according to.",
+          "type": "string"
+        },
+        "default_preview": {
+          "description": "Set to true to use as the default previewed file.",
+          "type": "boolean"
+        },
+        "bucket": {
+          "description": "TODO - Bucket id - what about third party storage systems?",
+          "type": "string"
+        },
+        "file_id": {
+          "description": "TODO - Identifier of the file. - same as for bucket",
+          "type": "string"
+        }
+      }
+    },
+
+    "agent-user": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "user": {
+          "type": "integer"
+        }
+      }
+    },
+
+    "agent": {
+      "description": "An agent.",
+      "oneOf": [
+        {"$ref": "#/definitions/agent-user"}
+      ]
+    }
+  },
+
+
+  "properties": {
+    "$schema": {
+      "description": "JSONSchema declaration.",
+      "type": "string"
+    },
+    "id": {
+      "description": "Persistent record identifier (alphanumeric).",
+      "type": "string"
+    },
+    "pid": {"$ref": "#/definitions/internal-pid"},
+
+    "conceptid": {
+      "description": "Persistent concept record identifier (alphanumeric).",
+      "type": "string"
+    },
+    "conceptpid": {"$ref": "#/definitions/internal-pid"},
+
+    "pids": {
+      "additionalProperties": {"$ref": "#/definitions/external-pid"}
+    },
+
     "metadata": {
-      "_default_preview": {
-        "description": "Default file previewed for the record.",
-        "type": "string"
-      },
-      "_internal_notes": {
-        "type": "array",
-        "minItems": 0,
-        "uniqueItems": true,
-        "items":{
+      "type": "object",
+      "description": "Resource metadata.",
+      "additionalProperties": false,
+      "properties": {
+
+        "resource_type": {"$ref": "#/definitions/resource_type"},
+
+        "creators": {
+          "description": "Creators of the resource.",
+          "type": "array",
+          "items": {
             "type": "object",
+            "additionalProperties": false,
+            "required": ["name"],
             "properties": {
-                "user": {"type": "string"},
-                "note": {"type": "string"},
-                "timestamp": {
-                  "description": "ISO8601 formatted date time stamp.",
-                  "type": "string",
-                  "format": "date-time"
-                }
-            },
-            "required": ["user", "note", "timestamp"]
-        }
-      },
-      "contact": {
-        "type": "string"
-      },
-      "contributors": {
-        "description": "Contributors in order of importance.",
-        "minItems": 0,
-        "type": "array",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-              "name": {"type": "string"},
-              "type": {"type": "string"},
-              "given_name": {"type": "string"},
-              "family_name": {"type": "string"},
-              "identifiers": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-              },
-              "affiliations": {
-                "type": "array",
-                "uniqueItems": true,
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {"type": "string"},
-                    "identifiers": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "required": ["name", "identifiers"]
-                }
-              },
-              "role": {"type": "string"}
-          },
-          "required": ["name", "role"]
-        }
-      },
-      "creators": {
-        "description": "Creators in order of importance.",
-        "minItems": 0,
-        "type": "array",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-              "name": {"type": "string"},
-              "type": {
-                "type": "string",
-                "description": "Type of name: Organizational or Personal"
-              },
-              "given_name": {"type": "string"},
-              "family_name": {"type": "string"},
-              "identifiers": {
-                "type": "object",
-                "additionalProperties": { "type": "string" }
-              },
-              "affiliations": {
-                "type": "array",
-                "uniqueItems": true,
-                "items": {
-                    "type": "object",
-                    "properties": {
-                      "name": {"type": "string"},
-                      "identifiers": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      }
-                    },
-                    "required": ["name", "identifiers"]
-                }
-              }
-          },
-          "required": ["name"]
-        }
-      },
-      "dates": {
-        "description": "Date or date interval.",
-        "minItems": 0,
-        "type": "array",
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "description": {
-              "description": "Description of the date or date interval e.g. 'Accepted' or 'Available' (CV).",
-              "type": "string"
-            },
-            "end": {
-              "description": "End date.",
-              "type": "string",
-              "format": "date-time"
-            },
-            "start": {
-              "description": "Start date.",
-              "type": "string",
-              "format": "date-time"
-            },
-            "type": {
-              "description": "Type of the date interval."
+                "name": {"type": "string"},
+                "type": {"$ref": "#/definitions/nameType"},
+                "given_name": {"type": "string"},
+                "family_name": {"type": "string"},
+                "identifiers": {"$ref": "#/definitions/identifiers"},
+                "affiliations": {"$ref": "#/definitions/affiliations"}
             }
-          },
-          "required": ["type"]
-        }
-      },
-      "descriptions": {
-        "description": "Description for record.",
-        "type": "array",
-        "uniqueItems": true,
-        "items": {
+          }
+        },
+
+        "title": {
+          "description": "Primary title of the record.",
+          "type": "string"
+        },
+
+        "additional_titles": {
+          "description": "Additional record titles.",
+          "type": "array",
+          "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "description": {
-                  "description": "Description/abstract for record.",
+                "title": {
+                  "description": "Additional title of the record.",
                   "type": "string"
                 },
-                "type": {
-                  "description": "Type of description.",
-                  "type": "string"
-                },
-                "lang": {
-                  "description": "Language of the description. ISO 639-3 language code.",
-                  "type": "string",
-                  "maxLength": 3
-                }
+                "type": {"$ref": "#/definitions/titleType"},
+                "lang": {"$ref": "#/definitions/lang"}
             },
-            "required": ["description"]
-        }
-      },
-      "embargo_date": {
-        "description": "Embargo date of record (ISO8601 formatted date).",
-        "type": "string",
-        "format": "date-time"
-      },
-      "identifiers": {
-        "type": "object",
-        "additionalProperties": { "type": "string" }
-      },
-      "language": {
-        "description": "Primary language of the resource. ISO 639-3 language code.",
-        "type": "string",
-        "maxLength": 3
-      },
-      "licenses": {
-        "description": "Any license or copyright information for this resource.",
-        "type": "array",
-        "uniqueItems": true,
-        "minItems": 1,
-        "items": {
-          "type": "object",
-          "properties": {
-              "license": {
-                "description": "The license itself. Free text.",
+            "required": ["title"]
+          }
+        },
+
+        "publisher": {
+          "type": "string"
+        },
+
+        "publication_date": {
+          "description": "Record publication date (EDTF level 0 format).",
+          "type": "string"
+        },
+
+        "subjects": {
+          "type": "array",
+          "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                  "subject": {"type": "string"},
+                  "identifier": {"type": "string"},
+                  "scheme": {"type": "string"}
+              },
+              "required": ["subject"]
+          }
+        },
+
+        "contributors": {
+          "description": "Contributors in order of importance.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "role"],
+            "properties": {
+                "name": {"type": "string"},
+                "type": {"$ref": "#/definitions/nameType"},
+                "role": {"$ref": "#/definitions/contributorType"},
+                "given_name": {"type": "string"},
+                "family_name": {"type": "string"},
+                "identifiers": {"$ref": "#/definitions/identifiers"},
+                "affiliations": {"$ref": "#/definitions/affiliations"}
+            }
+          }
+        },
+
+        "dates": {
+          "description": "Date or date interval.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "date": {
+                "description": "Date or date interval in EDTF level 0 format",
                 "type": "string"
               },
-              "uri": {
-                "description": "The URI of the license.",
-                "type": "string",
-                "format": "uri"
+              "type": {"$ref": "#/definitions/dateType"},
+              "description": {
+                "description": "Description of the date or date interval e.g. 'Accepted' or 'Available' (CV).",
+                "type": "string"
+              }
+            }
+          }
+        },
+
+        "languages": {
+          "description": "The primary languages of the resource. ISO 639-3 language code.",
+          "type": "array",
+          "items": {"$ref": "#/definitions/lang"}
+        },
+
+        "identifiers": {
+          "description": "Alternate identifiers for the record.",
+          "type": "array",
+          "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                  "identifier": {"type": "string"},
+                  "scheme": {"type": "string"}
+              }
+          },
+          "uniqueItems": true
+        },
+
+        "related_identifiers": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "identifier": {"type": "string"},
+                "scheme": {"type": "string"},
+                "relation": {"$ref": "#/definitions/relationType"},
+                "resource_type": {"$ref": "#/definitions/resource_type"}
+              }
+          }
+        },
+
+        "sizes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "formats": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+
+        "version": {
+          "description": "Record version tag.",
+          "type": "string"
+        },
+
+        "rights": {
+          "description": "Any license or copyright information for this resource.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "rights": {
+                "description": "The license name or license itself. Free text.",
+                "type": "string"
               },
               "identifier": {
-                "description": "A short, standardized version of the license name.",
+                "description": "An identifier for the license.",
                 "type": "string"
               },
               "scheme": {
-                "description": "The name of the scheme.",
+                "description": "An scheme for the identifier (e.g. spdx)",
                 "type": "string"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
               }
-          }
-        }
-      },
-      "locations": {
-        "description": "Geographical location.",
-        "type": "array",
-        "minItems": 0,
-        "items": {
-          "type": "object",
-          "properties": {
-            "point": {
-              "type": "object",
-              "properties": {
-                "lat": {
-                  "description": "Latitude of the location.",
-                  "type": "number"
-                },
-                "lon": {
-                  "description": "Longitude of the location.",
-                  "type": "number"
-                }
-              }
-            },
-            "place": {
-              "description": "Place of the location",
-              "type": "string"
-            },
-            "description": {
-              "description": "Description of the location",
-              "type": "string"
             }
-          },
-          "required": ["place"]
-        }
-      },
-      "publication_date": {
-        "description": "Record publication date (EDTF level 0 format).",
-        "type": "string"
-      },
-      "references": {
-        "type": "array",
-        "minItems": 0,
-        "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "reference_string": {"type": "string"},
-            "identifier": {"type": "string"},
-            "scheme": {"type": "string"}
           }
-        }
-      },
-      "related_identifiers": {
-        "type": "array",
-        "uniqueItems": true,
-        "minItems": 0,
-        "items": {
+        },
+
+        "description": {
+          "description": "Description for record (may contain HTML).",
+          "type": "string"
+        },
+
+        "additional_descriptions": {
+          "type": "array",
+          "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-              "identifier": {"type": "string"},
-              "scheme": {"type": "string"},
-              "relation_type": {"type": "string"},
-              "resource_type": {
+                "description": {
+                  "description": "Description for record.",
+                  "type": "string"
+                },
+                "type": {"$ref": "#/definitions/descriptionType"},
+                "lang": {"$ref": "#/definitions/lang"}
+            }
+          }
+        },
+
+        "locations": {
+          "description": "Geographical locations.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "point": {
                 "type": "object",
                 "additionalProperties": false,
                 "properties": {
-                  "type": {"type": "string"},
-                  "subtype": {"type": "string"}
-                },
-                "required": ["type"]
+                  "lat": {"$ref": "#/definitions/latitude"},
+                  "lon": {"$ref": "#/definitions/longitude"}
+                }
+              },
+              "place": {
+                "description": "Place of the location",
+                "type": "string"
+              },
+              "description": {
+                "description": "Description of the location",
+                "type": "string"
               }
-            },
-            "required": ["identifier", "scheme", "relation_type"]
-        }
-      },
-      "resource_type": {
-        "type": "object",
-        "additionalProperties": false,
-        "description": "Record resource type.",
-        "properties": {
-          "type": {
-            "default": "publication",
-            "description": "General resource type.",
-            "type": "string"
-          },
-          "subtype": {
-            "description": "Specific resource type.",
-            "type": "string"
+            }
           }
         },
-        "required": [
-          "type"
-        ]
-      },
-      "subjects": {
-        "type": "array",
-        "uniqueItems": true,
-        "minItems": 0,
-        "items": {
+
+        "funding": {
+          "type": "array",
+          "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "subject": {"type": "string"},
-                "identifier": {"type": "string"},
-                "scheme": {"type": "string"}
-            },
-            "required": ["subject"]
-        }
-      },
-      "titles": {
-        "description": "Record title.",
-        "type": "array",
-        "minItems": 1,
-        "uniqueItems": true,
-        "items": {
-          "type": "object",
-          "properties": {
-              "title": {
-                "description": "Title of the record.",
-                "type": "string"
+              "funder": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {"type": "string"},
+                  "identifier": {"type": "string"},
+                  "scheme": {"type": "string"}
+                }
               },
-              "type": {
-                "description": "Type of title.",
-                "type": "string"
-              },
-              "lang": {
-                "description": "Language of the title. ISO 639-3 language code.",
-                "type": "string",
-                "maxLength": 3
+              "award": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "title": {"type": "string"},
+                  "number": {"type": "string"},
+                  "identifier": {"type": "string"},
+                  "scheme": {"type": "string"}
+                }
               }
-          },
-          "required": ["title"]
-        }
-      },
-      "extensions": {
-        "additionalProperties": {
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": ["boolean", "number", "string"]
-              }
-            },
-            {"type": "boolean"},
-            {"type": "number"},
-            {"type": "string"}
-          ]
+            }
+          }
         },
-        "description": "Configured additional metadata",
-        "type": "object"
+
+        "references": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "reference_string": {"type": "string"},
+              "identifier": {"type": "string"},
+              "scheme": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
+
+    "metaext": {
+      "type": "object",
+      "description": "Configured additional metadata",
+      "propertyNames": {
+        "pattern": "^[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9_]+$"
       },
-      "version": {
-        "description": "Record version tag.",
-        "type": "string"
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": ["boolean", "number", "integer", "string"]
+            }
+          },
+          {"type": "boolean"},
+          {"type": "number"},
+          {"type": "integer"},
+          {"type": "string"}
+        ]
+      }
+    },
+
+    "tombstone": {
+      "type": "object",
+      "description": "Tombstone for the record.",
+      "additionalProperties": false,
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "Reason for removal."
+        },
+        "category": {
+          "type": "string",
+          "description": "Category for the removal."
+        },
+        "removed_by": {"$ref": "#/definitions/agent"},
+        "timestamp": {
+          "type": "string",
+          "description": "ISO8601 formatted timestamp in UTC.",
+          "format": "date-time"
+        }
+      }
+    },
+
+    "provenance": {
+      "type": "object",
+      "description": "Record provenance.",
+      "additionalProperties": false,
+      "properties": {
+        "created_by": {"$ref": "#/definitions/agent"},
+        "on_behalf_of": {"$ref": "#/definitions/agent"},
+        "contact": {"$ref": "#/definitions/agent"}
+      }
+    },
+
+    "access": {
+      "type": "object",
+      "description": "Record access control and ownership.",
+      "additionalProperties": false,
+      "properties": {
+
+        "metadata": {
+          "description": "Metadata visibility (true - public, false - private)",
+          "type": "boolean"
+        },
+
+        "files": {
+          "description": "Files visibility (true - public, false - private)",
+          "type": "boolean"
+        },
+
+        "contact": {
+          "description": "Enable the contact feature to contact owners.",
+          "type": "boolean"
+        },
+
+        "owned_by": {
+          "description": "List of user IDs that are owners of the record.",
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"$ref": "#/definitions/agent"}
+        },
+
+        "embargo_date": {
+          "description": "Embargo date of record (ISO8601 formatted date time in UTC). At this time both metadata and files will be made public.",
+          "type": "string",
+          "format": "date-time"
+        },
+
+        "access_condition": {
+          "description": "Conditions under which access to files are granted",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "condition": {
+              "type": "string",
+              "description": "Textual description under which conditions access is granted."
+            },
+            "default_link_validity": {
+              "type": "integer",
+              "description": "Number of days"
+            }
+          }
+        },
+
+        "access_right": {
+          "default": "open",
+          "description": "TODO - Access right for record. - should be computed or moved to metadata?",
+          "type": "string"
+        }
+      }
+    },
+
+    "files": {
+      "type": "object",
+      "description": "Files associated with the record",
+      "additionalProperties": false,
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "description": "Set to true for metadata only records."
+        },
+        "total_size": {
+          "type": "integer",
+          "description": "Total size of all files in bytes."
+        },
+        "count": {
+          "type": "integer",
+          "description": "Number of files."
+        },
+        "files": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/file"}
+        },
+        "bucket": {
+          "type": "string",
+          "description": "TODO - we need a bucket id, but what about third-party storage? systems"
+        }
+      }
+    },
+
+    "system": {
+      "type": "object",
+      "description": "System information.",
+      "properties": {
+        "notes": {
+          "type": "array",
+          "items":{
+              "type": "object",
+              "properties": {
+                  "created_by": {"$ref": "#/definitions/agent-user"},
+                  "note": {"type": "string"},
+                  "timestamp": {
+                    "description": "ISO8601 formatted date time stamp.",
+                    "type": "string",
+                    "format": "date-time"
+                  }
+              }
+          }
+        }
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
 #
-# Invenio-RDM-Records is free software; you can redistribute it and/or modifya
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration.

--- a/tests/records/conftest.py
+++ b/tests/records/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
 #
-# Invenio-RDM-Records is free software; you can redistribute it and/or modifya
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration.

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://localhost/schemas/records/record-v1.0.0.json",
+  "id": "abcde-12345",
+  "conceptid": "12345-abcde",
+  "pid": {
+    "pk": 1,
+    "pid_type": "recid",
+    "obj_type": "rec",
+    "status": "R"
+  },
+  "conceptpid": {
+    "pk": 2,
+    "pid_type": "recid",
+    "obj_type": "rec",
+    "status": "R"
+  },
+  "pids": {
+    "doi": {
+      "id": "10.5281/zenodo.1234",
+      "provider": "datacite",
+      "client": "zenodo"
+    },
+    "concept-doi": {
+      "id": "10.5281/zenodo.1234",
+      "provider": "datacite",
+      "client": "zenodo"
+    },
+    "handle": {
+      "id": "9.12314",
+      "provider": "cern-handle",
+      "client": "zenodo"
+    },
+    "oai": {
+      "id": "oai:zenodo.org:12345",
+      "provider": "zenodo"
+    }
+  },
+  "metadata": {
+    "resource_type": {
+      "type": "publication",
+      "subtype": "article"
+    },
+    "creators": [{
+      "name": "Nielsen, Lars Holm",
+      "type": "personal",
+      "given_name": "Lars Holm",
+      "family_name": "Nielsen",
+      "identifiers": {
+        "orcid": "0000-0001-8135-3489"
+      },
+      "affiliations": [{
+        "name": "CERN",
+        "identifiers": {
+          "ror": "01ggx4157",
+          "isni": "000000012156142X"
+        }
+      }]
+    }],
+    "title": "InvenioRDM",
+    "additional_titles": [{
+      "title": "a research data management platform",
+      "type": "subtitle",
+      "lang": "en"
+    }],
+    "publisher": "InvenioRDM",
+    "publication_date": "2018/2020-09",
+    "subjects": [{
+      "subject": "test",
+      "identifier": "test",
+      "scheme": "dewey"
+    }],
+    "contributors": [{
+      "name": "Nielsen, Lars Holm",
+      "type": "personal",
+      "role": "other",
+      "given_name": "Lars Holm",
+      "family_name": "Nielsen",
+      "identifiers": {
+        "orcid": "0000-0001-8135-3489"
+      },
+      "affiliations": [{
+        "name": "CERN",
+        "identifiers": {
+          "ror": "01ggx4157",
+          "isni": "000000012156142X"
+        }
+      }]
+    }],
+    "dates": [{
+      "date": "test",
+      "type": "other",
+      "description": "A date"
+    }],
+    "languages": ["da", "en"],
+    "identifiers": [{
+      "identifier": "10.1234/foo",
+      "scheme": "doi"
+    }],
+    "related_identifiers": [{
+      "identifier": "10.1234/foo.bar",
+      "scheme": "doi",
+      "relation": "cites"
+    }],
+    "sizes": [
+      "11 pages"
+    ],
+    "formats": [
+      "application/pdf"
+    ],
+    "version": "v1.0",
+    "rights": [{
+      "rights": "Creative Commons Attribution 4.0 International",
+      "scheme": "spdx",
+      "identifier": "cc-by-4.0",
+      "url": "https://creativecommons.org/licenses/by/4.0/"
+    }],
+    "description": "Test",
+    "additional_descriptions": [{
+      "description": "Bla bla bla",
+      "type": "methods",
+      "lang": "en"
+    }],
+    "locations": [{
+      "point": {
+        "lat": 1,
+        "lon": 2
+      },
+      "place": "home",
+      "description": "test"
+    }],
+    "funding": [{
+      "funder": {
+        "name": "European Commission",
+        "identifier": "1234",
+        "scheme": "ror"
+      },
+      "award": {
+        "title": "OpenAIRE",
+        "number": "246686",
+        "identifier": ".../246686",
+        "scheme": "openaire"
+      }
+    }],
+    "references": [{
+      "reference_string": "Nielsen et al,..",
+      "identifier": "101.234",
+      "scheme": "doi"
+    }]
+  },
+  "metaext": {
+    "dwc:collectionCode": "abc",
+    "dwc:collectionCode2": 1.1,
+    "dwc:collectionCode3": true,
+    "dwc:test": ["abc", 1, true]
+  },
+  "provenance": {
+    "created_by": {
+      "user": 1
+    },
+    "on_behalf_of": {
+      "user": 2
+    }
+  },
+  "access": {
+    "metadata": true,
+    "files": false,
+    "contact": true,
+    "owned_by": [{
+      "user": 1
+    }],
+    "embargo_date": "2021-01-01T00:00:00+0000",
+    "access_condition": {
+      "condition": "Medical doctors.",
+      "default_link_validity": 30
+    }
+  },
+  "files": {
+    "disabled": false,
+    "total_size": 1114324524355,
+    "count": 1,
+    "bucket": "81983514-22e5-473a-b521-24254bd5e049",
+    "files": [{
+      "checksum": "md5:234245234213421342",
+      "size": 1114324524355,
+      "key": "big-dataset.zip",
+      "ext": "zip",
+      "description": "File containing the data.",
+      "order": "1",
+      "default_preview": true,
+      "file_id": "445aaacd-9de1-41ab-af52-25ab6cb93df7"
+    }]
+  },
+  "system": {
+    "notes": [{
+      "note": "Under investigation for copyright infringement.",
+      "created_by": {
+        "user": 1
+      },
+      "timestamp": "2020-01-01T00:00:00+0000"
+    }]
+  }
+}

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -16,22 +16,22 @@
   },
   "pids": {
     "doi": {
-      "id": "10.5281/zenodo.1234",
+      "identifier": "10.5281/zenodo.1234",
       "provider": "datacite",
       "client": "zenodo"
     },
     "concept-doi": {
-      "id": "10.5281/zenodo.1234",
+      "identifier": "10.5281/zenodo.1234",
       "provider": "datacite",
       "client": "zenodo"
     },
     "handle": {
-      "id": "9.12314",
+      "identifier": "9.12314",
       "provider": "cern-handle",
       "client": "zenodo"
     },
     "oai": {
-      "id": "oai:zenodo.org:12345",
+      "identifier": "oai:zenodo.org:12345",
       "provider": "zenodo"
     }
   },
@@ -87,19 +87,20 @@
       }]
     }],
     "dates": [{
-      "date": "test",
+      "date": "1939/1945",
       "type": "other",
       "description": "A date"
     }],
     "languages": ["da", "en"],
     "identifiers": [{
-      "identifier": "10.1234/foo",
-      "scheme": "doi"
+      "identifier": "1924MNRAS..84..308E",
+      "scheme": "bibcode"
     }],
     "related_identifiers": [{
       "identifier": "10.1234/foo.bar",
       "scheme": "doi",
-      "relation": "cites"
+      "relation": "cites",
+      "resource_type": {"type": "dataset"}
     }],
     "sizes": [
       "11 pages"

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -6,29 +6,498 @@
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Test jsonschema validation."""
+"""JSONSchema tests."""
+
+import json
+from os.path import dirname, join
 
 import pytest
-from invenio_jsonschemas import current_jsonschemas
-from invenio_records.api import Record
+from jsonschema.exceptions import ValidationError
+
+from invenio_rdm_records.records.api import BibliographicRecord as Record
 
 
-@pytest.mark.skip()
-def test_metadata_extensions(appctx, minimal_record):
-    data = {
-        '$schema': (
-            current_jsonschemas.path_to_url('records/record-v1.0.0.json')
-        ),
-        'extensions': {
-            'dwc:family': 'Felidae',
-            'dwc:behavior': 'Plays with yarn, sleeps in cardboard box.',
-            'nubiomed:number_in_sequence': 3,
-            'nubiomed:scientific_sequence': [1, 1, 2, 3, 5, 8],
-            'nubiomed:original_presentation_date': '2019-02-14',
-            'nubiomed:right_or_wrong': True
-        }
+#
+# Assertion helpers
+#
+def validates(data):
+    """Assertion function used to validate according to the schema."""
+    data["$schema"] = "https://localhost/schemas/records/record-v1.0.0.json"
+    Record(data).validate()
+    return True
+
+
+def validates_meta(data):
+    """Validate metadata fields."""
+    return validates({"metadata": data})
+
+
+def fails(data):
+    """Assert that validation fails."""
+    pytest.raises(ValidationError, validates, data)
+    return True
+
+
+def fails_meta(data):
+    """Assert that validation fails for metadata."""
+    pytest.raises(ValidationError, validates_meta, data)
+    return True
+
+
+#
+# Fixtures
+#
+@pytest.fixture()
+def person():
+    """Person for creator or contributor."""
+    return {
+        "name": "Nielsen, Lars Holm",
+        "type": "personal",
+        "given_name": "Lars Holm",
+        "family_name": "Nielsen",
+        "identifiers": {
+            "orcid": "0000-0001-8135-3489"
+        },
+        "affiliations": [
+            {
+                "name": "CERN",
+                "identifiers": {
+                    "ror": "01ggx4157",
+                    "isni": "000000012156142X",
+                }
+            }
+        ]
     }
-    minimal_record.update(data)
-    record = Record(minimal_record)
 
-    record.validate()
+
+@pytest.fixture()
+def org():
+    """Organization for creator or contributor."""
+    return {
+        "name": "CERN",
+        "type": "organizational",
+        "identifiers": {
+            "ror": "01ggx4157"
+        },
+        "affiliations": [
+            {
+                "name": "CERN",
+                "identifiers": {
+                    "ror": "..."
+                }
+            }
+        ]
+    }
+
+
+def _load_json(filename):
+    with open(join(dirname(__file__), filename), 'rb') as fp:
+        return json.load(fp)
+
+
+#
+# Test a full record
+#
+def test_full_record(appctx):
+    """Test validation of a full record example."""
+    assert validates(_load_json('full-record.json'))
+
+
+def test_tombstone_record(appctx):
+    """Test validation of a tombstone record example."""
+    assert validates(_load_json('tombstone.json'))
+
+
+#
+# Tests internal/external identifiers
+#
+def test_id(appctx):
+    """Test id."""
+    assert validates({"id": "12345-abcd"})
+    assert fails({"id": 1})
+
+
+def test_conceptid(appctx):
+    """Test conceptid."""
+    assert validates({"conceptid": "12345-abcd"})
+    assert fails({"conceptid": {"id": "val"}})
+
+
+@pytest.mark.parametrize("prop", ["pid", "conceptpid"])
+def test_pid_conceptpid(appctx, prop):
+    """Test pid/conceptpid."""
+    pid = {
+        "pk": 1,
+        "pid_type": "recid",
+        "obj_type": "rec",
+        "status": "R",
+    }
+    assert validates({prop: pid})
+
+    # Valid status
+    for s in ["N", "K", "R", "M", "D"]:
+        pid["status"] = s
+        assert validates({prop: pid})
+
+    # Invalid status
+    pid["status"] = "INVALID"
+    assert fails({prop: pid})
+
+    # Extra propert
+    pid["invalid"] = "1"
+    assert fails({prop: pid})
+
+
+def test_pids(appctx):
+    """Test external pids."""
+    assert validates({"pids": {
+        "doi": {"id": "10.12345", "provider": "datacite", "client": "test"}
+    }})
+    assert validates({"pids": {
+        "doi": {"id": "10.12345", "provider": "datacite", "client": "test"},
+        "oai": {"id": "oai:10.12345", "provider": "local"},
+    }})
+    # Extra property
+    assert fails({"pids": {
+        "oai": {"id": "oai:10.12345", "provider": "local", "invalid": "test"}
+    }})
+    # Not a string
+    assert fails({"pids": {
+        "oai": {"id": 1, "provider": "local"}
+    }})
+
+
+#
+# Tests metadata
+#
+def test_metadata(appctx):
+    """Test empty metadata."""
+    assert validates({"metadata": {}})
+
+
+def test_resource_type(appctx):
+    """Test resource type."""
+    assert fails_meta({"resource_type": {}})
+    assert validates_meta({"resource_type": {"type": "publication"}})
+    assert validates_meta(
+        {"resource_type": {"type": "publication", "subtype": "test"}})
+    assert fails_meta(
+        {"resource_type": {"type": "publication", "invalid": "test"}})
+
+
+def test_creators(appctx, person, org):
+    """Test creators."""
+    assert fails_meta({"creators": {}})
+    assert validates_meta({"creators": []})
+    assert validates_meta({"creators": [{"name": "test"}]})
+
+    assert validates_meta({"creators": [person]})
+    assert validates_meta({"creators": [org]})
+    assert validates_meta({"creators": [person, org]})
+
+    # Additional prop fails
+    assert fails_meta({"creators": [{"name": "test", "invalid": "test"}]})
+    person["affiliations"][0]["invalid"] = "test"
+    assert fails_meta({"creators": [person]})
+
+
+def test_title(appctx):
+    """Test title property."""
+    assert validates_meta({"title": "Test"})
+    assert fails_meta({"title": {}})
+
+
+def test_additional_titles(appctx):
+    """Test additional titles property."""
+    assert fails_meta({"additional_titles": "Test"})
+    assert validates_meta({"additional_titles": []})
+    assert validates_meta({"additional_titles": [
+        {"title": "Test"}
+    ]})
+    assert validates_meta({"additional_titles": [
+        {"title": "Test", "type": "subtitle", "lang": "da"},
+    ]})
+
+    assert fails_meta({"additional_titles": [
+        {"title": "Test", "type": "invalid", "lang": "toolong"}
+    ]})
+    assert fails_meta({"additional_titles": [
+        {"title": "Test", "invalid": "invalid"}
+    ]})
+
+
+def test_publisher(appctx):
+    """Test publisher property."""
+    assert validates_meta({"publisher": "Zenodo"})
+    assert fails_meta({"publisher": 1})
+    assert fails_meta({"publisher": {}})
+
+
+def test_publication_date(appctx):
+    """Test publisher property."""
+    assert validates_meta({"publication_date": "2020-09-01"})
+    assert validates_meta({"publication_date": "2020-09"})
+    assert validates_meta({"publication_date": "2018/2020-09"})
+    assert fails_meta({"publisher": 2020})
+
+
+def test_subjects(appctx):
+    """Test publisher property."""
+    assert validates_meta({"subjects": []})
+    sub_min = {"subject": "Computing"}
+    sub_full = {"subject": "Computing", "scheme": "test", "identifier": "test"}
+    sub_invalid = {"subject": "Test", "invalid": "test"}
+    assert validates_meta({"subjects": [sub_min]})
+    assert validates_meta({"subjects": [sub_full]})
+    assert validates_meta({"subjects": [sub_min, sub_full]})
+    assert fails_meta({"subjects": [sub_invalid]})
+
+
+def test_contributors(appctx, person, org):
+    """Test contributors."""
+    assert fails_meta({"contributors": {}})
+    assert validates_meta({"contributors": []})
+    assert validates_meta({"contributors": [
+        {"name": "test", "role": "other"}]})
+
+    person["role"] = "other"
+    org["role"] = "hosting_institution"
+
+    assert validates_meta({"contributors": [person]})
+    assert validates_meta({"contributors": [org]})
+    assert validates_meta({"contributors": [person, org]})
+
+    # Additional prop fails
+    assert fails_meta({"contributors": [{"name": "test", "invalid": "test"}]})
+    person["affiliations"][0]["invalid"] = "test"
+    assert fails_meta({"contributors": [person]})
+
+
+def test_dates(appctx):
+    """Test dates."""
+    assert fails_meta({"dates": {}})
+    assert validates_meta({"dates": []})
+    assert validates_meta({"dates": [{"date": "test"}, ]})
+    assert validates_meta({"dates": [
+        {"date": "test", "type": "other", "description": "A date"}, ]})
+    # Additional prop fails
+    assert fails_meta({"dates": [{"date": "test", "invalid": "test"}, ]})
+
+
+def test_languages(appctx):
+    """Test language property."""
+    assert validates_meta({"languages": ["da", "en"]})
+    assert fails_meta({"languages": "da"})
+    assert fails_meta({"languages": ["invalid"]})
+
+
+def test_identifiers(appctx):
+    """Test alternate identifiers property."""
+    assert fails_meta({"identifiers": 1})
+    assert validates_meta({"identifiers": []})
+    assert validates_meta({"identifiers": [
+        {"identifier": "10.1234/test", "scheme": "doi"}
+    ]})
+    # Additional property
+    assert fails_meta({"identifiers": [
+        {"identifier": "10.1234/test", "invalid": "doi"}
+    ]})
+    # Unique
+    assert fails_meta({"identifiers": [
+        {"identifier": "10.1234/test", "scheme": "doi"},
+        {"identifier": "10.1234/test", "scheme": "doi"}
+    ]})
+
+
+def test_related_identifiers(appctx):
+    """Test alternate identifiers property."""
+    assert fails_meta({"related_identifiers": 1})
+    assert validates_meta({"related_identifiers": []})
+    assert validates_meta({"related_identifiers": [
+        {"identifier": "10.1234/test", "scheme": "doi", "relation": "cites"}
+    ]})
+    assert validates_meta({"related_identifiers": [
+        {"identifier": "10.1234/test", "relation": "cites"}
+    ]})
+    assert validates_meta({"related_identifiers": [
+        {"identifier": "10.1234/test", "relation": "cites"}
+    ]})
+    # Additional property
+    assert fails_meta({"related_identifiers": [
+        {"identifier": "10.1234/test", "invalid": "doi"}
+    ]})
+    # Unique
+    assert fails_meta({"related_identifiers": [
+        {"identifier": "10.1234/test", "scheme": "doi", "relation": "cites"},
+        {"identifier": "10.1234/test", "scheme": "doi", "relation": "cites"}
+    ]})
+
+
+def test_sizes(appctx):
+    """Test sizes property."""
+    assert validates_meta({"sizes": ["11 pages"]})
+    assert fails_meta({"sizes": [1]})
+    assert fails_meta({"sizes": "11 pages"})
+
+
+def test_formats(appctx):
+    """Test formats property."""
+    assert validates_meta({"formats": ["application/pdf"]})
+    assert fails_meta({"formats": [1]})
+    assert fails_meta({"formats": "PDF"})
+
+
+def test_version(appctx):
+    """Test version property."""
+    assert validates_meta({"version": "v1.0"})
+    assert fails_meta({"version": 1})
+    assert fails_meta({"version": {}})
+
+
+def test_rights(appctx):
+    """Test rights property."""
+    assert fails_meta({"rights": 1})
+    assert validates_meta({"rights": []})
+    lic_full = {
+        "rights": "Creative Commons Attribution 4.0 International",
+        "scheme": "spdx",
+        "identifier": "cc-by-4.0",
+        "url": "https://creativecommons.org/licenses/by/4.0/"
+    }
+    lic_min = {
+        "rights": "Copyright (C) 2020. All rights reserved.",
+        "url": "https://localhost"
+    }
+    assert validates_meta({"rights": [lic_full]})
+    assert validates_meta({"rights": [lic_min]})
+
+    # Additional property
+    lic_full["invalid"] = "test"
+    assert fails_meta({"rights": [lic_full]})
+    # Not a URI
+    lic_min["url"] = "invalid"
+    assert fails_meta({"rights": [lic_full]})
+
+
+def test_description(appctx):
+    """Test description property."""
+    assert validates_meta({"description": "Bla bla bla"})
+    assert fails_meta({"description": 1})
+    assert fails_meta({"description": {}})
+
+
+def test_additional_descriptions(appctx):
+    """Test dditional_descriptions property."""
+    assert fails_meta({"additional_descriptions": 1})
+    assert fails_meta({"additional_descriptions": {}})
+    desc = {
+        "description": "bla bla",
+        "type": "other",
+        "lang": "da",
+    }
+    assert validates_meta({"additional_descriptions": [desc]})
+    desc["invalid"] = "invalid"
+    assert fails_meta({"additional_descriptions": [desc]})
+
+
+def test_locations(appctx):
+    """Test locations property."""
+    p = {"lat": 1, "lon": 1}
+    assert validates_meta({"locations": [
+        {"point": p, "place": "home", "description": "cozy place"}
+    ]})
+    # Additional props
+    assert fails_meta({"locations": [{"point": p, "invalid": "home"}]})
+    p["invalid"] = 2
+    assert fails_meta({"locations": [{"point": p}]})
+    # Invalid lat/lon
+    assert fails_meta({"locations": [{"point": {"lat": -90.1, "lon": 1}}]})
+    assert fails_meta({"locations": [{"point": {"lat": 90.1, "lon": 1}}]})
+    assert fails_meta({"locations": [{"point": {"lat": 1, "lon": 180.1}}]})
+    assert fails_meta({"locations": [{"point": {"lat": 1, "lon": -180.1}}]})
+    assert validates_meta({"locations": [{"point": {"lat": 90, "lon": 180}}]})
+    assert validates_meta({
+        "locations": [{"point": {"lat": -90, "lon": -180}}]})
+
+
+def test_funding(appctx):
+    """Test funding references property."""
+    f = {
+        "name": "European Commission",
+        "identifier": "1234",
+        "scheme": "ror",
+    }
+    a = {
+        "title": "OpenAIRE",
+        "number": "246686",
+        "identifier": ".../246686",
+        "scheme": "openaire"
+    }
+
+    assert validates_meta({"funding": [{"funder": f}]})
+    assert validates_meta({"funding": [{"award": a}]})
+    assert validates_meta({"funding": [{"funder": f, "award": a}]})
+    # Additional props
+    f["invalid"] = "test"
+    assert fails_meta({"funding": [{"funder": f}]})
+    a["invalid"] = "test"
+    assert fails_meta({"funding": [{"award": a}]})
+
+
+def test_reference(appctx):
+    """Test references property."""
+    assert validates_meta({"references": [
+        {
+            "reference_string": "Nielsen et al,..",
+            "identifier": "101.234",
+            "scheme": "doi",
+        },
+    ]})
+    # Additional props
+    assert fails_meta({"references": [
+        {
+            "invalid": "Nielsen et al,..",
+        },
+    ]})
+
+
+#
+# Test metaext
+#
+def test_metaext(appctx):
+    """Test references property."""
+    data_types = [
+        "string",
+        1234,
+        1234.2,
+        True,
+        ["string"],
+        [1.2],
+        [False],
+        ["string", -132.4, True],
+    ]
+
+    for val in data_types:
+        assert validates({"metaext": {"dwc:afield": val}})
+
+    # Invalid field name
+    assert fails({"metaext": {"0dwc:afield": "test"}})
+    assert fails({"metaext": {"afield": "test"}})
+    assert fails({"metaext": {"afield": "test"}})
+
+
+#
+# Tombstones
+#
+def test_tombstones(appctx):
+    """Test a tombstone."""
+    assert validates({"tombstone": {
+        "reason": "Spam record, removed by InvenioRDM staff.",
+        "category": "spam_manual",
+        "removed_by": {"user": 1},
+        "timestamp": "2020-09-01T12:02:00+0000"
+    }})
+    assert fails({"tombstone": {
+        "reason": "Spam record, removed by InvenioRDM staff.",
+        "invalid": "test"
+    }})

--- a/tests/records/tombstone.json
+++ b/tests/records/tombstone.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://localhost/schemas/records/record-v1.0.0.json",
+  "id": "abcde-12345",
+  "conceptid": "12345-abcde",
+  "pid": {
+    "pk": 1,
+    "pid_type": "recid",
+    "obj_type": "rec",
+    "status": "R"
+  },
+  "conceptpid": {
+    "pk": 2,
+    "pid_type": "recid",
+    "obj_type": "rec",
+    "status": "R"
+  },
+  "pids": {
+    "doi": {
+      "id": "10.5281/zenodo.1234",
+      "provider": "datacite",
+      "client": "zenodo"
+    },
+    "concept-doi": {
+      "id": "10.5281/zenodo.1234",
+      "provider": "datacite",
+      "client": "zenodo"
+    },
+    "handle": {
+      "id": "9.12314",
+      "provider": "cern-handle",
+      "client": "zenodo"
+    },
+    "oai": {
+      "id": "oai:zenodo.org:12345",
+      "provider": "zenodo"
+    }
+  },
+  "tombstone": {
+    "reason": "Spam record, removed by InvenioRDM staff.",
+    "category": "spam_manual",
+    "removed_by": {"user": 1},
+    "timestamp": "2020-09-01T12:02:00+0000"
+  }
+}

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
 #
-# Invenio-RDM-Records is free software; you can redistribute it and/or modifya
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration.

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
 #
-# Invenio-RDM-Records is free software; you can redistribute it and/or modifya
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration.

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
 #
-# Invenio-RDM-Records is free software; you can redistribute it and/or modifya
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Pytest configuration.


### PR DESCRIPTION
This is a first draft of the update to the internal JSONSchema.

### Quick notes/questions

- Metadata and Extensions have been split apart.
- I've taken the following out of metadata: contact, internal notes, embargo date (their new location i didn't think properly about yet)
- Type definitions i've tried to put in the top, even if there's no controlled vocab (we need to discuss if all of them should be customizable).
- DataCite ``identifiers`` is taken care of by ``pid``, ``conceptpid`` and ``pids`` (i.e. all managed persistent identifiers).
- DataCite alternate identifiers is named identifiers.
- Field names: 
   - I've tried to stay as closed to datacite as possible, however 1) we need shorter names (and is not restricted by xml) 2) we need consistent naming for some properties.
- ``lang`` property - has not been added consistently, and we should disucss if we add them at all.
- Should we rename ``resource_type`` to ``type``? Could resource type be a single identifier?
- There's open questions regarding the structure of the fields that will have linked records (funders, awards, rights, subjects)
- DataCite support only 1 language, while we have requirements for mulitple languages 
- related identifiers have no support for hasMetadata etc, since the usage of it is very complex
- i've left out schemeURIs
- title/description is split in title/additional_titles and description/additional_descriptions in order to make it very clear what is the correct title/description to use for a record (otherwise we end in having different ways in different parts of the code).
- references/related_identifiers I guess we still have to discuss.
- required vs not required has not been properly addressed.