### PR TITLE
toggle 'more/less' detail message when expanding/collapsing stats

### DIFF
--- a/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
+++ b/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
@@ -178,3 +178,22 @@ dd {
 		display: block;
 	}
 }
+
+
+
+/* use these classes to change accordion title when up/down */
+div.accordion div.title.active span.up {
+  display: none;
+}
+
+div.accordion div.title.active span.down {
+  display: inline;
+}
+
+div.accordion div.title span.up {
+  display: inline;
+}
+
+div.accordion div.title span.down {
+  display: none;
+}

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
@@ -35,7 +35,8 @@
       <div class="ui accordion">
         <div class="title centered">
           <a style="cursor: pointer;" class="dropdown">
-            See more details...
+            <span class="up">See more detail...</span>
+            <span class="down">See less detail...</span>
           </a>
         </div>
         <div class="content">


### PR DESCRIPTION
Trying to get familar with Semantic-UI. I couldn't find this in the documentation, but I think this approach with CSS is valid? 

(Attempting to close #62)