### PR TITLE
datamodel: update jsonschema, full flow and validation for minimal record

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -34,4 +34,4 @@ recursive-include invenio_rdm_records *.json *.csv
 recursive-include invenio_rdm_records *.po *.pot
 recursive-include invenio_rdm_records *.png *.svg
 recursive-include invenio_rdm_records *.html *.js *.less
-recursive-include tests *.py *.csv
+recursive-include tests *.py *.csv *.json

--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -65,6 +65,12 @@
       ]
     },
 
+    "language": {
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 3
+    },
+
     "longitude": {
       "type": "number",
       "minimum": -180,
@@ -77,23 +83,31 @@
       "maximum": 90
     },
 
+    "scheme": {
+      "description": "A scheme.",
+      "type": "string"
+    },
+
+    "identifier": {
+      "description": "An identifier.",
+      "type": "string"
+    },
+
+    "identifiers": {
+      "description": "Identifiers object (keys being scheme, value being the identifier).",
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/identifier"}
+    },
+
     "internal-pid": {
       "type": "object",
       "description": "An internal persistent identifier object.",
       "additionalProperties": false,
-      "required": ["pk", "pid_type", "obj_type", "status"],
+      "required": ["pk", "status"],
       "properties": {
         "pk": {
           "description": "Primary key of the PID object.",
           "type": "integer"
-        },
-        "pid_type": {
-          "description": "The persistent identifier type (e.g. doi or recid).",
-          "type": "string"
-        },
-        "obj_type": {
-          "description": "The type of the assigned object (e.g. rec).",
-          "type": "string"
         },
         "status": {
           "description": "The status of the PID (from Invenio-PIDStore).",
@@ -113,12 +127,9 @@
       "type": "object",
       "description": "An external persistent identifier object.",
       "additionalProperties": false,
-      "required": ["id", "provider"],
+      "required": ["identifier", "provider"],
       "properties": {
-        "identifier": {
-          "description": "The value of the persistent identifier.",
-          "type": "string"
-        },
+        "identifier": {"$ref": "#/definitions/identifier"},
         "provider": {
           "description": "The provider of the persistent identifier.",
           "type": "string"
@@ -130,16 +141,6 @@
       }
     },
 
-    "identifiers": {
-      "description": "Identifiers object (keys being scheme, value being the identifier).",
-      "type": "object",
-      "additionalProperties": {"$ref": "#/definitions/identifier"}
-    },
-
-    "identifier": {
-      "description": "An identifier.",
-      "type": "string",
-    },
 
     "resource_type": {
       "type": "object",
@@ -211,10 +212,7 @@
           "description": "TODO - Bucket id - what about third party storage systems?",
           "type": "string"
         },
-        "file_id": {
-          "description": "TODO - Identifier of the file. - same as for bucket",
-          "type": "string"
-        }
+        "file_id": {"$ref": "#/definitions/identifier"}
       }
     },
 
@@ -303,6 +301,7 @@
                   "type": "string"
                 },
                 "type": {"$ref": "#/definitions/titleType"},
+                "lang": {"ref": "#/definitions/language"}
             },
             "required": ["title"]
           }
@@ -324,8 +323,8 @@
               "additionalProperties": false,
               "properties": {
                   "subject": {"type": "string"},
-                  "identifier": {"type": "string"},
-                  "scheme": {"type": "string"}
+                  "identifier": {"$ref": "#/definitions/identifier"},
+                  "scheme": {"$ref": "#/definitions/scheme"}
               },
               "required": ["subject"]
           }
@@ -373,7 +372,7 @@
         "languages": {
           "description": "The primary languages of the resource. ISO 639-3 language code.",
           "type": "array",
-          "items": {"$ref": "#/definitions/lang"}
+          "items": {"$ref": "#/definitions/language"}
         },
 
         "identifiers": {
@@ -383,8 +382,8 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                  "identifier": {"type": "string"},
-                  "scheme": {"type": "string"}
+                  "identifier": {"$ref": "#/definitions/identifier"},
+                  "scheme": {"$ref": "#/definitions/scheme"}
               }
           },
           "uniqueItems": true
@@ -397,8 +396,8 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "identifier": {"type": "string"},
-                "scheme": {"type": "string"},
+                "identifier": {"$ref": "#/definitions/identifier"},
+                "scheme": {"$ref": "#/definitions/scheme"},
                 "relation": {"$ref": "#/definitions/relationType"},
                 "resource_type": {"$ref": "#/definitions/resource_type"}
               }
@@ -435,14 +434,8 @@
                 "description": "The license name or license itself. Free text.",
                 "type": "string"
               },
-              "identifier": {
-                "description": "An identifier for the license.",
-                "type": "string"
-              },
-              "scheme": {
-                "description": "An scheme for the identifier (e.g. spdx)",
-                "type": "string"
-              },
+              "identifier": {"$ref": "#/definitions/identifier"},
+              "scheme": {"$ref": "#/definitions/scheme"},
               "url": {
                 "type": "string",
                 "format": "uri"
@@ -467,6 +460,7 @@
                   "type": "string"
                 },
                 "type": {"$ref": "#/definitions/descriptionType"},
+                "lang": {"ref": "#/definitions/language"}
             }
           }
         },
@@ -509,8 +503,8 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {"type": "string"},
-                  "identifier": {"type": "string"},
-                  "scheme": {"type": "string"}
+                  "identifier": {"$ref": "#/definitions/identifier"},
+                  "scheme": {"$ref": "#/definitions/scheme"}
                 }
               },
               "award": {
@@ -519,8 +513,8 @@
                 "properties": {
                   "title": {"type": "string"},
                   "number": {"type": "string"},
-                  "identifier": {"type": "string"},
-                  "scheme": {"type": "string"}
+                  "identifier": {"$ref": "#/definitions/identifier"},
+                  "scheme": {"$ref": "#/definitions/scheme"}
                 }
               }
             }
@@ -538,34 +532,17 @@
                 "type": "string",
                 "description": "A reference string."
               },
-              "identifier": {"type": "string"},
-              "scheme": {"type": "string"}
+              "identifier": {"$ref": "#/definitions/identifier"},
+              "scheme": {"$ref": "#/definitions/scheme"}
             }
           }
         }
       }
     },
 
-    "metaext": {
+    "ext": {
       "type": "object",
-      "description": "Configured additional metadata",
-      "propertyNames": {
-        "pattern": "^[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9_]+$"
-      },
-      "additionalProperties": {
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "type": ["boolean", "number", "integer", "string"]
-            }
-          },
-          {"type": "boolean"},
-          {"type": "number"},
-          {"type": "integer"},
-          {"type": "string"}
-        ]
-      }
+      "description": "Configured additional metadata"
     },
 
     "tombstone": {
@@ -596,8 +573,7 @@
       "additionalProperties": false,
       "properties": {
         "created_by": {"$ref": "#/definitions/agent"},
-        "on_behalf_of": {"$ref": "#/definitions/agent"},
-        "contact": {"$ref": "#/definitions/agent"}
+        "on_behalf_of": {"$ref": "#/definitions/agent"}
       }
     },
 
@@ -614,11 +590,6 @@
 
         "files": {
           "description": "Files visibility (true - public, false - private)",
-          "type": "boolean"
-        },
-
-        "contact": {
-          "description": "Enable the contact feature to contact owners.",
           "type": "boolean"
         },
 
@@ -688,25 +659,10 @@
       }
     },
 
-    "system": {
-      "type": "object",
-      "description": "System information.",
-      "properties": {
-        "notes": {
-          "type": "array",
-          "items":{
-              "type": "object",
-              "properties": {
-                  "created_by": {"$ref": "#/definitions/agent-user"},
-                  "note": {"type": "string"},
-                  "timestamp": {
-                    "description": "ISO8601 formatted date time stamp.",
-                    "type": "string",
-                    "format": "date-time"
-                  }
-              }
-          }
-        }
+    "notes": {
+      "type": "array",
+      "items":{
+          "type": "string"
       }
     }
   }

--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -11,13 +11,9 @@
 from invenio_drafts_resources.services.records.schema import RecordSchema
 from marshmallow import EXCLUDE, INCLUDE, Schema, fields, missing
 
-from .access import AccessSchemaV1
-from .communities import CommunitiesSchemaV1
-from .files import FilesSchemaV1
-from .metadata import MetadataSchemaV1
-from .pids import PIDSSchemaV1
-from .relations import RelationsSchemaV1
-from .stats import StatsSchemaV1
+from .access import AccessSchema
+from .metadata import MetadataSchema
+from .pids import PIDSchema
 
 
 # NOTE: Use this one for system fields only
@@ -35,7 +31,7 @@ class NestedAttribute(fields.Nested, AttributeAccessorFieldMixin):
     """Nested object attribute field."""
 
 
-class RDMRecordSchemaV1(RecordSchema):
+class RDMRecordSchema(RecordSchema):
     """Record schema."""
 
     class Meta:
@@ -51,24 +47,22 @@ class RDMRecordSchemaV1(RecordSchema):
         'files': 'read_files',
     }
 
-    # schema_version = fields.Interger(dump_only=True)
-    # revision = fields.Integer(attribute='revision_id', dump_only=True)
-    # id = fields.Str(attribute='recid', dump_only=True)
-    # concept_id = fields.Str(attribute='conceptrecid', dump_only=True)
+    id = fields.Str()
+    conceptid = fields.Str()
+    metadata = NestedAttribute(MetadataSchema)
+    access = NestedAttribute(AccessSchema)
+    pids = fields.List(NestedAttribute(PIDSchema))
     created = fields.Str(dump_only=True)
     updated = fields.Str(dump_only=True)
-
-    # status = fields.Str(dump_only=True)
-
-    metadata = NestedAttribute(MetadataSchemaV1)
-    access = NestedAttribute(AccessSchemaV1)
+    revision = fields.Integer(dump_only=True)
     # files = NestedAttribute(FilesSchemaV1, dump_only=True)
     # communities = NestedAttribute(CommunitiesSchemaV1)
     # pids = NestedAttribute(PIDSSchemaV1)
     # stats = NestedAttribute(StatsSchemaV1, dump_only=True)
     # relations = NestedAttribute(RelationsSchemaV1, dump_only=True)
+    # schema_version = fields.Interger(dump_only=True)
 
 
 __all__ = (
-    'RDMRecordSchemaV1',
+    'RDMRecordSchema',
 )

--- a/invenio_rdm_records/services/schemas/access.py
+++ b/invenio_rdm_records/services/schemas/access.py
@@ -9,24 +9,33 @@
 """RDM record schemas."""
 
 import arrow
-from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
 from marshmallow import Schema, ValidationError, fields, validate, validates, \
     validates_schema
+from marshmallow_utils.fields import EDTFDateString, SanitizedUnicode
 
 from .utils import validate_entry
 
 
-class AccessSchemaV1(Schema):
+class AccessConditionSchema(Schema):
+    """Access condition schema.
+
+    Conditions under which access to files are granted.
+    """
+
+    condition = fields.String()
+    default_link_validity = fields.Integer()
+
+
+class AccessSchema(Schema):
     """Access schema."""
 
-    metadata_restricted = fields.Bool(required=True)
-    files_restricted = fields.Bool(required=True)
-    owners = fields.List(
+    metadata = fields.Bool(required=True)
+    files = fields.Bool(required=True)
+    owned_by = fields.List(
         fields.Integer, validate=validate.Length(min=1), required=True)
-    created_by = fields.Integer(required=True)
-    embargo_date = DateString()
-    contact = SanitizedUnicode(data_key="contact", attribute="contact")
     access_right = SanitizedUnicode(required=True)
+    embargo_date = EDTFDateString()
+    access_condition = fields.Nested(AccessConditionSchema)
 
     @validates('embargo_date')
     def validate_embargo_date(self, value):

--- a/invenio_rdm_records/services/schemas/communities.py
+++ b/invenio_rdm_records/services/schemas/communities.py
@@ -15,7 +15,7 @@ from marshmallow import INCLUDE, Schema, fields, validate
 #
 # Communities
 #
-class CommunitiesRequestV1(Schema):
+class CommunitiesRequest(Schema):
     """Community Request Schema."""
 
     id = SanitizedUnicode(required=True)
@@ -41,23 +41,23 @@ class CommunitiesRequestV1(Schema):
     #     return res
 
 
-class CommunitiesSchemaV1(Schema):
+class CommunitiesSchema(Schema):
     """Communities schema."""
 
-    pending = fields.List(fields.Nested(CommunitiesRequestV1))
-    accepted = fields.List(fields.Nested(CommunitiesRequestV1))
-    rejected = fields.List(fields.Nested(CommunitiesRequestV1))
+    pending = fields.List(fields.Nested(CommunitiesRequest))
+    accepted = fields.List(fields.Nested(CommunitiesRequest))
+    rejected = fields.List(fields.Nested(CommunitiesRequest))
 
 
-# TODO: See how this can be integrated in `CommunitiesSchemaV1`
+# TODO: See how this can be integrated in `CommunitiesSchema`
 def dump_communities(self, obj):
     """Dumps communities related to the record."""
     # NOTE: If the field is already there, it's coming from ES
     if '_communities' in obj:
-        return CommunitiesSchemaV1().dump(obj['_communities'])
+        return CommunitiesSchema().dump(obj['_communities'])
 
     record = self.context.get('record')
     if record:
         _record = Record(record, model=record.model)
-        return CommunitiesSchemaV1().dump(
+        return CommunitiesSchema().dump(
             RecordCommunitiesCollection(_record).as_dict())

--- a/invenio_rdm_records/services/schemas/files.py
+++ b/invenio_rdm_records/services/schemas/files.py
@@ -12,7 +12,7 @@ from invenio_records_rest.schemas.fields import SanitizedUnicode
 from marshmallow import INCLUDE, Schema, fields, validate
 
 
-class FileSchemaV1(Schema):
+class FileSchema(Schema):
     """File schema."""
 
     type = fields.String()
@@ -31,9 +31,9 @@ class FileSchemaV1(Schema):
     #     }
 
 
-class FilesSchemaV1(Schema):
+class FilesSchema(Schema):
     """Files metadata schema."""
 
     enabled = fields.Bool()
     default_preview = SanitizedUnicode()
-    items = fields.List(fields.Nested(FileSchemaV1))
+    items = fields.List(fields.Nested(FileSchema))

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -22,9 +22,6 @@ from marshmallow_utils.fields import EDTFDateString, GenFunction, \
 
 from .utils import validate_entry
 
-# TODO (Alex): This file can be split into separate parts for each group
-#              of fields
-
 
 def prepare_publication_date(record_dict):
     """
@@ -42,7 +39,7 @@ def prepare_publication_date(record_dict):
 
     NOTE: Keeping this function outside the class to make it easier to move
           when dealing with deposit. By then, if only called here, it can
-          be merged in MetadataSchemaV1.
+          be merged in MetadataSchema.
 
     :param record_dict: loaded Record dict
     """
@@ -55,7 +52,7 @@ def prepare_publication_date(record_dict):
     )
 
 
-class InternalNoteSchemaV1(Schema):
+class InternalNoteSchema(Schema):
     """Internal note shema."""
 
     user = SanitizedUnicode(required=True)
@@ -63,7 +60,7 @@ class InternalNoteSchemaV1(Schema):
     timestamp = ISODateString(required=True)
 
 
-class DateSchemaV1(Schema):
+class DateSchema(Schema):
     """Schema for date intervals."""
 
     DATE_TYPES = [
@@ -136,7 +133,7 @@ def Identifiers():
     )
 
 
-class AffiliationSchemaV1(Schema):
+class AffiliationSchema(Schema):
     """Affiliation of a creator/contributor."""
 
     name = SanitizedUnicode(required=True)
@@ -155,7 +152,7 @@ class AffiliationSchemaV1(Schema):
             raise ValidationError(_("Invalid identifier."))
 
 
-class CreatorSchemaV1(Schema):
+class CreatorSchema(Schema):
     """Creator schema."""
 
     NAMES = [
@@ -174,7 +171,7 @@ class CreatorSchemaV1(Schema):
     given_name = SanitizedUnicode()
     family_name = SanitizedUnicode()
     identifiers = fields.Dict()
-    affiliations = fields.List(fields.Nested(AffiliationSchemaV1))
+    affiliations = fields.List(fields.Nested(AffiliationSchema))
 
     @validates("identifiers")
     def validate_identifiers(self, value):
@@ -216,7 +213,7 @@ class CreatorSchemaV1(Schema):
                 raise ValidationError({"identifiers": messages})
 
 
-class ContributorSchemaV1(CreatorSchemaV1):
+class ContributorSchema(CreatorSchema):
     """Contributor schema."""
 
     role = SanitizedUnicode(required=True)
@@ -227,7 +224,7 @@ class ContributorSchemaV1(CreatorSchemaV1):
         validate_entry('contributors.role', data)
 
 
-class ResourceTypeSchemaV1(Schema):
+class ResourceTypeSchema(Schema):
     """Resource type schema."""
 
     type = fields.Str(required=True)
@@ -239,7 +236,7 @@ class ResourceTypeSchemaV1(Schema):
         validate_entry('resource_type', data)
 
 
-class TitleSchemaV1(Schema):
+class TitleSchema(Schema):
     """Schema for the additional title."""
 
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
@@ -252,7 +249,7 @@ class TitleSchemaV1(Schema):
         validate_entry('titles.type', data)
 
 
-class DescriptionSchemaV1(Schema):
+class DescriptionSchema(Schema):
     """Schema for the additional descriptions."""
 
     DESCRIPTION_TYPES = [
@@ -272,7 +269,7 @@ class DescriptionSchemaV1(Schema):
     lang = ISOLangString()
 
 
-class LicenseSchemaV1(Schema):
+class LicenseSchema(Schema):
     """License schema."""
 
     license = SanitizedUnicode(required=True)
@@ -281,7 +278,7 @@ class LicenseSchemaV1(Schema):
     scheme = SanitizedUnicode()
 
 
-class SubjectSchemaV1(Schema):
+class SubjectSchema(Schema):
     """Subject schema."""
 
     subject = SanitizedUnicode(required=True)
@@ -289,7 +286,7 @@ class SubjectSchemaV1(Schema):
     scheme = SanitizedUnicode()
 
 
-class DateSchemaV1(Schema):
+class DateSchema(Schema):
     """Schema for date intervals."""
 
     DATE_TYPES = [
@@ -334,7 +331,7 @@ class DateSchemaV1(Schema):
             )
 
 
-class RelatedIdentifierSchemaV1(Schema):
+class RelatedIdentifierSchema(Schema):
     """Related identifier schema."""
 
     RELATIONS = [
@@ -405,10 +402,10 @@ class RelatedIdentifierSchemaV1(Schema):
             choices=RELATIONS,
             error=_('Invalid relation type. {input} not one of {choices}.')
         ))
-    resource_type = fields.Nested(ResourceTypeSchemaV1)
+    resource_type = fields.Nested(ResourceTypeSchema)
 
 
-class ReferenceSchemaV1(Schema):
+class ReferenceSchema(Schema):
     """Reference schema."""
 
     SCHEMES = [
@@ -425,22 +422,22 @@ class ReferenceSchemaV1(Schema):
         ))
 
 
-class PointSchemaV1(Schema):
+class PointSchema(Schema):
     """Point schema."""
 
     lat = fields.Number(required=True)
     lon = fields.Number(required=True)
 
 
-class LocationSchemaV1(Schema):
+class LocationSchema(Schema):
     """Location schema."""
 
-    point = fields.Nested(PointSchemaV1)
+    point = fields.Nested(PointSchema)
     place = SanitizedUnicode(required=True)
     description = SanitizedUnicode()
 
 
-class MetadataSchemaV1(Schema):
+class MetadataSchema(Schema):
     """Schema for the record metadata."""
 
     field_load_permissions = {
@@ -459,23 +456,23 @@ class MetadataSchemaV1(Schema):
         unknown = INCLUDE
 
     # Metadata fields
-    titles = fields.List(fields.Nested(TitleSchemaV1), required=True)
-    creators = fields.List(fields.Nested(CreatorSchemaV1), required=True)
-    resource_type = fields.Nested(ResourceTypeSchemaV1, required=True)
+    title = fields.String(required=True, validate=validate.Length(min=3))
+    additional_titles = fields.List(fields.Nested(TitleSchema))
+    creators = fields.List(fields.Nested(CreatorSchema), required=True)
+    resource_type = fields.Nested(ResourceTypeSchema, required=True)
     publication_date = EDTFDateString(required=True)
-    subjects = fields.List(fields.Nested(SubjectSchemaV1))
-    contributors = fields.List(fields.Nested(ContributorSchemaV1))
-    dates = fields.List(fields.Nested(DateSchemaV1))
-    language = ISOLangString()
-    related_identifiers = fields.List(
-        fields.Nested(RelatedIdentifierSchemaV1))
-    version = SanitizedUnicode()
-    licenses = fields.List(fields.Nested(LicenseSchemaV1))
-    descriptions = fields.List(fields.Nested(DescriptionSchemaV1))
-    locations = fields.List(fields.Nested(LocationSchemaV1))
-    references = fields.List(fields.Nested(ReferenceSchemaV1))
-
-    _internal_notes = fields.List(fields.Nested(InternalNoteSchemaV1))
+    # subjects = fields.List(fields.Nested(SubjectSchema))
+    # contributors = fields.List(fields.Nested(ContributorSchema))
+    # dates = fields.List(fields.Nested(DateSchema))
+    # language = ISOLangString()
+    # related_identifiers = fields.List(
+    #     fields.Nested(RelatedIdentifierSchema))
+    # version = SanitizedUnicode()
+    # licenses = fields.List(fields.Nested(LicenseSchema))
+    # descriptions = fields.List(fields.Nested(DescriptionSchema))
+    # locations = fields.List(fields.Nested(LocationSchema))
+    # references = fields.List(fields.Nested(ReferenceSchema))
+    # notes = fields.List(fields.Nested(InternalNoteSchema))
 
     # TODO (Alex): this might go in a separate top-level field?
     # extensions = fields.Method('dump_extensions', 'load_extensions')

--- a/invenio_rdm_records/services/schemas/pids.py
+++ b/invenio_rdm_records/services/schemas/pids.py
@@ -14,10 +14,9 @@ from marshmallow import INCLUDE, Schema, fields, validate
 #
 # PIDs
 #
-# TODO (Alex): See how this will be managed
-class PIDSSchemaV1(Schema):
+class PIDSchema(Schema):
     """PIDs schema."""
 
-    doi = fields.Str()
-    concept_doi = fields.Str()
-    oai = fields.Str()
+    identifier = fields.Str(required=True)
+    provider = fields.Str(required=True)
+    client = fields.Str()

--- a/invenio_rdm_records/services/schemas/relations.py
+++ b/invenio_rdm_records/services/schemas/relations.py
@@ -11,7 +11,7 @@
 from marshmallow import Schema, fields
 
 
-class RelationsSchemaV1(Schema):
+class RelationsSchema(Schema):
     """Relations schema."""
 
     version = fields.Raw()

--- a/invenio_rdm_records/services/schemas/stats.py
+++ b/invenio_rdm_records/services/schemas/stats.py
@@ -11,7 +11,7 @@
 from marshmallow import Schema, fields
 
 
-class StatsSchemaV1(Schema):
+class StatsSchema(Schema):
     """Files metadata schema."""
 
     views = fields.Int()

--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -23,7 +23,7 @@ from invenio_records_resources.services.records.service import RecordService
 from ..records import BibliographicDraft, BibliographicRecord
 from .components import CommunitiesComponent, StatsComponent
 from .permissions import RDMRecordPermissionPolicy
-from .schemas import RDMRecordSchemaV1
+from .schemas import RDMRecordSchema
 
 
 class BibliographicRecordServiceConfig(RecordDraftServiceConfig):
@@ -34,7 +34,7 @@ class BibliographicRecordServiceConfig(RecordDraftServiceConfig):
     # Draft class
     draft_cls = BibliographicDraft
 
-    schema = RDMRecordSchemaV1
+    schema = RDMRecordSchema
     permission_policy_cls = RDMRecordPermissionPolicy
 
     search_facets_options = dict(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,121 +66,187 @@ def create_app():
 def full_record():
     """Full record data as dict coming from the external world."""
     return {
-        "_access": {
-            "metadata_restricted": False,
-            "files_restricted": False
+        "pids": {
+            "doi": {
+                "identifier": "10.5281/zenodo.1234",
+                "provider": "datacite",
+                "client": "zenodo"
+            },
+            "concept-doi": {
+                "identifier": "10.5281/zenodo.1234",
+                "provider": "datacite",
+                "client": "zenodo"
+            },
+            "handle": {
+                "identifier": "9.12314",
+                "provider": "cern-handle",
+                "client": "zenodo"
+            },
+            "oai": {
+                "identifier": "oai:zenodo.org:12345",
+                "provider": "zenodo"
+            }
         },
-        "_created_by": 2,  # TODO: Revisit with deposit
-        "_default_preview": "previewer one",
-        "_internal_notes": [{
-            "user": "inveniouser",
-            "note": "RDM record",
-            "timestamp": "2020-02-01"
-        }],
-        "_owners": [1],  # TODO: Revisit with deposit
-        "access_right": "open",
-        "embargo_date": "2022-12-31",
-        "contact": "info@inveniosoftware.org",
-        "resource_type": {
-            "type": "image",
-            "subtype": "image-photo"
-        },
-        "identifiers": {
-            "DOI": "10.5281/zenodo.9999999",
-            "arXiv": "9999.99999"
-        },
-        "creators": [
-            {
-                "name": "Julio Cesar",
-                "type": "Personal",
-                "given_name": "Julio",
-                "family_name": "Cesar",
+        "metadata": {
+            "resource_type": {
+                "type": "publication",
+                "subtype": "article"
+            },
+            "creators": [{
+                "name": "Nielsen, Lars Holm",
+                "type": "personal",
+                "given_name": "Lars Holm",
+                "family_name": "Nielsen",
                 "identifiers": {
-                    "Orcid": "0000-0002-1825-0097"
+                    "orcid": "0000-0001-8135-3489"
                 },
                 "affiliations": [{
-                    "name": "Entity One",
+                    "name": "CERN",
                     "identifiers": {
-                        "ror": "03yrm5c26"
+                        "ror": "01ggx4157",
+                        "isni": "000000012156142X"
                     }
                 }]
-            },
-            {
-                "name": "California Digital Library",
-                "type": "Organizational",
+            }],
+            "title": "InvenioRDM",
+            "additional_titles": [{
+                "title": "a research data management platform",
+                "type": "subtitle",
+                "lang": "eng"
+            }],
+            "publisher": "InvenioRDM",
+            "publication_date": "2018/2020-09",
+            "subjects": [{
+                "subject": "test",
+                "identifier": "test",
+                "scheme": "dewey"
+            }],
+            "contributors": [{
+                "name": "Nielsen, Lars Holm",
+                "type": "personal",
+                "role": "other",
+                "given_name": "Lars Holm",
+                "family_name": "Nielsen",
                 "identifiers": {
-                    "ror": "03yrm5c26",
-                }
-            }
-        ],
-        "titles": [{
-            "title": "A Romans story",
-            "type": "Other",
-            "lang": "eng"
-        }],
-        "publication_date": "2020-06-01",
-        "subjects": [{
-            "subject": "Romans",
-            "identifier": "subj-1",
-            "scheme": "no-scheme"
-        }],
-        "contributors": [{
-            "name": "Maximo Decimo Meridio",
-            "type": "Personal",
-            "given_name": "Maximo",
-            "family_name": "Decimo Meridio",
-            "identifiers": {
-                "Orcid": "0000-0002-1825-0097",
-            },
-            "affiliations": [{
-                "name": "Entity One",
-                "identifiers": {
-                    "ror": "03yrm5c26"
+                    "orcid": "0000-0001-8135-3489"
+                },
+                "affiliations": [{
+                    "name": "CERN",
+                    "identifiers": {
+                        "ror": "01ggx4157",
+                        "isni": "000000012156142X"
+                    }
+                }]
+            }],
+            "dates": [{
+                "date": "1939/1945",
+                "type": "other",
+                "description": "A date"
+            }],
+            "languages": ["da", "en"],
+            "identifiers": [{
+                "identifier": "1924MNRAS..84..308E",
+                "scheme": "bibcode"
+            }],
+            "related_identifiers": [{
+                "identifier": "10.1234/foo.bar",
+                "scheme": "doi",
+                "relation": "cites",
+                "resource_type": {"type": "dataset"}
+            }],
+            "sizes": [
+                "11 pages"
+            ],
+            "formats": [
+                "application/pdf"
+            ],
+            "version": "v1.0",
+            "rights": [{
+                "rights": "Creative Commons Attribution 4.0 International",
+                "scheme": "spdx",
+                "identifier": "cc-by-4.0",
+                "url": "https://creativecommons.org/licenses/by/4.0/"
+            }],
+            "description": "Test",
+            "additional_descriptions": [{
+                "description": "Bla bla bla",
+                "type": "methods",
+                "lang": "eng"
+            }],
+            "locations": [{
+                "point": {
+                    "lat": 1,
+                    "lon": 2
+                },
+                "place": "home",
+                "description": "test"
+            }],
+            "funding": [{
+                "funder": {
+                    "name": "European Commission",
+                    "identifier": "1234",
+                    "scheme": "ror"
+                },
+                "award": {
+                    "title": "OpenAIRE",
+                    "number": "246686",
+                    "identifier": ".../246686",
+                    "scheme": "openaire"
                 }
             }],
-            "role": "RightsHolder"
-        }],
-        "dates": [{
-            "start": "2020-06-01",
-            "end":  "2021-06-01",
-            "description": "Random test date",
-            "type": "Other"
-        }],
-        "language": "eng",
-        "related_identifiers": [{
-            "identifier": "10.5281/zenodo.9999988",
-            "scheme": "DOI",
-            "relation_type": "Requires",
-            "resource_type": {
-                "type": "image",
-                "subtype": "image-photo"
+            "references": [{
+                "reference": "Nielsen et al,..",
+                "identifier": "101.234",
+                "scheme": "doi"
+            }]
+        },
+        "ext": {
+            "dwc": {
+                "collectionCode": "abc",
+                "collectionCode2": 1.1,
+                "collectionCode3": True,
+                "test": ["abc", 1, True]
             }
-        }],
-        "version": "v0.0.1",
-        "licenses": [{
-            "license": "Berkeley Software Distribution 3",
-            "uri": "https://opensource.org/licenses/BSD-3-Clause",
-            "identifier": "BSD-3",
-            "scheme": "BSD-3",
-        }],
-        "descriptions": [{
-            "description": "A story on how Julio Cesar relates to Gladiator.",
-            "type": "Abstract",
-            "lang": "eng"
-        }],
-        "locations": [{
-            "point": {
-                "lat": 41.902604,
-                "lon": 12.496189
+        },
+        "provenance": {
+            "created_by": {
+                "user": 1
             },
-            "place": "Rome",
-            "description": "Rome, from Romans"
-        }],
-        "references": [{
-            "reference_string": "Reference to something et al.",
-            "identifier": "9999.99988",
-            "scheme": "GRID"
-        }]
+            "on_behalf_of": {
+                "user": 2
+            }
+        },
+        "access": {
+            "metadata": True,
+            "files": False,
+            "owned_by": [{
+                "user": 1
+            }],
+            "embargo_date": "2021-01-01T00:00:00+0000",
+            "access_condition": {
+                "condition": "Medical doctors.",
+                "default_link_validity": 30
+            }
+        },
+        "files": {
+            "disabled": False,
+            "total_size": 1114324524355,
+            "count": 1,
+            "bucket": "81983514-22e5-473a-b521-24254bd5e049",
+            "files": [{
+                "checksum": "md5:234245234213421342",
+                "size": 1114324524355,
+                "key": "big-dataset.zip",
+                "ext": "zip",
+                "description": "File containing the data.",
+                "order": "1",
+                "default_preview": True,
+                "identifier": "445aaacd-9de1-41ab-af52-25ab6cb93df7"
+            }]
+        },
+        "notes": [
+            "Under investigation for copyright infringement."
+        ]
     }
 
 
@@ -189,11 +255,10 @@ def minimal_record():
     """Minimal record data as dict coming from the external world."""
     return {
         "access": {
-            "metadata_restricted": False,
-            "files_restricted": False,
-            "owners": [1],
-            "access_right": "open",
-            "created_by": 1,
+            "metadata": False,
+            "files": False,
+            "owned_by": [1],
+            "access_right": "open"
         },
         "metadata": {
             "publication_date": "2020-06-01",
@@ -206,10 +271,6 @@ def minimal_record():
                 "name": "John Doe",
                 "type": "Personal"
             }],
-            "titles": [{
-                "title": "A Romans story",
-                "type": "Other",
-                "lang": "eng"
-            }]
+            "title": "A Romans story"
         }
     }

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -4,14 +4,10 @@
   "conceptid": "12345-abcde",
   "pid": {
     "pk": 1,
-    "pid_type": "recid",
-    "obj_type": "rec",
     "status": "R"
   },
   "conceptpid": {
     "pk": 2,
-    "pid_type": "recid",
-    "obj_type": "rec",
     "status": "R"
   },
   "pids": {
@@ -60,7 +56,7 @@
     "additional_titles": [{
       "title": "a research data management platform",
       "type": "subtitle",
-      "lang": "en"
+      "lang": "eng"
     }],
     "publisher": "InvenioRDM",
     "publication_date": "2018/2020-09",
@@ -91,7 +87,7 @@
       "type": "other",
       "description": "A date"
     }],
-    "languages": ["da", "en"],
+    "languages": ["dan", "eng"],
     "identifiers": [{
       "identifier": "1924MNRAS..84..308E",
       "scheme": "bibcode"
@@ -119,7 +115,7 @@
     "additional_descriptions": [{
       "description": "Bla bla bla",
       "type": "methods",
-      "lang": "en"
+      "lang": "eng"
     }],
     "locations": [{
       "point": {
@@ -143,16 +139,18 @@
       }
     }],
     "references": [{
-      "reference_string": "Nielsen et al,..",
+      "reference": "Nielsen et al,..",
       "identifier": "101.234",
       "scheme": "doi"
     }]
   },
-  "metaext": {
-    "dwc:collectionCode": "abc",
-    "dwc:collectionCode2": 1.1,
-    "dwc:collectionCode3": true,
-    "dwc:test": ["abc", 1, true]
+  "ext": {
+    "dwc": {
+      "collectionCode": "abc",
+      "collectionCode2": 1.1,
+      "collectionCode3": true,
+      "test": ["abc", 1, true]
+    }
   },
   "provenance": {
     "created_by": {
@@ -165,7 +163,6 @@
   "access": {
     "metadata": true,
     "files": false,
-    "contact": true,
     "owned_by": [{
       "user": 1
     }],
@@ -191,13 +188,8 @@
       "file_id": "445aaacd-9de1-41ab-af52-25ab6cb93df7"
     }]
   },
-  "system": {
-    "notes": [{
-      "note": "Under investigation for copyright infringement.",
-      "created_by": {
-        "user": 1
-      },
-      "timestamp": "2020-01-01T00:00:00+0000"
-    }]
-  }
+
+  "notes": [
+    "Under investigation for copyright infringement."
+  ]
 }

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -128,8 +128,6 @@ def test_pid_conceptpid(appctx, prop):
     """Test pid/conceptpid."""
     pid = {
         "pk": 1,
-        "pid_type": "recid",
-        "obj_type": "rec",
         "status": "R",
     }
     assert validates({prop: pid})
@@ -151,19 +149,27 @@ def test_pid_conceptpid(appctx, prop):
 def test_pids(appctx):
     """Test external pids."""
     assert validates({"pids": {
-        "doi": {"id": "10.12345", "provider": "datacite", "client": "test"}
+        "doi": {
+            "identifier": "10.12345", "provider": "datacite", "client": "test"
+        }
     }})
     assert validates({"pids": {
-        "doi": {"id": "10.12345", "provider": "datacite", "client": "test"},
-        "oai": {"id": "oai:10.12345", "provider": "local"},
+        "doi": {
+            "identifier": "10.12345", "provider": "datacite", "client": "test"
+        },
+        "oai": {"identifier": "oai:10.12345", "provider": "local"},
     }})
     # Extra property
     assert fails({"pids": {
-        "oai": {"id": "oai:10.12345", "provider": "local", "invalid": "test"}
+        "oai": {
+            "identifier": "oai:10.12345",
+            "provider": "local",
+            "invalid": "test"
+        }
     }})
     # Not a string
     assert fails({"pids": {
-        "oai": {"id": 1, "provider": "local"}
+        "oai": {"identifier": 1, "provider": "local"}
     }})
 
 
@@ -215,7 +221,7 @@ def test_additional_titles(appctx):
         {"title": "Test"}
     ]})
     assert validates_meta({"additional_titles": [
-        {"title": "Test", "type": "subtitle", "lang": "da"},
+        {"title": "Test", "type": "subtitle", "lang": "dan"},
     ]})
 
     assert fails_meta({"additional_titles": [
@@ -286,8 +292,9 @@ def test_dates(appctx):
 
 def test_languages(appctx):
     """Test language property."""
-    assert validates_meta({"languages": ["da", "en"]})
-    assert fails_meta({"languages": "da"})
+    assert validates_meta({"languages": ["dan", "eng"]})
+    assert fails_meta({"languages": ["da"]})
+    assert fails_meta({"languages": "dan"})
     assert fails_meta({"languages": ["invalid"]})
 
 
@@ -393,7 +400,7 @@ def test_additional_descriptions(appctx):
     desc = {
         "description": "bla bla",
         "type": "other",
-        "lang": "da",
+        "lang": "dan"
     }
     assert validates_meta({"additional_descriptions": [desc]})
     desc["invalid"] = "invalid"
@@ -448,7 +455,7 @@ def test_reference(appctx):
     """Test references property."""
     assert validates_meta({"references": [
         {
-            "reference_string": "Nielsen et al,..",
+            "reference": "Nielsen et al,..",
             "identifier": "101.234",
             "scheme": "doi",
         },
@@ -462,9 +469,9 @@ def test_reference(appctx):
 
 
 #
-# Test metaext
+# Test ext
 #
-def test_metaext(appctx):
+def test_ext(appctx):
     """Test references property."""
     data_types = [
         "string",
@@ -478,12 +485,7 @@ def test_metaext(appctx):
     ]
 
     for val in data_types:
-        assert validates({"metaext": {"dwc:afield": val}})
-
-    # Invalid field name
-    assert fails({"metaext": {"0dwc:afield": "test"}})
-    assert fails({"metaext": {"afield": "test"}})
-    assert fails({"metaext": {"afield": "test"}})
+        assert validates({"ext": {"dwc": {"afield": val}}})
 
 
 #

--- a/tests/records/tombstone.json
+++ b/tests/records/tombstone.json
@@ -4,34 +4,30 @@
   "conceptid": "12345-abcde",
   "pid": {
     "pk": 1,
-    "pid_type": "recid",
-    "obj_type": "rec",
     "status": "R"
   },
   "conceptpid": {
     "pk": 2,
-    "pid_type": "recid",
-    "obj_type": "rec",
     "status": "R"
   },
   "pids": {
     "doi": {
-      "id": "10.5281/zenodo.1234",
+      "identifier": "10.5281/zenodo.1234",
       "provider": "datacite",
       "client": "zenodo"
     },
     "concept-doi": {
-      "id": "10.5281/zenodo.1234",
+      "identifier": "10.5281/zenodo.1234",
       "provider": "datacite",
       "client": "zenodo"
     },
     "handle": {
-      "id": "9.12314",
+      "identifier": "9.12314",
       "provider": "cern-handle",
       "client": "zenodo"
     },
     "oai": {
-      "id": "oai:zenodo.org:12345",
+      "identifier": "oai:zenodo.org:12345",
       "provider": "zenodo"
     }
   },

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -60,12 +60,12 @@ def test_simple_flow(app, client, minimal_record, headers):
 
     # Update and save draft
     data = read_draft.json
-    data["metadata"]["titles"][0]["title"] = 'New title'
+    data["metadata"]["title"] = 'New title'
 
     res = client.put(
         f'/records/{id_}/draft', headers=headers, data=json.dumps(data))
     assert res.status_code == 200
-    assert res.json['metadata']['titles'][0]["title"] == 'New title'
+    assert res.json['metadata']["title"] == 'New title'
 
     # Publish it
     response = client.post(
@@ -88,7 +88,7 @@ def test_simple_flow(app, client, minimal_record, headers):
     assert res.json['hits']['hits'][0]['metadata'] == \
         created_record['metadata']
     data = res.json['hits']['hits'][0]
-    assert data['metadata']['titles'][0]['title'] == 'New title'
+    assert data['metadata']['title'] == 'New title'
 
 
 def test_create_draft(client, minimal_record, headers):
@@ -122,14 +122,14 @@ def test_update_draft(client, minimal_record, headers):
         "/records", data=json.dumps(minimal_record), headers=headers)
 
     assert response.status_code == 201
-    assert response.json['metadata']['titles'][0]["title"] == \
-        minimal_record['metadata']['titles'][0]["title"]
+    assert response.json['metadata']["title"] == \
+        minimal_record['metadata']["title"]
 
     recid = response.json['id']
 
-    orig_title = minimal_record['metadata']['titles'][0]["title"]
+    orig_title = minimal_record['metadata']["title"]
     edited_title = "Edited title"
-    minimal_record['metadata']['titles'][0]["title"] = edited_title
+    minimal_record['metadata']["title"] = edited_title
 
     # Update draft content
     update_response = client.put(
@@ -139,7 +139,7 @@ def test_update_draft(client, minimal_record, headers):
     )
 
     assert update_response.status_code == 200
-    assert update_response.json["metadata"]['titles'][0]["title"] == \
+    assert update_response.json["metadata"]["title"] == \
         edited_title
     assert update_response.json["id"] == recid
 
@@ -148,7 +148,7 @@ def test_update_draft(client, minimal_record, headers):
         "/records/{}/draft".format(recid), headers=headers)
 
     assert update_response.status_code == 200
-    assert update_response.json["metadata"]['titles'][0]["title"] == \
+    assert update_response.json["metadata"]["title"] == \
         edited_title
     assert update_response.json["id"] == recid
 
@@ -228,8 +228,8 @@ def test_create_publish_new_revision(client, minimal_record,
     # time.sleep(70)
 
     # Create new draft of said record
-    orig_title = minimal_record["metadata"]["titles"][0]["title"]
-    minimal_record["metadata"]["titles"][0]["title"] = "Edited title"
+    orig_title = minimal_record["metadata"]["title"]
+    minimal_record["metadata"]["title"] = "Edited title"
     response = client.post(
         "/records/{}/draft".format(recid),
         headers=headers
@@ -254,7 +254,7 @@ def test_create_publish_new_revision(client, minimal_record,
 
     assert response.status_code == 200
     _assert_single_item_response(response)
-    assert response.json['metadata']['titles'][0]["title"] == orig_title
+    assert response.json['metadata']["title"] == orig_title
 
     # Publish it to check the increment in reversion
     response = client.post(
@@ -265,15 +265,15 @@ def test_create_publish_new_revision(client, minimal_record,
 
     assert response.json['id'] == recid
     assert response.json['revision_id'] == 2
-    assert response.json['metadata']["titles"][0]["title"] == \
-        minimal_record["metadata"]["titles"][0]["title"]
+    assert response.json['metadata']["title"] == \
+        minimal_record["metadata"]["title"]
 
     # Check it was actually edited
     response = client.get(
         "/records/{}".format(recid), headers=headers)
 
-    assert response.json["metadata"]["titles"][0]["title"] == \
-        minimal_record["metadata"]["titles"][0]["title"]
+    assert response.json["metadata"]["title"] == \
+        minimal_record["metadata"]["title"]
 
 
 def test_ui_data_in_record(

--- a/tests/services/test_schemas/test_access.py
+++ b/tests/services/test_schemas/test_access.py
@@ -10,36 +10,38 @@
 
 import pytest
 from flask_babelex import lazy_gettext as _
+from marshmallow.exceptions import ValidationError
 
-from invenio_rdm_records.services.schemas.access import AccessSchemaV1
+from invenio_rdm_records.services.schemas.access import AccessSchema
 
 from .test_utils import assert_raises_messages
 
 
 def test_valid_full(vocabulary_clear):
     valid_full = {
-        "metadata_restricted": False,
-        "files_restricted": False,
-        "owners": [1],
-        "created_by": 1,
+        "metadata": False,
+        "files": False,
+        "owned_by": [1],
         "embargo_date": "2120-10-06",
-        "contact": "foo@example.com",
-        "access_right": "open"
+        "access_right": "open",
+        "access_condition": {
+            "condition": "because it is needed",
+            "default_link_validity": 30
+        }
     }
-    assert valid_full == AccessSchemaV1().load(valid_full)
+    assert valid_full == AccessSchema().load(valid_full)
 
 
 def test_invalid_access_right(vocabulary_clear):
     invalid_access_right = {
-        "metadata_restricted": False,
-        "files_restricted": False,
-        "owners": [1],
-        "created_by": 1,
+        "metadata": False,
+        "files": False,
+        "owned_by": [1],
         "access_right": "invalid value"
     }
 
     assert_raises_messages(
-        lambda: AccessSchemaV1().load(invalid_access_right),
+        lambda: AccessSchema().load(invalid_access_right),
         {
             "access_right": [_(
                 "Invalid value. Choose one of ['closed', 'embargoed', "
@@ -49,8 +51,17 @@ def test_invalid_access_right(vocabulary_clear):
     )
 
 
-# TODO: Implement
-# Tests not implemented in the interest of time
-@pytest.mark.skip()
-def test_invalid_empty_owners(vocabulary_clear):
-    assert False
+@pytest.mark.parametrize("invalid_access,missing_attr", [
+    ({"metadata": False, "files": False, "access_right": "open"}, "owned_by"),
+    ({"metadata": False, "files": False, "owned_by": [1]}, "access_right"),
+    ({"metadata": False, "owned_by": [1], "access_right": "open"}, "files"),
+    ({"files": False, "owned_by": [1], "access_right": "open"}, "metadata")
+])
+def test_invalid(invalid_access, missing_attr):
+
+    with pytest.raises(ValidationError) as e:
+        AccessSchema().load(invalid_access)
+
+        error_fields = e.value.messages.keys()
+        assert len(error_fields) == 1
+        assert missing_attr in error_fields

--- a/tests/services/test_schemas/test_creators_contributors.py
+++ b/tests/services/test_schemas/test_creators_contributors.py
@@ -13,8 +13,8 @@ import os
 import pytest
 from flask_babelex import lazy_gettext as _
 
-from invenio_rdm_records.services.schemas.metadata import \
-    ContributorSchemaV1, CreatorSchemaV1
+from invenio_rdm_records.services.schemas.metadata import ContributorSchema, \
+    CreatorSchema
 
 from .test_utils import assert_raises_messages
 
@@ -24,7 +24,7 @@ def test_creator_valid_minimal():
         "name": "Julio Cesar",
         "type": "Personal"
     }
-    assert valid_minimal == CreatorSchemaV1().load(valid_minimal)
+    assert valid_minimal == CreatorSchema().load(valid_minimal)
 
 
 def test_creator_valid_full_person():
@@ -43,7 +43,7 @@ def test_creator_valid_full_person():
             }
         }]
     }
-    data = CreatorSchemaV1().load(valid_full_person)
+    data = CreatorSchema().load(valid_full_person)
     assert data == valid_full_person
 
 
@@ -58,7 +58,7 @@ def test_creator_valid_full_organization():
         # "given_name", "family_name" and "affiliations" are ignored if passed
         "family_name": "I am ignored!"
     }
-    data = CreatorSchemaV1().load(valid_full_org)
+    data = CreatorSchema().load(valid_full_org)
     assert data == valid_full_org
 
 
@@ -79,7 +79,7 @@ def test_creator_invalid_no_name():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_no_name),
+        lambda: CreatorSchema().load(invalid_no_name),
         {'name': ['Missing data for required field.']}
     )
 
@@ -90,7 +90,7 @@ def test_creator_invalid_no_type():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_no_type),
+        lambda: CreatorSchema().load(invalid_no_type),
         {'type': ['Missing data for required field.']}
     )
 
@@ -102,7 +102,7 @@ def test_creator_invalid_type():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_type),
+        lambda: CreatorSchema().load(invalid_type),
         {'type': [
             "Invalid value. Choose one of ['Organizational', 'Personal']."
         ]}
@@ -119,7 +119,7 @@ def test_creator_invalid_identifiers_scheme():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_scheme),
+        lambda: CreatorSchema().load(invalid_scheme),
         {'identifiers': ["Invalid value. Choose one of ['Orcid', 'ror']."]}
     )
 
@@ -135,7 +135,7 @@ def test_creator_invalid_identifiers_orcid():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_orcid_identifier),
+        lambda: CreatorSchema().load(invalid_orcid_identifier),
         {'identifiers': {'Orcid': ["Invalid value."]}}
     )
 
@@ -150,7 +150,7 @@ def test_creator_invalid_identifiers_ror():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_ror_identifier),
+        lambda: CreatorSchema().load(invalid_ror_identifier),
         {'identifiers': {'ror': ["Invalid value."]}}
     )
 
@@ -165,7 +165,7 @@ def test_creator_invalid_identifiers_for_person():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_identifier_for_person),
+        lambda: CreatorSchema().load(invalid_identifier_for_person),
         {'identifiers': ["Invalid value. Choose one of ['Orcid']."]}
     )
 
@@ -180,7 +180,7 @@ def test_creator_invalid_identifiers_for_org():
     }
 
     assert_raises_messages(
-        lambda: CreatorSchemaV1().load(invalid_identifier_for_org),
+        lambda: CreatorSchema().load(invalid_identifier_for_org),
         {'identifiers': ["Invalid value. Choose one of ['ror']."]}
     )
 
@@ -202,7 +202,7 @@ def test_contributor_valid_full(vocabulary_clear):
         }],
         "role": "RightsHolder"
     }
-    assert valid_full == ContributorSchemaV1().load(valid_full)
+    assert valid_full == ContributorSchema().load(valid_full)
 
 
 def test_contributor_valid_minimal(vocabulary_clear):
@@ -211,7 +211,7 @@ def test_contributor_valid_minimal(vocabulary_clear):
         "type": "Personal",
         "role": "RightsHolder"
     }
-    assert valid_minimal == ContributorSchemaV1().load(valid_minimal)
+    assert valid_minimal == ContributorSchema().load(valid_minimal)
 
 
 def test_contributor_invalid_no_name(vocabulary_clear):
@@ -226,7 +226,7 @@ def test_contributor_invalid_no_name(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ContributorSchemaV1().load(invalid_no_name),
+        lambda: ContributorSchema().load(invalid_no_name),
         {'name': ['Missing data for required field.']}
     )
 
@@ -243,7 +243,7 @@ def test_contributor_invalid_no_role(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ContributorSchemaV1().load(invalid_no_role),
+        lambda: ContributorSchema().load(invalid_no_role),
         {'role': ['Missing data for required field.']}
     )
 
@@ -281,7 +281,7 @@ def test_contributor_invalid_role(custom_config, vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ContributorSchemaV1().load(invalid_role),
+        lambda: ContributorSchema().load(invalid_role),
         {'role': [
             "Invalid value. Choose one of ['DataCollector', 'Librarian']."
         ]}

--- a/tests/services/test_schemas/test_resource_type.py
+++ b/tests/services/test_schemas/test_resource_type.py
@@ -14,7 +14,7 @@ import pytest
 from flask_babelex import lazy_gettext as _
 from marshmallow import ValidationError
 
-from invenio_rdm_records.services.schemas.metadata import ResourceTypeSchemaV1
+from invenio_rdm_records.services.schemas.metadata import ResourceTypeSchema
 
 from .test_utils import assert_raises_messages
 
@@ -24,14 +24,14 @@ def test_valid_full(vocabulary_clear):
         "type": "image",
         "subtype": "image-photo"
     }
-    assert valid_full == ResourceTypeSchemaV1().load(valid_full)
+    assert valid_full == ResourceTypeSchema().load(valid_full)
 
 
 def test_valid_no_subtype(vocabulary_clear):
     valid_no_subtype = {
         "type": "poster"
     }
-    assert valid_no_subtype == ResourceTypeSchemaV1().load(valid_no_subtype)
+    assert valid_no_subtype == ResourceTypeSchema().load(valid_no_subtype)
 
 
 def test_invalid_no_type(vocabulary_clear):
@@ -40,7 +40,7 @@ def test_invalid_no_type(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ResourceTypeSchemaV1().load(invalid_no_type),
+        lambda: ResourceTypeSchema().load(invalid_no_type),
         {"type": ["Missing data for required field."]}
     )
 
@@ -72,7 +72,7 @@ def test_invalid_type(custom_config, vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ResourceTypeSchemaV1().load(invalid_type),
+        lambda: ResourceTypeSchema().load(invalid_type),
         {
             "type": [_(
                 "Invalid value. Choose one of ['my_image', 'publication', "
@@ -88,7 +88,7 @@ def test_invalid_no_subtype_when_required(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ResourceTypeSchemaV1().load(invalid_no_subtype_when_required),
+        lambda: ResourceTypeSchema().load(invalid_no_subtype_when_required),
         {
             "subtype": [_(
                 "Invalid value. Choose one of ['image-diagram', "
@@ -106,7 +106,7 @@ def test_invalid_subtype(custom_config, vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ResourceTypeSchemaV1().load(invalid_subtype),
+        lambda: ResourceTypeSchema().load(invalid_subtype),
         {
             "subtype": [_(
                 "Invalid value. Choose one of ['my_photo']."
@@ -121,7 +121,7 @@ def test_custom_valid_full(custom_config, vocabulary_clear):
         "type": "my_image",
         "subtype": "my_photo"
     }
-    data = ResourceTypeSchemaV1().load(valid_full)
+    data = ResourceTypeSchema().load(valid_full)
     assert data == valid_full
 
 
@@ -132,7 +132,7 @@ def test_custom_default_now_invalid(custom_config, vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: ResourceTypeSchemaV1().load(now_invalid_subtype),
+        lambda: ResourceTypeSchema().load(now_invalid_subtype),
         {
             "type": [_(
                 "Invalid value. Choose one of ['my_image', 'publication', "

--- a/tests/services/test_schemas/test_titles.py
+++ b/tests/services/test_schemas/test_titles.py
@@ -12,7 +12,7 @@ import pytest
 from flask_babelex import lazy_gettext as _
 from marshmallow import ValidationError
 
-from invenio_rdm_records.services.schemas.metadata import TitleSchemaV1
+from invenio_rdm_records.services.schemas.metadata import TitleSchema
 
 from .test_utils import assert_raises_messages
 
@@ -23,7 +23,7 @@ def test_valid_full(vocabulary_clear):
         "type": "Other",
         "lang": "eng"
     }
-    assert valid_full == TitleSchemaV1().load(valid_full)
+    assert valid_full == TitleSchema().load(valid_full)
 
 
 def test_valid_partial(vocabulary_clear):
@@ -31,15 +31,15 @@ def test_valid_partial(vocabulary_clear):
         "title": "A Romans story",
         "lang": "eng"
     }
-    data = TitleSchemaV1().load(valid_partial)
+    data = TitleSchema().load(valid_partial)
     assert dict(valid_partial, type='MainTitle') == data
 
 
 def test_valid_minimal(vocabulary_clear):
     valid_minimal = {
-        "title": "A Romans story",
+        "title": "A Romans story"
     }
-    data = TitleSchemaV1().load(valid_minimal)
+    data = TitleSchema().load(valid_minimal)
     assert data == dict(valid_minimal, type='MainTitle')
 
 
@@ -50,7 +50,7 @@ def test_invalid_no_title(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: TitleSchemaV1().load(invalid_no_title),
+        lambda: TitleSchema().load(invalid_no_title),
         {'title': ['Missing data for required field.']}
     )
 
@@ -63,7 +63,7 @@ def test_invalid_title_empty(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: TitleSchemaV1().load(invalid_title_empty),
+        lambda: TitleSchema().load(invalid_title_empty),
         {'title': ['Shorter than minimum length 3.']}
     )
 
@@ -76,7 +76,7 @@ def test_invalid_too_short(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: TitleSchemaV1().load(too_short),
+        lambda: TitleSchema().load(too_short),
         {'title': ['Shorter than minimum length 3.']}
     )
 
@@ -89,7 +89,7 @@ def test_invalid_title_type(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: TitleSchemaV1().load(invalid_title_type),
+        lambda: TitleSchema().load(invalid_title_type),
         {'type': [_(
             "Invalid value. Choose one of ['AlternativeTitle', "
             "'MainTitle', 'Other', 'Subtitle', 'TranslatedTitle']."
@@ -105,6 +105,6 @@ def test_invalid_lang(vocabulary_clear):
     }
 
     assert_raises_messages(
-        lambda: TitleSchemaV1().load(invalid_lang),
+        lambda: TitleSchema().load(invalid_lang),
         {'lang': ['Language must be a lower-cased 3-letter ISO 639-3 string.']}
     )

--- a/tests/services/test_upload_errors.py
+++ b/tests/services/test_upload_errors.py
@@ -70,7 +70,7 @@ def test_nested_field_error(client, minimal_record, es_clear):
 
 def test_multiple_errors(client, minimal_record):
     minimal_record["metadata"]["publication_date"] = ""
-    minimal_record["metadata"]["titles"] = [{
+    minimal_record["metadata"]["additional_titles"] = [{
         "title": "A Romans story",
         "type": "invalid",
         "lang": "eng"
@@ -88,7 +88,7 @@ def test_multiple_errors(client, minimal_record):
             "messages": ["Please provide a valid date or interval."]
         },
         {
-            "field": "metadata.titles.0.type",
+            "field": "metadata.additional_titles.0.type",
             "messages": [
                 "Invalid value. Choose one of ['AlternativeTitle', "
                 "'MainTitle', 'Other', 'Subtitle', 'TranslatedTitle']."


### PR DESCRIPTION
- Removed `obj_type` and `pid_type` from internal-pid
- `file.file_id` --> `file.id` or even `file.identifier` (we have a definition for it)
- Use `identifier` definition for all identifiers occurences. Did the same for `scheme`.
- Removed `contact` from `provenance` and `access` until send message feature is implemented
- Made `notes` into a simple string on top level

**Open questions**
- In the JSONSchema states languages are ISO 639-**3**, however it is tested with strings of length 2 (it should fail, by definition this ISO has length 3). Should we allow both IS 639-2 and 3 or change tests?
- What about removing `title` from the type:

```diff
    "titleType": {
      "description": "Type of title.",
      "type": "string",
      "enum": [
-         "alternative_title",
+         "alternative",
          "subtitle",
-         "translated_title",
+         "translated",
          "other"
      ]
    },
```
- `resource_type` vs `type`
