### PR TITLE
schema: add locations

### DIFF
--- a/invenio_rdm_records/cli.py
+++ b/invenio_rdm_records/cli.py
@@ -176,6 +176,30 @@ def create_fake_record():
                     "scheme": "openaire"
                 }
             }],
+            "locations": [{
+                'geometry': {
+                    'type': 'Point',
+                    'coordinates': [
+                        float(fake.latitude()), float(fake.longitude())
+                    ]
+                },
+                "place": fake.location_on_land()[2],
+                "description": "Random place on land...",
+                'identifiers': {
+                    'wikidata': '12345abcde',
+                    'geonames': '12345abcde'
+                }
+            }, {
+                'geometry': {
+                    'type': 'MultiPoint',
+                    'coordinates': [
+                        [float(fake.latitude()), float(fake.longitude())],
+                        [float(fake.latitude()), float(fake.longitude())]
+                    ]
+                },
+                "place": fake.location_on_land()[2],
+            }
+            ],
             "references": [{
                 "reference": "Reference to something et al.",
                 "identifier": "9999.99988",

--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -471,14 +471,18 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "point": {
+              "geometry": {
                 "type": "object",
-                "additionalProperties": false,
                 "properties": {
-                  "lat": {"$ref": "#/definitions/latitude"},
-                  "lon": {"$ref": "#/definitions/longitude"}
+                  "type": {
+                    "type": "string"
+                  },
+                  "coordinates": {
+                    "type": "array"
+                  }
                 }
               },
+              "identifiers": {"$ref": "#/definitions/identifiers"},
               "place": {
                 "description": "Place of the location",
                 "type": "string"

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
@@ -177,21 +177,24 @@
             },
             "locations" : {
               "properties" : {
-                "description" : {
-                  "type" : "text"
+                "geometry": {
+                  "properties" : {
+                    "type" : {
+                      "type" : "keyword"
+                    },
+                    "coordinates" : {
+                      "type" : "float"
+                    }
+                  }
                 },
                 "place" : {
                   "type" : "text"
                 },
-                "point" : {
-                  "properties" : {
-                    "lat" : {
-                      "type" : "double"
-                    },
-                    "lon" : {
-                      "type" : "double"
-                    }
-                  }
+                "identifiers" : {
+                  "type" : "object"
+                },
+                "description" : {
+                  "type" : "text"
                 }
               }
             },

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
@@ -177,21 +177,24 @@
             },
             "locations" : {
               "properties" : {
-                "description" : {
-                  "type" : "text"
+                "geometry": {
+                  "properties" : {
+                    "type" : {
+                      "type" : "keyword"
+                    },
+                    "coordinates" : {
+                      "type" : "float"
+                    }
+                  }
                 },
                 "place" : {
                   "type" : "text"
                 },
-                "point" : {
-                  "properties" : {
-                    "lat" : {
-                      "type" : "double"
-                    },
-                    "lon" : {
-                      "type" : "double"
-                    }
-                  }
+                "identifiers" : {
+                  "type" : "object"
+                },
+                "description" : {
+                  "type" : "text"
                 }
               }
             },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
@@ -176,21 +176,24 @@
           },
           "locations" : {
             "properties" : {
-              "description" : {
-                "type" : "text"
+              "geometry": {
+                "properties": {
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "coordinates": {
+                    "type": "float"
+                  }
+                }
               },
               "place" : {
                 "type" : "text"
               },
-              "point" : {
-                "properties" : {
-                  "lat" : {
-                    "type" : "double"
-                  },
-                  "lon" : {
-                    "type" : "double"
-                  }
-                }
+              "identifiers" : {
+                "type" : "object"
+              },
+              "description" : {
+                "type" : "text"
               }
             }
           },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
@@ -176,21 +176,24 @@
           },
           "locations" : {
             "properties" : {
-              "description" : {
-                "type" : "text"
+              "geometry": {
+                "properties": {
+                  "type": {
+                    "type": "keyword"
+                  },
+                  "coordinates": {
+                    "type": "float"
+                  }
+                }
               },
               "place" : {
                 "type" : "text"
               },
-              "point" : {
-                "properties" : {
-                  "lat" : {
-                    "type" : "double"
-                  },
-                  "lon" : {
-                    "type" : "double"
-                  }
-                }
+              "identifiers" : {
+                "type" : "object"
+              },
+              "description" : {
+                "type" : "text"
               }
             }
           },

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.23.4'
+__version__ = '0.23.5'

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -118,12 +118,16 @@
       "lang": "eng"
     }],
     "locations": [{
-      "point": {
-        "lat": 1,
-        "lon": 2
+      "geometry": {
+        "type": "Point",
+        "coordinates": [6.05, 46.23333]
       },
-      "place": "home",
-      "description": "test"
+      "identifiers": {
+        "geonames": "2661235",
+        "tgn": "http://vocab.getty.edu/tgn/8703679"
+      },
+      "place": "CERN",
+      "description": "Invenio birth place."
     }],
     "funding": [{
       "funder": {

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -408,23 +408,39 @@ def test_additional_descriptions(appctx):
 
 
 def test_locations(appctx):
-    """Test locations property."""
-    p = {"lat": 1, "lon": 1}
-    assert validates_meta({"locations": [
-        {"point": p, "place": "home", "description": "cozy place"}
-    ]})
+    """Test locations property.
+
+    Note: point bounds (i.e. +-90) are checked at Marshmallow schema level.
+    """
+    assert validates_meta({"locations": [{
+        "geometry": {"type": "Point", "coordinates": [6.05, 46.23333]},
+    }]})
+    assert validates_meta({"locations": [{
+        "identifiers": {
+            "geonames": "2661235",
+            "tgn": "http://vocab.getty.edu/tgn/8703679"
+        },
+    }]})
+    assert validates_meta({"locations": [{
+        "place": "CERN"
+    }]})
+    assert validates_meta({"locations": [{
+        "description": "Invenio birth place."
+    }]})
+    assert validates_meta({"locations": [{
+        "geometry": {"type": "Point", "coordinates": [6.05, 46.23333]},
+        "identifiers": {
+            "geonames": "2661235",
+            "tgn": "http://vocab.getty.edu/tgn/8703679"
+        },
+        "place": "CERN",
+        "description": "Invenio birth place."
+    }]})
     # Additional props
-    assert fails_meta({"locations": [{"point": p, "invalid": "home"}]})
-    p["invalid"] = 2
-    assert fails_meta({"locations": [{"point": p}]})
-    # Invalid lat/lon
-    assert fails_meta({"locations": [{"point": {"lat": -90.1, "lon": 1}}]})
-    assert fails_meta({"locations": [{"point": {"lat": 90.1, "lon": 1}}]})
-    assert fails_meta({"locations": [{"point": {"lat": 1, "lon": 180.1}}]})
-    assert fails_meta({"locations": [{"point": {"lat": 1, "lon": -180.1}}]})
-    assert validates_meta({"locations": [{"point": {"lat": 90, "lon": 180}}]})
-    assert validates_meta({
-        "locations": [{"point": {"lat": -90, "lon": -180}}]})
+    assert fails_meta({"locations": [{
+        "place": "CERN",
+        "invalid": "home"
+    }]})
 
 
 def test_funding(appctx):

--- a/tests/services/schemas/test_location.py
+++ b/tests/services/schemas/test_location.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Test location schema."""
+
+import pytest
+from marshmallow import ValidationError
+
+from invenio_rdm_records.services.schemas.metadata import LocationSchema, \
+    MetadataSchema
+
+
+@pytest.fixture(scope="function")
+def valid_full_location():
+    """Input data (as coming from the view layer)."""
+    return {
+        "geometry": {
+            "type": "Point",
+            "coordinates": [-32.94682, -60.63932]
+        },
+        "place": "test location place",
+        "identifiers": {
+            "wikidata": "12345abcde",
+            "geonames": "12345abcde",
+        },
+        "description": "test location description"
+    }
+
+
+def test_valid_full(valid_full_location):
+    assert valid_full_location == LocationSchema().load(valid_full_location)
+
+
+@pytest.mark.parametrize("valid_minimal_location", [
+    ({"geometry": {"type": "Point", "coordinates": [-32.94682, -60.63932]}}),
+    ({"description": "test location description"}),
+    ({"place": "test location place"}),
+    ({"identifiers": {"wikidata": "12345abcde", "geonames": "12345abcde"}})
+])
+def test_valid_minimal(valid_minimal_location):
+    assert valid_minimal_location == \
+        LocationSchema().load(valid_minimal_location)
+
+
+def test_invalid_geometry_type(valid_full_location):
+    valid_full_location["geometry"]["type"] = "invalid"
+
+    with pytest.raises(ValidationError):
+        data = LocationSchema().load(valid_full_location)
+
+
+def test_invalid_wrong_geometry_type(valid_full_location):
+    # type multipoint, but point coordinates
+    valid_full_location["geometry"]["type"] = "MultiPoint"
+
+    with pytest.raises(ValidationError):
+        data = LocationSchema().load(valid_full_location)
+
+
+def test_invalid_empty(valid_full_location):
+    with pytest.raises(ValidationError):
+        data = LocationSchema().load({})
+
+
+def test_valid_single_location(app, minimal_record, valid_full_location):
+    metadata = minimal_record['metadata']
+    metadata['locations'] = [valid_full_location]
+
+    assert metadata == MetadataSchema().load(metadata)
+
+
+def test_valid_multiple_locations(app, minimal_record, valid_full_location):
+    metadata = minimal_record['metadata']
+    metadata['locations'] = [valid_full_location, valid_full_location]
+
+    assert metadata == MetadataSchema().load(metadata)
+
+
+def test_invalid_no_list_location(app, minimal_record, valid_full_location):
+    metadata = minimal_record['metadata']
+    metadata['locations'] = valid_full_location
+
+    with pytest.raises(ValidationError):
+        data = MetadataSchema().load(metadata)

--- a/tests/services/test_schemas_json_load.py
+++ b/tests/services/test_schemas_json_load.py
@@ -12,65 +12,9 @@ from invenio_records_rest.schemas.fields import DateString, SanitizedUnicode
 from marshmallow import ValidationError
 from marshmallow.fields import Bool, Integer, List
 
-from invenio_rdm_records.services.schemas.metadata import LocationSchema, \
-    MetadataSchema, PointSchema
+from invenio_rdm_records.services.schemas.metadata import MetadataSchema
 from invenio_rdm_records.services.schemas.metadata_extensions import \
     MetadataExtensions
-
-
-def test_point():
-    """Test point."""
-    valid_full = {
-        "lat": 41.902604,
-        "lon": 12.496189
-    }
-
-    data = PointSchema().load(valid_full)
-    assert data == valid_full
-
-    invalid_no_lat = {
-        "lon": 12.496189
-    }
-    with pytest.raises(ValidationError):
-        data = PointSchema().load(invalid_no_lat)
-
-    invalid_no_lon = {
-        "lat": 41.902604,
-    }
-    with pytest.raises(ValidationError):
-        data = PointSchema().load(invalid_no_lon)
-
-
-def test_location():
-    """Test location schema."""
-    valid_full = {
-        "point": {
-            "lat": 41.902604,
-            "lon": 12.496189
-        },
-        "place": "Rome",
-        "description": "Rome, from Romans"
-    }
-
-    data = LocationSchema().load(valid_full)
-    assert data == valid_full
-
-    valid_minimal = {
-        "place": "Rome",
-    }
-
-    data = LocationSchema().load(valid_minimal)
-    assert data == valid_minimal
-
-    invalid_no_place = {
-        "point": {
-            "lat": 41.902604,
-            "lon": 12.496189
-        },
-        "description": "Rome, from Romans"
-    }
-    with pytest.raises(ValidationError):
-        data = LocationSchema().load(invalid_no_place)
 
 
 @pytest.mark.skip()


### PR DESCRIPTION
Requires marshmallow-utils GeoJSONSchema merge and release https://github.com/inveniosoftware/marshmallow-utils/pull/21
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/231

**Important notes**
- The ES mappings `coordinates` field inside the `geometry` is of type`float`, however it correctly stores the locations for both `point` and `multipoint`
```
"coordinates": {
    "type": "float"
}
```

indexed:
```
"locations" : [
              {
                "geometry" : {
                  "type" : "point",
                  "coordinates" : [
                    3.5480075,
                    165.577299
                  ]
                },
                "identifiers" : {
                  "wikidata" : "12345abcde",
                  "geonames" : "12345abcde"
                },
                "place" : "Naga",
                "description" : "Random place on land..."
              },
              {
                "geometry" : {
                  "type" : "multipoint",
                  "coordinates" : [
                    [
                      1.973974,
                      49.308415
                    ],
                    [
                      -9.508502,
                      -21.08845
                    ]
                  ]
                },
                "place" : "Losheim"
              }
            ],
```