### PR TITLE
[skip ci] workflows: add test action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+jobs:
+
+  check-manifest:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v2
+        - name: Setup Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.7
+        - name: Check Python manifest completeness
+          run: |
+            python -m pip install --upgrade pip setuptools py wheel
+            pip install -e .[tests]
+            ./run-tests.sh --check-manifest
+
+  docs-sphinx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install Python dependencies
+        run: |
+          pip install --upgrade pip setuptools py wheel
+          pip install -e .[postgresql,elasticsearch7,docs]
+      - name: Run Sphinx documentation with doctests
+        run: ./run-tests.sh --check-sphinx
+
+  python-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+          python-version: [3.6, 3.7, 3.8]
+          services: [release, lowest]
+          include:
+          - services: release
+            SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
+            POSTGRESQL_VERSION: POSTGRESQL_12_LATEST
+            ES_VERSION: "ES_7_LATEST"
+            REQUIREMENTS: "release"
+            REQUIREMENTS_LEVEL: "pypi"
+
+          - services: lowest
+            SQLALCHEMY_DATABASE_URI: "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
+            POSTGRESQL_VERSION: POSTGRESQL_9_LATEST
+            ES_VERSION: "ES_6_LATEST"
+            REQUIREMENTS: "lowest"
+            REQUIREMENTS_LEVEL: "min"
+    env:
+      SQLALCHEMY_DATABASE_URI: ${{matrix.SQLALCHEMY_DATABASE_URI}}
+      POSTGRESQL_VERSION: ${{matrix.POSTGRESQL_VERSION}}
+      ES_VERSION: ${{matrix.ES_VERSION}}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Generate dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools py twine wheel coveralls requirements-builder
+          requirements-builder -e all,postgresql,elasticsearch7 --level=${{matrix.REQUIREMENTS_LEVEL}} setup.py > .${{matrix.REQUIREMENTS}}-requirements.txt
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.${{matrix.REQUIREMENTS}}-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          pip install -r .${{matrix.REQUIREMENTS}}-requirements.txt
+          pip install -e .[all]
+          pip freeze
+          docker --version
+          docker-compose --version
+      - name: Run tests
+        run: |
+          ./run-tests.sh --check-pytest

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,10 +7,41 @@
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-python -m check_manifest --ignore ".travis-*" && \
-python -m sphinx.cmd.build -qnNW docs docs/_build/html && \
-docker-services-cli up es postgresql redis
-python -m pytest
-tests_exit_code=$?
-docker-services-cli down
-exit "$tests_exit_code"
+# # Quit on errors
+# set -o errexit
+
+# # Quit on unbound symbols
+# set -o nounset
+
+check_manifest () {
+    python -m check_manifest --ignore ".*-requirements.txt"
+}
+
+check_sphinx () {
+  python -m sphinx.cmd.build -qnNW docs docs/_build/html
+}
+
+check_pytest () {
+  docker-services-cli up es postgresql redis
+  python -m pytest
+  tests_exit_code=$?
+  docker-services-cli down
+  exit "$tests_exit_code"
+}
+
+
+if [ $# -eq 0 ]
+then
+  check_manifest
+  check_sphinx
+  check_pytest
+else
+  for arg in "$@"
+  do
+      case $arg in
+          --check-manifest) check_manifest;;
+          --check-sphinx) check_sphinx;;
+          --check-pytest) check_pytest;;
+      esac
+  done
+fi


### PR DESCRIPTION
This PR allows to run the tests on GH actions. It is based on:
    - [Indico](https://github.com/indico/indico/blob/master/.github/workflows/ci.yml)
    - [CERNOpenData](https://github.com/cernopendata/cernopendata-client/blob/master/.github/workflows/ci.yml)

**Changes**:
- Modified `run-test.sh` script to split manifest, docs and pytest checks (note that linting and isort are run by pytest). Changes are backwards compatible, running the script with no arguments will perform all checks as done before.

The current matrix is:
- For each python version (3.6, 3.7, 3.8) run with lowest and release.
- `release` is understood by the combination of release python dependencies and the latest supported version of each service (e.g. ES 7 and PostgreSQL 12)
- `lowest ` is understood by the combination of lowest python dependencies and the latest supported version of each service (e.g. ES 6 and PostgreSQL 9)

It looks like:

![Screenshot 2020-10-28 at 12 03 07](https://user-images.githubusercontent.com/6756943/97427965-9cc38900-1915-11eb-87ba-d67e4e4c173b.png)

Note: currently failing to pass the health check on PostgreSQL. Working on docker-services-cli to understand the issue.

**Missing**

- Test coverage. Can use a provided action (e.g. [cernopendata](https://github.com/cernopendata/cernopendata-client/blob/master/.github/workflows/ci.yml#L132) but it requires a secret to be set (can be done at organization level)
- Make it into organization template. PR needed to [inveniosoftware/.github](https://github.com/inveniosoftware/.github). More info [here](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/sharing-workflows-with-your-organization).


**Nice to have's for a future sprint** (to be made into issues)

- Make all into a single parametrized action simple action (e.g. call invenio-test-action with ES, PostgreSQL and Python version)
- Build status board.
- Report back with Discord plugin to PR creator
