### PR TITLE
schema: fix minor issues

### DIFF
--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -29,51 +29,6 @@ def _no_duplicates(value_list):
     return len(value_list) == len(set(str_list))
 
 
-class DateSchema(Schema):
-    """Schema for date intervals."""
-
-    DATE_TYPES = [
-        "accepted",
-        "available",
-        "copyrighted",
-        "collected",
-        "created",
-        "issued",
-        "submitted",
-        "updated",
-        "valid",
-        "withdrawn",
-        "other"
-    ]
-
-    start = ISODateString()
-    end = ISODateString()
-    type = fields.Str(required=True, validate=validate.OneOf(
-            choices=DATE_TYPES,
-            error=_('Invalid date type. {input} not one of {choices}.')
-        ))
-    description = fields.Str()
-
-    @validates_schema
-    def validate_dates(self, data, **kwargs):
-        """Validate that start date is before the corresponding end date."""
-        start = arrow.get(data.get('start'), 'YYYY-MM-DD').date() \
-            if data.get('start') else None
-        end = arrow.get(data.get('end'), 'YYYY-MM-DD').date() \
-            if data.get('end') else None
-
-        if not start and not end:
-            raise ValidationError(
-                _('There must be at least one date.'),
-                field_names=['dates']
-            )
-        if start and end and start > end:
-            raise ValidationError(
-                _('"start" date must be before "end" date.'),
-                field_names=['dates']
-            )
-
-
 class AffiliationSchema(Schema):
     """Affiliation of a creator/contributor."""
 

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -61,10 +61,17 @@ class CreatorSchema(Schema):
     #       current mock-up doesn't have `name` field, so there is assumed
     #       work on the front-end to fill this value.
     name = SanitizedUnicode(required=True)
-    type = SanitizedUnicode(validate=validate.OneOf(
-                choices=NAMES,
-                error=_(f'Invalid value. Choose one of {NAMES}.')
-            ))
+    type = SanitizedUnicode(
+        required=True,
+        validate=validate.OneOf(
+            choices=NAMES,
+            error=_(f'Invalid value. Choose one of {NAMES}.')
+        ),
+        error_messages={
+            # NOTE: [] needed to mirror above error message
+            "required": [_(f'Invalid value. Choose one of {NAMES}.')]
+        }
+    )
     given_name = SanitizedUnicode()
     family_name = SanitizedUnicode()
     identifiers = fields.Dict()

--- a/tests/services/schemas/test_creator_contributor.py
+++ b/tests/services/schemas/test_creator_contributor.py
@@ -84,6 +84,19 @@ def test_creator_invalid_no_name():
     )
 
 
+def test_creator_invalid_no_type():
+    invalid_no_type = {
+        "name": "Julio Cesar",
+    }
+
+    assert_raises_messages(
+        lambda: CreatorSchema().load(invalid_no_type),
+        {'type': [
+            "Invalid value. Choose one of ['organizational', 'personal']."
+        ]}
+    )
+
+
 def test_creator_invalid_type():
     invalid_type = {
         "name": "Julio Cesar",


### PR DESCRIPTION
- There were 2 DateSchema in `metadata.py`. I removed the one that according to tests is not valid anymore.
- `CreatorSchema::type` was not explicitly required which was ambiguous when it came to implementing frontend field. Also, not passing a type would cause a KeyError, because validation assumed it was present.

This is probably a symptom of the lack of CI plus the frequent merging.