### PR TITLE
dumpers: use arrow to avoid timezone bias on dates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    'arrow>=0.17.0',
     'CairoSVG>=1.0.20',
     'Faker>=2.0.3',
     'ftfy>=4.4.3,<5.0.0',
@@ -77,6 +78,7 @@ install_requires = [
     'marshmallow-utils>=0.2.2,<0.3.0',
     # until fix in invenio-previewer is released
     'nbconvert[execute]>=4.1.0,<6.0.0',
+    'pytz>=2020.4',
     # TODO: Get from invenio-base
     'six>=1.12.0'  # Needed to pass CI tests
 ]


### PR DESCRIPTION
Closes #232 

Arrow's `fromtimestamp` returns a datetime object, in contrast to the date object returned by datetime. From my perspective times are not really useful for the use cases we have now, so I kept it consistent with the previous behaviour.

> We don't support publication date following EDTF level above 0 in [marshmallow-utils](https://github.com/inveniosoftware/marshmallow-utils/blob/master/marshmallow_utils/fields/edtfdatestring.py#L60), because those levels allow for a lot more complex date scenarios. This reduces the publication dates to dates or intervals of dates.

This was discussed with @lnielsen when developing the EDTF dumper. The conclusion was that there is no need for using level 0 parser in the dumper since Marshmallow will not allow anything that is not level 0.

**How to test**:

- Change your PC timezone to Chicago ;)
