### PR TITLE
landing page: add more fields and use ui serializer

### DIFF
--- a/invenio_rdm_records/cli.py
+++ b/invenio_rdm_records/cli.py
@@ -98,11 +98,25 @@ def create_fake_record():
                         "ror": "03yrm5c26"
                     }
                 }]
-            }],
+            } for i in range(4)],
             "title": fake.company() + "'s gallery",
+            "additional_titles": [{
+                "title": "a research data management platform",
+                "type": "subtitle",
+                "lang": "eng"
+            }, {
+                "title": fake.company() + "'s gallery",
+                "type": "alternativetitle",
+                "lang": "eng"
+            }],
+            "publisher": "InvenioRDM",
             "publication_date": fake_edtf_level_0(),
             "subjects": [{
-                "subject": "Romans",
+                "subject": fake.word(),
+                "identifier": "subj-1",
+                "scheme": "no-scheme"
+            }, {
+                "subject": fake.word(),
                 "identifier": "subj-1",
                 "scheme": "no-scheme"
             }],
@@ -116,7 +130,7 @@ def create_fake_record():
                     }
                 }],
                 "role": "rightsholder"
-            }],
+            } for i in range(3)],
             "dates": [{
                 # No end date to avoid computations based on start
                 "date": fake.date(pattern='%Y-%m-%d'),
@@ -130,6 +144,12 @@ def create_fake_record():
                 "relation_type": "requires",
                 "resource_type": fake_resource_type()
             }],
+            "sizes": [
+                "11 pages"
+            ],
+            "formats": [
+                "application/pdf"
+            ],
             "version": "v0.0.1",
             "rights": [{
                 "rights": "Berkeley Software Distribution 3",
@@ -138,13 +158,23 @@ def create_fake_record():
                 "scheme": "BSD-3",
             }],
             "description": fake.text(max_nb_chars=3000),
-            "locations": [{
-                "point": {
-                    "lat": str(fake.latitude()),
-                    "lon": str(fake.longitude())
+            "additional_descriptions": [{
+                "description": fake.text(max_nb_chars=200),
+                "type": "methods",
+                "lang": "eng"
+            } for i in range(2)],
+            "funding": [{
+                "funder": {
+                    "name": "European Commission",
+                    "identifier": "1234",
+                    "scheme": "ror"
                 },
-                "place": fake.location_on_land()[2],
-                "description": "Random place on land for random coordinates..."
+                "award": {
+                    "title": "OpenAIRE",
+                    "number": "246686",
+                    "identifier": ".../246686",
+                    "scheme": "openaire"
+                }
             }],
             "references": [{
                 "reference": "Reference to something et al.",

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -75,36 +75,6 @@ RECORDS_UI_ENDPOINTS = {
     },
 }
 
-#: Allow list of contributor types.
-RECORD_CONTRIBUTOR_TYPES = [
-    dict(label='Contact person', datacite='ContactPerson'),
-    dict(label='Data collector', datacite='DataCollector'),
-    dict(label='Data curator', datacite='DataCurator'),
-    dict(label='Data manager', datacite='DataManager'),
-    dict(label='Distributor', datacite='Distributor'),
-    dict(label='Editor', datacite='Editor'),
-    dict(label='Hosting institution', datacite='HostingInstitution'),
-    dict(label='Other', datacite='Other'),
-    dict(label='Producer', datacite='Producer'),
-    dict(label='Project leader', datacite='ProjectLeader'),
-    dict(label='Project manager', datacite='ProjectManager'),
-    dict(label='Project member', datacite='ProjectMember'),
-    dict(label='Registration agency', datacite='RegistrationAgency'),
-    dict(label='Registration authority', datacite='RegistrationAuthority'),
-    dict(label='Related person', datacite='RelatedPerson'),
-    dict(label='Researcher', datacite='Researcher'),
-    dict(label='Research group', datacite='ResearchGroup'),
-    dict(label='Rights holder', datacite='RightsHolder'),
-    dict(label='Sponsor', datacite='Sponsor'),
-    dict(label='Supervisor', datacite='Supervisor'),
-    dict(label='Work package leader', datacite='WorkPackageLeader'),
-    dict(label='Other', datacite='Other')
-]
-
-RECORD_CONTRIBUTOR_TYPES_LABELS = {
-    x['datacite']: x['label'] for x in RECORD_CONTRIBUTOR_TYPES
-}
-
 """Records UI for RDM Records."""
 
 # Invenio-Formatter

--- a/invenio_rdm_records/resources/serializers.py
+++ b/invenio_rdm_records/resources/serializers.py
@@ -29,9 +29,14 @@ class UIJSONSerializer(JSONSerializer):
                 attr="metadata.publication_date",
                 obj=obj
             )
+
         if obj.get('updated'):
             obj['ui']['updated_date_l10n'] = format_date(
                     arrow.get(obj['updated']).datetime, format='long')
+
+        if obj.get('created'):
+            obj['ui']['created_date_l10n'] = format_date(
+                arrow.get(obj['created']).datetime, format='long')
 
     def _serialize_access_right(self, obj):
         """Inject ui config for `access_right` field."""
@@ -106,11 +111,15 @@ class UIJSONSerializer(JSONSerializer):
         obj.setdefault('ui', {}).update(self._serialize_access_right(obj))
         obj['ui'].update(self._serialize_resource_type(obj))
 
-    def serialize_object(self, obj, response_ctx=None, *args, **kwargs):
-        """Dump the object into a json string."""
+    def serialize_to_dict(self, obj, response_ctx=None, *args, **kwargs):
+        """Serialize the object into a dict."""
         self._serialize_obj_ui(obj)
         self._serialize_obj_dates(obj)
-        return json.dumps(obj)
+        return obj
+
+    def serialize_object(self, obj, response_ctx=None, *args, **kwargs):
+        """Dump the object into a json string."""
+        return json.dumps(self.serialize_to_dict(obj))
 
     def serialize_object_list(
             self, obj_list, response_ctx=None, *args, **kwargs):

--- a/invenio_rdm_records/theme/assets/semantic-ui/js/invenio_rdm_records/rdmrecords.js
+++ b/invenio_rdm_records/theme/assets/semantic-ui/js/invenio_rdm_records/rdmrecords.js
@@ -22,3 +22,7 @@ $(document).ready(function () {
     $("#doi-modal").modal("show");
   });
 });
+
+$("#jump-btn").on("click", function (event) {
+  document.documentElement.scrollTop = 0;
+});

--- a/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
+++ b/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
@@ -30,9 +30,9 @@
 
 .label-keyword {
     color:#777;
-    border: 1px solid#777;
+    border: 2px solid rgba(119, 119, 119, 0.56);
     border-radius: 4px;
-    padding: 2px;
+    padding: 3.5px;
 }
 
 .entities-title {
@@ -71,6 +71,10 @@ dt {
 
 dd {
     margin-inline-start: 0px;
+}
+
+.span-dd {
+    margin: 15px 0px 20px 0px;
 }
 
 .ui.rdm-sidebar {
@@ -143,6 +147,10 @@ dd {
             }
         }
         }
+    }
+
+    a.export-format {
+        margin: 3px;
     }
 }
 

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/contributors.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/contributors.html
@@ -8,6 +8,6 @@
 {%- from "invenio_rdm_records/details/list_entities.html" import list_entities %}
 
 {%- for group in metadata.contributors|groupby('role')%}
-<h4><b>{{group.grouper|contributortype_title}}(s)</b></h4>
+<h4><b>{{group.grouper | vocabulary_title('contributors.role', 'role')}}(s)</b></h4>
 {{ list_entities(group.list) }}
 {%- endfor %}

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/description.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/description.html
@@ -9,5 +9,5 @@
 
 <dt class="record-info-title"><b>{{ _('Description')}}</b></dt>
 <dd>
-  {{ metadata.get('descriptions', [{'description': 'No description'}])[0].description | safe }}
+  {{ metadata.get('description', [{'description': 'No description'}]) | safe }}
 </dd>

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/details.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/details.html
@@ -1,0 +1,29 @@
+{#
+  Copyright (C) 2020 CERN.
+  Copyright (C) 2020 Northwestern University.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+
+{%- from "invenio_rdm_records/macros/detail.html" import show_detail %}
+
+<dt class="record-info-title"><b>{{ _('Details')}}</b></dt>
+<hr class="thin-line"></hr>
+<dd>
+  {{ show_detail(_('Resource type'), metadata.resource_type.type) }}
+  {{ show_detail(_('Publication date'), record.ui.publication_date_l10n ) }}
+  {{ show_detail(_('Publisher'), metadata.publisher) }}
+  {{ show_detail(_('Additional titles'), metadata.additional_titles) }}
+  {{ show_detail(_('Additional descriptions'), metadata.additional_descriptions) }}
+  {{ show_detail(_('Dates'), metadata.dates) }}
+  {{ show_detail(_('Formats'), metadata.formats) }}
+  {{ show_detail(_('Sizes'), metadata.sizes) }}
+  {{ show_detail(_('Rights'), metadata.rights) }}
+  {{ show_detail(_('Funding'), metadata.funding) }}
+  {{ show_detail(_('Related identifiers'), metadata.related_identifiers) }}
+  {{ show_detail(_('References'), metadata.references) }}
+</dd>
+<hr class="thin-line"></hr>
+

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/keywords.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/keywords.html
@@ -7,10 +7,8 @@
 #}
 
 <dt class="record-info-title"><b>{{_('Subjects')}}</b></dt>
-<dd>
+<dd class="span-dd">
   {%- for keyword in metadata.subjects %}
-  <span class="label label-keyword">
-    {{ keyword.subject }}
-  </span>
+  <span class="label label-keyword">{{ keyword.subject }}</span>
   {%- endfor %}
 </dd>

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/list_entities.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/list_entities.html
@@ -8,23 +8,21 @@
 
 {% macro list_entities(entities) %}
   {% for entity in entities %}
-    {# TODO: Revisit when more than ORCiD accepted #}
     {%- if "orcid" in entity.identifiers %}
-      <a href="{{ entity.identifiers['orcid']|pid_url('orcid') }}">
-        <img class="inline-orcid" src="{{ url_for('static', filename='images/orcid.svg') }}" />
-      </a>
+    <a href="{{ entity.identifiers['orcid']|pid_url('orcid') }}">
+      <img class="inline-orcid" src="{{ url_for('static', filename='images/orcid.svg') }}" />
+    </a>
     {%- elif "ror" in entity.identifiers %}
-      {# TODO: Use ROR icon when they come up with one #}
-      <a href="{{ entity.identifiers['ror']|pid_url('ror') }}">
-        <i class="building outline icon"></i>
-      </a>
+    <a href="{{ entity.identifiers['ror']|pid_url('ror') }}">
+      <i class="building outline icon"></i>
+    </a>
     {# if no identifiers: distinguish btw people and organizations #}
     {%- elif entity.type == "organizational" %}
     <i class="group icon"></i>
     {%- endif %}
 
     <span class="text-muted" {% if entity.affiliations and entity.affiliations[0] %}data-toggle="tooltip"
-      title="{{entity.affiliations[0].name}}" {% endif %}>{{entity.name}}</span>
+      title="{{entity.affiliations[0].name}}" {% endif %}>{{entity.name}}{{ ", " if not loop.last }}</span>
 
   {% endfor %}
 

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/side_bar.html
@@ -114,8 +114,7 @@
           <a href="{{ url_for('invenio_records_ui.recid', pid_value=record.id) }}">{{ metadata.version }}</a>
           <small class="text-muted">{{ metadata.identifiers|doi_identifier }}</small>
         </td>
-        <td align="right"><small
-            class="text-muted">{{ metadata.publication_date|to_date|format_date(format='medium')}}</small></td>
+        <td align="right"><smallclass="text-muted">{{ record.ui.publication_date_l10n }}</small></td>
       </tr>
     </tbody>
   </table>
@@ -133,17 +132,17 @@
 <dt class="record-info-title"><b>{{ _('Export')}}</b></dt>
 <hr class="thin-line">
 </hr>
-<dd>
-  <a href="/coming-soon">BibTeX</a>
-  <a href="/coming-soon">CSL</a>
-  <a href="/coming-soon">DataCite</a>
-  <a href="/coming-soon">Dublin Core</a>
-  <a href="/coming-soon">DCAT</a>
-  <a href="/coming-soon">JSON</a>
-  <a href="/coming-soon">JSON-LD</a>
-  <a href="/coming-soon">GeoJSON</a>
-  <a href="/coming-soon">MARCXML</a>
-  <a href="/coming-soon"><i class="fa fa-external-link"></i> Mendeley</a>
+<dd class="span-dd">
+  <a class="export-format" href="/coming-soon">BibTeX</a>
+  <a class="export-format" href="/coming-soon">CSL</a>
+  <a class="export-format" href="/coming-soon">DataCite</a>
+  <a class="export-format" href="/coming-soon">Dublin Core</a>
+  <a class="export-format" href="/coming-soon">DCAT</a>
+  <a class="export-format" href="/coming-soon">JSON</a>
+  <a class="export-format" href="/coming-soon">JSON-LD</a>
+  <a class="export-format" href="/coming-soon">GeoJSON</a>
+  <a class="export-format" href="/coming-soon">MARCXML</a>
+  <a class="export-format" href="/coming-soon">Mendeley</a>
 </dd>
 
 </div>

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/macros/detail.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/macros/detail.html
@@ -1,0 +1,19 @@
+{#
+  Copyright (C) 2020 CERN.
+
+  Invenio RDM Records is free software; you can redistribute it and/or modify
+  it under the terms of the MIT License; see LICENSE file for more details.
+#}
+
+{% macro show_detail(title, value) %}
+<div class="ui relaxed grid">
+  <div class="two column row">
+    <div class="six wide column">
+      <p class="record-info-title"><b>{{ title }}</b></p>
+    </div>
+    <div class="ten wide column">
+      {{ value }}
+    </div>
+  </div>
+</div>
+{%- endmacro %}

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
@@ -14,11 +14,11 @@
 {%- endblock css %}
 
 {%- from "invenio_rdm_records/macros/files.html" import file_list_box, preview_file_box %}
+{%- from "invenio_rdm_records/macros/detail.html" import show_detail %}
 
+{%- set record = record|serialize_ui %}
 {%- set metadata = record.metadata %}
-{%- set access = record.access %}
-{# FIXME: Take it from record.ui.access_right.category #}
-{%- set access_right_category = access.access_right %}
+
 {%- block page_body %}
 <div class="ui container">
   <div class="ui padded relaxed grid">
@@ -28,23 +28,21 @@
         <div class="ui grid">
           <div class="two column row">
             <div class="left floated left aligned column">
-              <span class="ui"
-                title="Publication date">{{ metadata.publication_date|to_date|format_date(format='long') }}</span>
+              <span class="ui" title="Publication date">{{ record.ui.publication_date_l10n }}</span>
               {%- if metadata.version %}
               <span class="label record-version"> | Version {{ metadata.version }}</span>
               {% endif %}
             </div>
             <div class="right floated right aligned column">
               <span class="ui label grey">{{ metadata.resource_type | vocabulary_subtitle('resource_type') }}</span>
-              <span class="ui label access-right {{ access_right_category }}">
-                {{ access | vocabulary_title('access_right') }}
+              <span class="ui label access-right {{ record.ui.access_right.icon }}">
+                <i class="icon {{ record.ui.access_right.icon }}"></i>
+                Open Access
               </span>
             </div>
           </div>
         </div>
-
         <h1>{{ metadata.title }}</h1>
-        {# TODO: How do we want to display metadata.additional_titles ? #}
         <p>{%- include "invenio_rdm_records/details/creators.html" %}</p>
         <p>{%- include "invenio_rdm_records/details/contributors.html" %}</p>
 
@@ -63,12 +61,35 @@
         {% endif %}
 
         {# More details #}
+        {%- include "invenio_rdm_records/details/details.html" %}
+
+        <div class="ui grid">
+          <div class="two column row">
+            <div class="six wide column">
+              <p class="record-info-title"><b>Upload infromation</b></p>
+            </div>
+            <div class="ten wide column">
+              <span class="label record-version">
+                <b>Created:</b> TODO | <b>Created:</b> TODO | <b>Modified:</b> TODO
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="ui grid">
+          <div class="centered row" id="jump-btn">
+            <a style="cursor: pointer;">
+              <span class="ui button">
+                <i class="arrow alternate circle up outline icon"></i>Jump up</span>
+            </a>
+          </div>
+        </div>
 
         {%- endblock record_body %}
       </div>
       <div class="six wide column">
         {% block sidebar %}
-          {%- include "invenio_rdm_records/details/side_bar.html" %}
+        {%- include "invenio_rdm_records/details/side_bar.html" %}
         {% endblock sidebar %}
       </div>
     </div>

--- a/tests/ui/test_views.py
+++ b/tests/ui/test_views.py
@@ -13,7 +13,7 @@ import datetime
 import pytest
 
 from invenio_rdm_records.theme.views import doi_identifier, \
-    doi_locally_managed, to_date, vocabulary_title
+    doi_locally_managed, vocabulary_title
 
 
 def test_vocabulary_title(app):
@@ -28,23 +28,6 @@ def test_vocabulary_title(app):
     # Invalid key
     title = vocabulary_title({"role": "garbage"}, 'contributor_role')
     assert title == ""
-
-
-def test_to_date():
-    # Valid date_string
-    date_string = "2020-08-27"
-    date = to_date(date_string)
-    assert datetime.date(2020, 8, 27) == date
-
-    # Non-string date_string
-    with pytest.raises(AssertionError):
-        date_string = None
-        date = to_date(date_string)
-
-    # Invalid date_string
-    date_string = "garbage"
-    date = to_date(date_string)
-    assert date == "garbage"
 
 
 def test_doi_identifier():


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/244
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/243
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/305
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/365
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/364

**Changes**

- Enriches the CLI demo records
- Cleans unused config, jinja filters, etc.
- Uses as much as possible the UI serialized object
- Adds bottom *details* section

**Current status/Remaining work** (In a different PR if agreed):

1- The publication date is formated as "long" according to flask-babelext. However, it does not seem to be the same "long" format we used to get from the babel jinja filter.
2- Resource type and access labels seem to not have the exact same size
3- Fix the content of the side bar. **Maybe we should remove place holders (e.g. metrics) since we are gonna have a _release_**
4- Add spacing after Details and before Resource type
![Screenshot 2020-11-03 at 17 14 33](https://user-images.githubusercontent.com/6756943/98011681-78294e80-1df8-11eb-8c40-a925167e3c3d.png)

5- Add spacing after Details and before Resource type (Same as number 3 above)
6- Style all the content... Note that is just a print of the json objects
7- Add space before upload information
8- None of the 3 values come with the UI serilialized object (it is weird for created and updated to not be there 🤔 ). **How should vibility be calculated? Should it have the same text as the "access.title"**?
![Screenshot 2020-11-03 at 17 14 43](https://user-images.githubusercontent.com/6756943/98011685-795a7b80-1df8-11eb-83ef-008102c44966.png)


