### PR TITLE
ui: fix labels alignment and size on the landing page

### DIFF
--- a/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
+++ b/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/theme.less
@@ -42,6 +42,10 @@
     color:#777;
 }
 
+.ui.label > .icon { //Overwrite default icon
+    margin: 0rem 0.25rem 0rem 0rem;
+}
+
 .label-keyword {
     color:#777;
     border: 2px solid rgba(119, 119, 119, 0.56);
@@ -71,11 +75,11 @@
     #collapse-stats {
         margin-top: 15px;
         margin-left: 10px;
-        font-size: 12px;
+        font-size: @font-size-small;
     }
 
     .stats-data {
-        font-size: 36px;
+        font-size: @font-size-massive;
     }
 }
 

--- a/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/variables.less
+++ b/invenio_rdm_records/theme/assets/semantic-ui/less/invenio_rdm_records/variables.less
@@ -12,3 +12,4 @@
 @font-size-base: 14px;
 @font-size-small: 12px;
 @font-size-tiny: 10px;
+@font-size-massive: 36px;

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/record_landing_page.html
@@ -38,8 +38,8 @@
               {% endif %}
             </div>
             <div class="right floated right aligned column">
-              <span class="ui label grey">{{ record.ui.resource_type_short.title }}</span>
-              <span class="ui label access-right {{ record.ui.access_right.icon }}">
+              <span class="ui label small grey">{{ record.ui.resource_type_short.title }}</span>
+              <span class="ui label small access-right {{ record.ui.access_right.icon }}">
                 <i class="icon {{ record.ui.access_right.icon }}"></i>{{ record.ui.access_right.title }}</span>
             </div>
           </div>


### PR DESCRIPTION
Closes #249 

**What was the issue**
The inner `<i>` node had a bigger font-size (1rem vs 0.85rem).

**Solution**
Adding the `small` class forces the font-size.

**Extra**
Created font-sizes variables to make them easier to use across the theme files.

**Screenshots**

![Screenshot 2020-11-06 at 11 11 27](https://user-images.githubusercontent.com/6756943/98354858-9b831200-2021-11eb-97d3-6ca2a11b004b.png)


Specifically (Note that it also removes an extra margin that existed between the lock and the "open access" text)
![Screenshot 2020-11-06 at 11 11 34](https://user-images.githubusercontent.com/6756943/98354869-a047c600-2021-11eb-959b-21c9e8a4362f.png)

**Still bothers me**

The lock starts on the bottom, while the text seems to have a slight padding-bottom (didn't find it upon inspection). However, I was not able to fix this with CSS.