### PR TITLE
ui: fix landing page when creators have no affiliations

### DIFF
--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/creators.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/creators.html
@@ -18,10 +18,12 @@
     </a>
   </div>
 
+  {% if record.ui.creators.affiliations %}
   <div class="content">
     <div class="transition hidden">
       {{ list_affiliations(record.ui.creators.affiliations) }}
     </div>
   </div>
+  {% endif %}
 
 </div>

--- a/invenio_rdm_records/theme/templates/invenio_rdm_records/details/list_entities.html
+++ b/invenio_rdm_records/theme/templates/invenio_rdm_records/details/list_entities.html
@@ -32,8 +32,10 @@
     >
     {{ entity.name }}
     </span>
+    {% if show_affiliations and entity.affiliations %}
     <sup class="font-tiny">{% for footnote in entity.affiliations.footnotes %}{{ footnote }}{{ ", " if not loop.last }}{% endfor %}</sup>
     {{ "; " if not loop.last }}
+    {% endif %}
   {% endfor %}
 
 {%- endmacro %}


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/256

**NOTE** I was unable to reproduce the exact stacktrace of the issue (seems to be old code, since the mentioned line did not exist in the module's code base).

However, it was breaking on the footnotes. This PR fixes the issues. Still displays correctly:


No affiliations:
![Screenshot 2020-11-09 at 10 33 25](https://user-images.githubusercontent.com/6756943/98524811-f01fca80-2277-11eb-9500-8e4bff1f9655.png)

With affiliations:
![Screenshot 2020-11-09 at 10 40 21](https://user-images.githubusercontent.com/6756943/98524842-fb72f600-2277-11eb-9cd5-91dff49dd319.png)
