### PR TITLE
dumpers: add EDTFListDumperExt, change mappings

### DIFF
--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -20,7 +20,7 @@ from invenio_vocabularies.records.models import VocabularyType
 from werkzeug.local import LocalProxy
 
 from . import models
-from .dumpers import EDTFDumperExt
+from .dumpers import EDTFDumperExt, EDTFListDumperExt
 
 
 class Language(Vocabulary):
@@ -54,11 +54,13 @@ class BibliographicRecord(Record):
     model_cls = models.RecordMetadata
 
     index = IndexField(
-        'rdmrecords-records-record-v1.0.0', search_alias='rdmrecords-records')
+        "rdmrecords-records-record-v1.0.0", search_alias="rdmrecords-records"
+    )
 
     dumper = ElasticsearchDumper(
         extensions=[
             EDTFDumperExt('metadata.publication_date'),
+            EDTFListDumperExt("metadata.dates", "date"),
             RelationDumperExt('relations'),
         ])
 
@@ -91,11 +93,13 @@ class BibliographicDraft(Draft):
     model_cls = models.DraftMetadata
 
     index = IndexField(
-        'rdmrecords-drafts-draft-v1.0.0', search_alias='rdmrecords-drafts')
+        "rdmrecords-drafts-draft-v1.0.0", search_alias="rdmrecords-drafts"
+    )
 
     dumper = ElasticsearchDumper(
         extensions=[
             EDTFDumperExt('metadata.publication_date'),
+            EDTFListDumperExt("metadata.dates", "date"),
             RelationDumperExt('relations'),
         ])
 

--- a/invenio_rdm_records/records/dumpers/__init__.py
+++ b/invenio_rdm_records/records/dumpers/__init__.py
@@ -7,5 +7,5 @@
 
 """ElasticSearch dumpers, for transforming to and from versions to index."""
 
-from .edtf import EDTFDumperExt
+from .edtf import EDTFDumperExt, EDTFListDumperExt
 from .locations import LocationsDumper

--- a/invenio_rdm_records/records/dumpers/edtf.py
+++ b/invenio_rdm_records/records/dumpers/edtf.py
@@ -31,9 +31,9 @@ class EDTFDumperExt(ElasticsearchDumperExt):
     :code:`{"lte": lower_strict, "gte": upper_strict}`, whose values correspond
     to the lower strict and upper strict bounds.
     They are required for sorting.
-    In an ascending sort (most recent last), sort by publication_date_start
+    In an ascending sort (most recent last), sort by `<FIELD_NAME>_range.gte`
     to get a natural sort order. In a descending sort (most recent first),
-    sort by publication_date_end.
+    sort by `<FIELD_NAME>_range.lte`.
     """
 
     def __init__(self, field):
@@ -83,16 +83,19 @@ class EDTFListDumperExt(ElasticsearchDumperExt):
     from their EDTF fields (specified by the key).
     These values correspond to the lower strict and upper strict bounds.
     They are required for sorting.
-    In an ascending sort (most recent last), sort by publication_date_start
+    In an ascending sort (most recent last), sort by `<FIELD_NAME>_range.gte`
     to get a natural sort order. In a descending sort (most recent first),
-    sort by publication_date_end.
+    sort by `<FIELD_NAME>_range.lte`.
     """
 
     def __init__(self, list_field, key):
         """Constructor.
 
-        :param list_field: dot separated path to the array to process.
-        :param key: name of the EDTF field in each array item.
+        :param list_field: dot-separated path to the array to process.
+        :param key: name of the (scalar) EDTF field. This field has to be
+                    present in each array item. In contrast to `list_field`,
+                    this should be a simple field name (and not a
+                    dot-separated path).
         """
         super(EDTFListDumperExt, self).__init__()
         self.keys = parse_lookup_key(list_field)

--- a/invenio_rdm_records/records/dumpers/edtf.py
+++ b/invenio_rdm_records/records/dumpers/edtf.py
@@ -64,10 +64,8 @@ class EDTFDumperExt(ElasticsearchDumperExt):
         """Load the data."""
         try:
             parent_data = dict_lookup(data, self.keys, parent=True)
-
             # `None` covers the cases where exceptions were raised in _dump
-            parent_data.pop(f"{self.key}_start", None)
-            parent_data.pop(f"{self.key}_end", None)
+            parent_data.pop(self.range_key, None)
         except KeyError:
             # Drafts partially saved with no data
             # The empty {} gets removed by `clear_none`

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
@@ -48,12 +48,6 @@
                 }
               }
             },
-            "publication_date_start" : {
-              "type" : "date"
-            },
-            "publication_date_end" : {
-              "type" : "date"
-            },
             "contact" : {
               "type" : "keyword"
             },
@@ -125,6 +119,9 @@
                 },
                 "date" : {
                   "type" : "keyword"
+                },
+                "date_range" : {
+                  "type" : "date_range"
                 },
                 "type" : {
                   "type" : "keyword"
@@ -207,6 +204,9 @@
             },
             "publication_date" : {
               "type" : "keyword"
+            },
+            "publication_date_range" : {
+              "type" : "date_range"
             },
             "references" : {
               "properties" : {

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
@@ -48,12 +48,6 @@
                 }
               }
             },
-            "publication_date_start" : {
-              "type" : "date"
-            },
-            "publication_date_end" : {
-              "type" : "date"
-            },
             "contact" : {
               "type" : "keyword"
             },
@@ -125,6 +119,9 @@
                 },
                 "date" : {
                   "type" : "keyword"
+                },
+                "date_range" : {
+                  "type" : "date_range"
                 },
                 "type" : {
                   "type" : "keyword"
@@ -207,6 +204,9 @@
             },
             "publication_date" : {
               "type" : "keyword"
+            },
+            "publication_date_range" : {
+              "type" : "date_range"
             },
             "references" : {
               "properties" : {

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
@@ -47,12 +47,6 @@
               }
             }
           },
-          "publication_date_start" : {
-            "type" : "date"
-          },
-          "publication_date_end" : {
-            "type" : "date"
-          },
           "contact" : {
             "type" : "keyword"
           },
@@ -124,6 +118,9 @@
               },
               "date" : {
                 "type" : "keyword"
+              },
+              "date_range" : {
+                "type" : "date_range"
               },
               "type" : {
                 "type" : "keyword"
@@ -206,6 +203,9 @@
           },
           "publication_date" : {
             "type" : "keyword"
+          },
+          "publication_date_range" : {
+            "type" : "date_range"
           },
           "references" : {
             "properties" : {

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
@@ -47,12 +47,6 @@
               }
             }
           },
-          "publication_date_start" : {
-            "type" : "date"
-          },
-          "publication_date_end" : {
-            "type" : "date"
-          },
           "contact" : {
             "type" : "keyword"
           },
@@ -124,6 +118,9 @@
               },
               "date" : {
                 "type" : "keyword"
+              },
+              "date_range" : {
+                "type" : "date_range"
               },
               "type" : {
                 "type" : "keyword"
@@ -206,6 +203,9 @@
           },
           "publication_date" : {
             "type" : "keyword"
+          },
+          "publication_date_range" : {
+            "type" : "date_range"
           },
           "references" : {
             "properties" : {

--- a/tests/records/test_dumpers.py
+++ b/tests/records/test_dumpers.py
@@ -139,7 +139,7 @@ def test_eslistdumper_with_edtfext_parse_error(app, db, minimal_record):
     """Test edft extension implementation."""
     dumper = ElasticsearchDumper(
         extensions=[
-            EDTFListDumperExt("metadata.creators", "name"),
+            EDTFListDumperExt("metadata.creators", "family_name"),
         ]
     )
 
@@ -149,13 +149,13 @@ def test_eslistdumper_with_edtfext_parse_error(app, db, minimal_record):
 
     # Dump it
     dump = record.dumps(dumper=dumper)
-    assert "name_range" not in dump["metadata"]["creators"][0]
-    assert "name" in dump["metadata"]["creators"][0]
+    assert "family_name_range" not in dump["metadata"]["creators"][0]
+    assert "family_name" in dump["metadata"]["creators"][0]
 
     # Load it
     new_record = BibliographicRecord.loads(dump, loader=dumper)
-    assert 'name_range' not in new_record["metadata"]["creators"][0]
-    assert 'name' in new_record["metadata"]["creators"][0]
+    assert 'family_name_range' not in new_record['metadata']['creators'][0]
+    assert 'family_name' in new_record['metadata']['creators'][0]
     assert 'type_start' not in new_record['metadata']['resource_type']
     assert 'type_end' not in new_record['metadata']['resource_type']
     assert 'type' in new_record['metadata']['resource_type']

--- a/tests/records/test_dumpers.py
+++ b/tests/records/test_dumpers.py
@@ -139,7 +139,7 @@ def test_eslistdumper_with_edtfext_parse_error(app, db, minimal_record):
     """Test edft extension implementation."""
     dumper = ElasticsearchDumper(
         extensions=[
-            EDTFListDumperExt("metadata.contributors", "name"),
+            EDTFListDumperExt("metadata.creators", "name"),
         ]
     )
 
@@ -149,13 +149,13 @@ def test_eslistdumper_with_edtfext_parse_error(app, db, minimal_record):
 
     # Dump it
     dump = record.dumps(dumper=dumper)
-    assert "name_range" not in dump["metadata"]["contributors"][0]
-    assert "name" in dump["metadata"]["contributors"][0]
+    assert "name_range" not in dump["metadata"]["creators"][0]
+    assert "name" in dump["metadata"]["creators"][0]
 
     # Load it
     new_record = BibliographicRecord.loads(dump, loader=dumper)
-    assert 'name_range' not in new_record["metadata"]["contributors"][0]
-    assert 'name' in new_record["metadata"]["contributors"][0]
+    assert 'name_range' not in new_record["metadata"]["creators"][0]
+    assert 'name' in new_record["metadata"]["creators"][0]
     assert 'type_start' not in new_record['metadata']['resource_type']
     assert 'type_end' not in new_record['metadata']['resource_type']
     assert 'type' in new_record['metadata']['resource_type']


### PR DESCRIPTION
Addresses issue #223

* add EDTFListDumperExt to handle arrays of dates (e.g. 'metadata.dates') in addition to the existing EDTFDumperExt, which handles scalar values (e.g. 'metadata.publication_date')
* remove the date-type ES mappings KEY_start and KEY_end
* replace them with the date_range-type ES mapping KEY_range
* allows for simple date range queries (e.g. q=date:[1939-01-01 TO 1945-12-31])