### PR TITLE
schema and dumper: account for empty partial metadata in drafts

### DIFF
--- a/invenio_rdm_records/records/dumpers.py
+++ b/invenio_rdm_records/records/dumpers.py
@@ -54,8 +54,13 @@ class EDTFDumperExt(ElasticsearchDumperExt):
 
     def load(self, data, record_cls):
         """Load the data."""
-        parent_data = dict_lookup(data, self.keys, parent=True)
+        try:
+            parent_data = dict_lookup(data, self.keys, parent=True)
 
-        # `None` covers the cases where exceptions were raised in _dump
-        parent_data.pop(f"{self.key}_start", None)
-        parent_data.pop(f"{self.key}_end", None)
+            # `None` covers the cases where exceptions were raised in _dump
+            parent_data.pop(f"{self.key}_start", None)
+            parent_data.pop(f"{self.key}_end", None)
+        except KeyError:
+            # Drafts partially saved with no data
+            # The empty {} gets removed by `clear_none`
+            pass

--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -9,7 +9,7 @@
 """RDM record schemas."""
 
 from invenio_drafts_resources.services.records.schema import RecordSchema
-from marshmallow import EXCLUDE, INCLUDE, Schema, fields, missing
+from marshmallow import EXCLUDE, INCLUDE, Schema, fields, missing, post_dump
 
 from .access import AccessSchema
 from .files import FilesSchema
@@ -91,6 +91,20 @@ class RDMRecordSchema(RecordSchema):
     #     ExtensionSchema = current_app_metadata_extensions.to_schema()
 
     #     return ExtensionSchema().load(value)
+
+    @post_dump
+    def default_nested(self, data, many, **kwargs):
+        """Serialize metadata as empty dict for partial drafts.
+
+        Cannot use marshmallow for Nested fields due to issue:
+        https://github.com/marshmallow-code/marshmallow/issues/1566
+        https://github.com/marshmallow-code/marshmallow/issues/41
+        and more.
+        """
+        if not data.get("metadata"):
+            data["metadata"] = {}
+
+        return data
 
 
 __all__ = (

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.25.7'
+__version__ = '0.25.8'


### PR DESCRIPTION
Why?

Because the partially saved draft with no content sends `metadata: {}` which gets removed by the `clear_none` function in the `services.update_draft` method. This has two consequences:

- Gets indexed without it (therefore the dumper try except)
- Needs to be set back to `{}` in the post_dump serialization. Due to a marshmallow issue the `default` value cannot be used (it does not work when the value is `None` on `Nested` fields).