### PR TITLE
refactor contributors

### DIFF
--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -102,6 +102,16 @@
       "additionalProperties": {"$ref": "#/definitions/identifier"}
     },
 
+    "identifiers_with_scheme": {
+      "description": "Identifiers object with identifier value and scheme in separate keys.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "identifier": {"$ref": "#/definitions/identifier"},
+        "scheme": {"$ref": "#/definitions/scheme"}
+      }
+    },
+
     "internal-pid": {
       "type": "object",
       "description": "An internal persistent identifier object.",
@@ -172,7 +182,11 @@
           "additionalProperties": false,
           "properties": {
             "name": {"type": "string"},
-            "identifiers": {"$ref": "#/definitions/identifiers"}
+            "identifiers": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+              "uniqueItems": true
+            }
           },
           "required": ["name", "identifiers"]
       }
@@ -493,13 +507,25 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name"],
+            "required": ["person_or_org"],
             "properties": {
-                "name": {"type": "string"},
-                "type": {"$ref": "#/definitions/nameType"},
-                "given_name": {"type": "string"},
-                "family_name": {"type": "string"},
-                "identifiers": {"$ref": "#/definitions/identifiers"},
+                "person_or_org": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["name"],
+                  "properties": {
+                    "name": {"type": "string"},
+                    "type": {"$ref": "#/definitions/nameType"},
+                    "given_name": {"type": "string"},
+                    "family_name": {"type": "string"},
+                    "identifiers": {
+                      "type": "array",
+                      "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+                      "uniqueItems": true
+                    }
+                  }
+                },
+                "role": {"type": "string"},
                 "affiliations": {"$ref": "#/definitions/affiliations"}
             }
           }
@@ -557,15 +583,26 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name", "role"],
+            "required": ["person_or_org", "role"],
             "properties": {
-                "name": {"type": "string"},
-                "type": {"$ref": "#/definitions/nameType"},
-                "role": {"$ref": "#/definitions/contributorType"},
-                "given_name": {"type": "string"},
-                "family_name": {"type": "string"},
-                "identifiers": {"$ref": "#/definitions/identifiers"},
-                "affiliations": {"$ref": "#/definitions/affiliations"}
+              "person_or_org": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["name"],
+                "properties": {
+                  "name": {"type": "string"},
+                  "type": {"$ref": "#/definitions/nameType"},
+                  "given_name": {"type": "string"},
+                  "family_name": {"type": "string"},
+                  "identifiers": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+                    "uniqueItems": true
+                  }
+                }
+              },
+              "role": {"$ref": "#/definitions/contributorType"},
+              "affiliations": {"$ref": "#/definitions/affiliations"}
             }
           }
         },
@@ -599,14 +636,7 @@
         "identifiers": {
           "description": "Alternate identifiers for the record.",
           "type": "array",
-          "items": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
-              }
-          },
+          "items": {"$ref": "#/definitions/identifiers_with_scheme"},
           "uniqueItems": true
         },
 
@@ -713,7 +743,11 @@
                       "additionalProperties": false
                     }]
                   },
-                  "identifiers": {"$ref": "#/definitions/identifiers"},
+                  "identifiers": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+                    "uniqueItems": true
+                  },
                   "place": {
                     "description": "Place of the location",
                     "type": "string",

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v1.0.0.json
@@ -56,29 +56,47 @@
                 "affiliations" : {
                   "properties" : {
                     "identifiers" : {
-                      "type" : "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "name" : {
                       "type" : "text"
                     }
                   }
                 },
-                "family_name" : {
-                  "type" : "text"
-                },
-                "given_name" : {
-                  "type" : "text"
-                },
-                "identifiers" : {
-                  "type" : "object"
-                },
-                "name" : {
-                  "type" : "text"
+                "person_or_org": {
+                  "properties": {
+                    "family_name" : {
+                      "type" : "text"
+                    },
+                    "given_name" : {
+                      "type" : "text"
+                    },
+                    "identifiers" : {
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    },
+                    "name" : {
+                      "type" : "text"
+                    },
+                    "type" : {
+                      "type" : "keyword"
+                    }
+                  }
                 },
                 "role" : {
-                  "type" : "keyword"
-                },
-                "type" : {
                   "type" : "keyword"
                 }
               }
@@ -88,26 +106,47 @@
                 "affiliations" : {
                   "properties" : {
                     "identifiers" : {
-                      "type" : "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "name" : {
                       "type" : "text"
                     }
                   }
                 },
-                "family_name" : {
-                  "type" : "text"
+                "person_or_org": {
+                  "properties": {
+                    "family_name" : {
+                      "type" : "text"
+                    },
+                    "given_name" : {
+                      "type" : "text"
+                    },
+                    "identifiers" : {
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    },
+                    "name" : {
+                      "type" : "text"
+                    },
+                    "type" : {
+                      "type" : "keyword"
+                    }
+                  }
                 },
-                "given_name" : {
-                  "type" : "text"
-                },
-                "identifiers" : {
-                  "type" : "object"
-                },
-                "name" : {
-                  "type" : "text"
-                },
-                "type" : {
+                "role" : {
                   "type" : "keyword"
                 }
               }
@@ -151,7 +190,14 @@
               }
             },
             "identifiers" : {
-              "type" : "object"
+              "properties": {
+                "identifier" : {
+                  "type" : "text"
+                },
+                "scheme" : {
+                  "type" : "keyword"
+                }
+              }
             },
             "languages" : {
               "properties" : {
@@ -193,7 +239,14 @@
                       "type": "text"
                     },
                     "identifiers": {
-                      "type": "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "description": {
                       "type": "text"

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v1.0.0.json
@@ -56,29 +56,47 @@
                 "affiliations" : {
                   "properties" : {
                     "identifiers" : {
-                      "type" : "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "name" : {
                       "type" : "text"
                     }
                   }
                 },
-                "family_name" : {
-                  "type" : "text"
-                },
-                "given_name" : {
-                  "type" : "text"
-                },
-                "identifiers" : {
-                  "type" : "object"
-                },
-                "name" : {
-                  "type" : "text"
+                "person_or_org": {
+                  "properties": {
+                    "family_name" : {
+                      "type" : "text"
+                    },
+                    "given_name" : {
+                      "type" : "text"
+                    },
+                    "identifiers" : {
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    },
+                    "name" : {
+                      "type" : "text"
+                    },
+                    "type" : {
+                      "type" : "keyword"
+                    }
+                  }
                 },
                 "role" : {
-                  "type" : "keyword"
-                },
-                "type" : {
                   "type" : "keyword"
                 }
               }
@@ -88,26 +106,47 @@
                 "affiliations" : {
                   "properties" : {
                     "identifiers" : {
-                      "type" : "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "name" : {
                       "type" : "text"
                     }
                   }
                 },
-                "family_name" : {
-                  "type" : "text"
+                "person_or_org": {
+                  "properties": {
+                    "family_name" : {
+                      "type" : "text"
+                    },
+                    "given_name" : {
+                      "type" : "text"
+                    },
+                    "identifiers" : {
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
+                    },
+                    "name" : {
+                      "type" : "text"
+                    },
+                    "type" : {
+                      "type" : "keyword"
+                    }
+                  }
                 },
-                "given_name" : {
-                  "type" : "text"
-                },
-                "identifiers" : {
-                  "type" : "object"
-                },
-                "name" : {
-                  "type" : "text"
-                },
-                "type" : {
+                "role" : {
                   "type" : "keyword"
                 }
               }
@@ -151,7 +190,14 @@
               }
             },
             "identifiers" : {
-              "type" : "object"
+              "properties": {
+                "identifier" : {
+                  "type" : "text"
+                },
+                "scheme" : {
+                  "type" : "keyword"
+                }
+              }
             },
             "languages" : {
               "properties" : {
@@ -193,7 +239,14 @@
                       "type": "text"
                     },
                     "identifiers": {
-                      "type": "object"
+                      "properties": {
+                        "identifier" : {
+                          "type" : "keyword"
+                        },
+                        "scheme" : {
+                          "type" : "keyword"
+                        }
+                      }
                     },
                     "description": {
                       "type": "text"

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v1.0.0.json
@@ -55,29 +55,47 @@
               "affiliations" : {
                 "properties" : {
                   "identifiers" : {
-                    "type" : "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "name" : {
                     "type" : "text"
                   }
                 }
               },
-              "family_name" : {
-                "type" : "text"
-              },
-              "given_name" : {
-                "type" : "text"
-              },
-              "identifiers" : {
-                "type" : "object"
-              },
-              "name" : {
-                "type" : "text"
+              "person_or_org": {
+                "properties": {
+                  "family_name" : {
+                    "type" : "text"
+                  },
+                  "given_name" : {
+                    "type" : "text"
+                  },
+                  "identifiers" : {
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "name" : {
+                    "type" : "text"
+                  },
+                  "type" : {
+                    "type" : "keyword"
+                  }
+                }
               },
               "role" : {
-                "type" : "keyword"
-              },
-              "type" : {
                 "type" : "keyword"
               }
             }
@@ -87,26 +105,47 @@
               "affiliations" : {
                 "properties" : {
                   "identifiers" : {
-                    "type" : "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "name" : {
                     "type" : "text"
                   }
                 }
               },
-              "family_name" : {
-                "type" : "text"
+              "person_or_org": {
+                "properties": {
+                  "family_name" : {
+                    "type" : "text"
+                  },
+                  "given_name" : {
+                    "type" : "text"
+                  },
+                  "identifiers" : {
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "name" : {
+                    "type" : "text"
+                  },
+                  "type" : {
+                    "type" : "keyword"
+                  }
+                }
               },
-              "given_name" : {
-                "type" : "text"
-              },
-              "identifiers" : {
-                "type" : "object"
-              },
-              "name" : {
-                "type" : "text"
-              },
-              "type" : {
+              "role" : {
                 "type" : "keyword"
               }
             }
@@ -150,7 +189,14 @@
             }
           },
           "identifiers" : {
-            "type" : "object"
+            "properties": {
+              "identifier" : {
+                "type" : "text"
+              },
+              "scheme" : {
+                "type" : "keyword"
+              }
+            }
           },
           "languages" : {
             "properties" : {
@@ -192,7 +238,14 @@
                     "type": "text"
                   },
                   "identifiers": {
-                    "type": "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "description": {
                     "type": "text"

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v1.0.0.json
@@ -55,29 +55,47 @@
               "affiliations" : {
                 "properties" : {
                   "identifiers" : {
-                    "type" : "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "name" : {
                     "type" : "text"
                   }
                 }
               },
-              "family_name" : {
-                "type" : "text"
-              },
-              "given_name" : {
-                "type" : "text"
-              },
-              "identifiers" : {
-                "type" : "object"
-              },
-              "name" : {
-                "type" : "text"
+              "person_or_org": {
+                "properties": {
+                  "family_name" : {
+                    "type" : "text"
+                  },
+                  "given_name" : {
+                    "type" : "text"
+                  },
+                  "identifiers" : {
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "name" : {
+                    "type" : "text"
+                  },
+                  "type" : {
+                    "type" : "keyword"
+                  }
+                }
               },
               "role" : {
-                "type" : "keyword"
-              },
-              "type" : {
                 "type" : "keyword"
               }
             }
@@ -87,26 +105,47 @@
               "affiliations" : {
                 "properties" : {
                   "identifiers" : {
-                    "type" : "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "name" : {
                     "type" : "text"
                   }
                 }
               },
-              "family_name" : {
-                "type" : "text"
+              "person_or_org": {
+                "properties": {
+                  "family_name" : {
+                    "type" : "text"
+                  },
+                  "given_name" : {
+                    "type" : "text"
+                  },
+                  "identifiers" : {
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
+                  },
+                  "name" : {
+                    "type" : "text"
+                  },
+                  "type" : {
+                    "type" : "keyword"
+                  }
+                }
               },
-              "given_name" : {
-                "type" : "text"
-              },
-              "identifiers" : {
-                "type" : "object"
-              },
-              "name" : {
-                "type" : "text"
-              },
-              "type" : {
+              "role" : {
                 "type" : "keyword"
               }
             }
@@ -150,7 +189,14 @@
             }
           },
           "identifiers" : {
-            "type" : "object"
+            "properties": {
+              "identifier" : {
+                "type" : "text"
+              },
+              "scheme" : {
+                "type" : "keyword"
+              }
+            }
           },
           "languages" : {
             "properties" : {
@@ -192,7 +238,14 @@
                     "type": "text"
                   },
                   "identifiers": {
-                    "type": "object"
+                    "properties": {
+                      "identifier" : {
+                        "type" : "keyword"
+                      },
+                      "scheme" : {
+                        "type" : "keyword"
+                      }
+                    }
                   },
                   "description": {
                     "type": "text"

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -39,8 +39,8 @@ class AffiliationSchema(Schema):
     )
 
 
-class CreatibutorSchema(Schema):
-    """Creator/Contributor schema."""
+class PersonOrOrganizationSchema(Schema):
+    """Person or Organization schema."""
 
     NAMES = [
         "organizational",
@@ -70,7 +70,6 @@ class CreatibutorSchema(Schema):
             allowed_schemes=["orcid", "isni", "gnd", "ror"]
         ))
     )
-    affiliations = fields.List(fields.Nested(AffiliationSchema))
 
     @validates_schema
     def validate_names(self, data, **kwargs):
@@ -108,10 +107,12 @@ class CreatibutorSchema(Schema):
         return data
 
 
-class CreatorSchema(CreatibutorSchema):
+class CreatorSchema(Schema):
     """Creator schema."""
 
+    person_or_org = fields.Nested(PersonOrOrganizationSchema, required=True)
     role = SanitizedUnicode()
+    affiliations = fields.List(fields.Nested(AffiliationSchema))
 
     @validates_schema
     def validate_role(self, data, **kwargs):
@@ -120,10 +121,12 @@ class CreatorSchema(CreatibutorSchema):
             validate_entry('creators.role', data)
 
 
-class ContributorSchema(CreatibutorSchema):
+class ContributorSchema(Schema):
     """Contributor schema."""
 
+    person_or_org = fields.Nested(PersonOrOrganizationSchema)
     role = SanitizedUnicode(required=True)
+    affiliations = fields.List(fields.Nested(AffiliationSchema))
 
     @validates_schema
     def validate_role(self, data, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,14 +89,16 @@ def full_record():
                 "subtype": "publication-article"
             },
             "creators": [{
-                "name": "Nielsen, Lars Holm",
-                "type": "personal",
-                "given_name": "Lars Holm",
-                "family_name": "Nielsen",
-                "identifiers": [{
-                    "scheme": "orcid",
-                    "identifier": "0000-0001-8135-3489"
-                }],
+                "person_or_org": {
+                    "name": "Nielsen, Lars Holm",
+                    "type": "personal",
+                    "given_name": "Lars Holm",
+                    "family_name": "Nielsen",
+                    "identifiers": [{
+                        "scheme": "orcid",
+                        "identifier": "0000-0001-8135-3489"
+                    }],
+                },
                 "affiliations": [{
                     "name": "CERN",
                     "identifiers": [{
@@ -122,15 +124,17 @@ def full_record():
                 "scheme": "dewey"
             }],
             "contributors": [{
-                "name": "Nielsen, Lars Holm",
-                "type": "personal",
+                "person_or_org": {
+                    "name": "Nielsen, Lars Holm",
+                    "type": "personal",
+                    "given_name": "Lars Holm",
+                    "family_name": "Nielsen",
+                    "identifiers": [{
+                        "scheme": "orcid",
+                        "identifier": "0000-0001-8135-3489"
+                    }],
+                },
                 "role": "other",
-                "given_name": "Lars Holm",
-                "family_name": "Nielsen",
-                "identifiers": [{
-                    "scheme": "orcid",
-                    "identifier": "0000-0001-8135-3489"
-                }],
                 "affiliations": [{
                     "name": "CERN",
                     "identifiers": [{
@@ -271,17 +275,21 @@ def minimal_record():
                 "subtype": "image-photo"
             },
             "creators": [{
-                "family_name": "Brown",
-                "given_name": "Troy",
-                "type": "personal"
+                "person_or_org": {
+                    "family_name": "Brown",
+                    "given_name": "Troy",
+                    "type": "personal"
+                }
             }, {
-                "family_name": "Lester",
-                "given_name": "Phillip",
-                "type": "personal",
-                "identifiers": [{
-                    "scheme": "orcid",
-                    "identifier": "0000-0001-8135-3489"
-                }],
+                "person_or_org": {
+                    "family_name": "Lester",
+                    "given_name": "Phillip",
+                    "type": "personal",
+                    "identifiers": [{
+                        "scheme": "orcid",
+                        "identifier": "0000-0001-8135-3489"
+                    }],
+                },
                 "affiliations": [{
                     "name": "Carter-Morris",
                     "identifiers": [{
@@ -290,13 +298,15 @@ def minimal_record():
                     }]
                 }]
             }, {
-                "family_name": "Williamson",
-                "given_name": "Steven",
-                "type": "personal",
-                "identifiers": [{
-                    "scheme": "orcid",
-                    "identifier": "0000-0001-8135-3489"
-                }],
+                "person_or_org": {
+                    "family_name": "Williamson",
+                    "given_name": "Steven",
+                    "type": "personal",
+                    "identifiers": [{
+                        "scheme": "orcid",
+                        "identifier": "0000-0001-8135-3489"
+                    }],
+                },
                 "affiliations": [{
                     "name": "Ritter and Sons",
                     "identifiers": [{

--- a/tests/records/dumpers/test_edtf_dumpers.py
+++ b/tests/records/dumpers/test_edtf_dumpers.py
@@ -150,13 +150,15 @@ def test_eslistdumper_with_edtfext_parse_error(app, db, minimal_record):
 
     # Dump it
     dump = record.dumps(dumper=dumper)
-    assert "family_name_range" not in dump["metadata"]["creators"][0]
-    assert "family_name" in dump["metadata"]["creators"][0]
+    person_or_org = dump["metadata"]["creators"][0]["person_or_org"]
+    assert "family_name_range" not in person_or_org
+    assert "family_name" in person_or_org
 
     # Load it
     new_record = BibliographicRecord.loads(dump, loader=dumper)
-    assert 'family_name_range' not in new_record['metadata']['creators'][0]
-    assert 'family_name' in new_record['metadata']['creators'][0]
+    person_or_org = dump["metadata"]["creators"][0]["person_or_org"]
+    assert 'family_name_range' not in person_or_org
+    assert 'family_name' in person_or_org
     assert 'type_start' not in new_record['metadata']['resource_type']
     assert 'type_end' not in new_record['metadata']['resource_type']
     assert 'type' in new_record['metadata']['resource_type']

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -37,19 +37,25 @@
       "subtype": "article"
     },
     "creators": [{
-      "name": "Nielsen, Lars Holm",
-      "type": "personal",
-      "given_name": "Lars Holm",
-      "family_name": "Nielsen",
-      "identifiers": {
-        "orcid": "0000-0001-8135-3489"
+      "person_or_org": {
+        "name": "Nielsen, Lars Holm",
+        "type": "personal",
+        "given_name": "Lars Holm",
+        "family_name": "Nielsen",
+        "identifiers": [{
+          "scheme": "orcid",
+          "identifier": "0000-0001-8135-3489"
+        }]
       },
       "affiliations": [{
         "name": "CERN",
-        "identifiers": {
-          "ror": "01ggx4157",
-          "isni": "000000012156142X"
-        }
+        "identifiers": [{
+          "scheme": "ror",
+          "identifier": "01ggx4157"
+        }, {
+          "scheme": "isni",
+          "identifier": "000000012156142X"
+        }]
       }]
     }],
     "title": "InvenioRDM",
@@ -66,20 +72,26 @@
       "scheme": "dewey"
     }],
     "contributors": [{
-      "name": "Nielsen, Lars Holm",
-      "type": "personal",
-      "role": "other",
-      "given_name": "Lars Holm",
-      "family_name": "Nielsen",
-      "identifiers": {
-        "orcid": "0000-0001-8135-3489"
+      "person_or_org": {
+        "name": "Nielsen, Lars Holm",
+        "type": "personal",
+        "given_name": "Lars Holm",
+        "family_name": "Nielsen",
+        "identifiers": [{
+          "scheme": "orcid",
+          "identifier": "0000-0001-8135-3489"
+        }]
       },
+      "role": "other",
       "affiliations": [{
         "name": "CERN",
-        "identifiers": {
-          "ror": "01ggx4157",
-          "isni": "000000012156142X"
-        }
+        "identifiers": [{
+          "scheme": "ror",
+          "identifier": "01ggx4157"
+        }, {
+          "scheme": "isni",
+          "identifier": "000000012156142X"
+        }]
       }]
     }],
     "dates": [{
@@ -123,10 +135,13 @@
           "type": "Point",
           "coordinates": [6.05, 46.23333]
         },
-        "identifiers": {
-          "geonames": "2661235",
-          "tgn": "http://vocab.getty.edu/tgn/8703679"
-        },
+        "identifiers": [{
+          "scheme": "geonames",
+          "identifier": "2661235"
+        }, {
+          "scheme": "tgn",
+          "identifier": "http://vocab.getty.edu/tgn/8703679"
+        }],
         "place": "CERN",
         "description": "Invenio birth place."
       }]
@@ -134,7 +149,7 @@
     "funding": [{
       "funder": {
         "name": "European Commission",
-        "identifier": "1234",
+        "identifier": "01ggx4157",
         "scheme": "ror"
       },
       "award": {

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -52,22 +52,26 @@ def fails_meta(data):
 def person():
     """Person for creator or contributor."""
     return {
-        "name": "Nielsen, Lars Holm",
-        "type": "personal",
-        "given_name": "Lars Holm",
-        "family_name": "Nielsen",
-        "identifiers": {
-            "orcid": "0000-0001-8135-3489"
+        "person_or_org": {
+            "name": "Nielsen, Lars Holm",
+            "type": "personal",
+            "given_name": "Lars Holm",
+            "family_name": "Nielsen",
+            "identifiers": [{
+                "scheme": "orcid",
+                "identifier": "0000-0001-8135-3489"
+            }],
         },
-        "affiliations": [
-            {
-                "name": "CERN",
-                "identifiers": {
-                    "ror": "01ggx4157",
-                    "isni": "000000012156142X",
-                }
-            }
-        ]
+        "affiliations": [{
+            "name": "CERN",
+            "identifiers": [{
+                "scheme": "ror",
+                "identifier": "01ggx4157"
+            }, {
+                "scheme": "isni",
+                "identifier": "000000012156142X"
+            }]
+        }]
     }
 
 
@@ -75,19 +79,21 @@ def person():
 def org():
     """Organization for creator or contributor."""
     return {
-        "name": "CERN",
-        "type": "organizational",
-        "identifiers": {
-            "ror": "01ggx4157"
+        "person_or_org": {
+            "name": "CERN",
+            "type": "organizational",
+            "identifiers": [{
+                "scheme": "ror",
+                "identifier": "01ggx4157"
+            }],
         },
-        "affiliations": [
-            {
-                "name": "CERN",
-                "identifiers": {
-                    "ror": "..."
-                }
-            }
-        ]
+        "affiliations": [{
+            "name": "CERN",
+            "identifiers": [{
+                "scheme": "ror",
+                "identifier": "..."
+            }],
+        }]
     }
 
 
@@ -196,14 +202,16 @@ def test_creators(appctx, person, org):
     """Test creators."""
     assert fails_meta({"creators": {}})
     assert validates_meta({"creators": []})
-    assert validates_meta({"creators": [{"name": "test"}]})
+    assert validates_meta({"creators": [{"person_or_org": {"name": "test"}}]})
 
     assert validates_meta({"creators": [person]})
     assert validates_meta({"creators": [org]})
     assert validates_meta({"creators": [person, org]})
 
     # Additional prop fails
-    assert fails_meta({"creators": [{"name": "test", "invalid": "test"}]})
+    assert fails_meta({"creators": [
+        {"person_or_org": {"name": "test"}, "invalid": "test"}
+    ]})
     person["affiliations"][0]["invalid"] = "test"
     assert fails_meta({"creators": [person]})
 
@@ -265,7 +273,8 @@ def test_contributors(appctx, person, org):
     assert fails_meta({"contributors": {}})
     assert validates_meta({"contributors": []})
     assert validates_meta({"contributors": [
-        {"name": "test", "role": "other"}]})
+        {"person_or_org": {"name": "test"}, "role": "other"}
+    ]})
 
     person["role"] = "other"
     org["role"] = "hosting_institution"
@@ -275,7 +284,8 @@ def test_contributors(appctx, person, org):
     assert validates_meta({"contributors": [person, org]})
 
     # Additional prop fails
-    assert fails_meta({"contributors": [{"name": "test", "invalid": "test"}]})
+    assert fails_meta({"contributors": [
+        {"person_or_org": {"name": "test"}, "invalid": "test"}]})
     person["affiliations"][0]["invalid"] = "test"
     assert fails_meta({"contributors": [person]})
 
@@ -412,20 +422,26 @@ def test_additional_descriptions(appctx):
     [{
         "geometry": {"type": "Point", "coordinates": [6.05, 46.23333]},
     }], [{
-        "identifiers": {
-            "geonames": "2661235",
-            "tgn": "http://vocab.getty.edu/tgn/8703679"
-        },
+        "identifiers": [{
+            "scheme": "geonames",
+            "identifier": "2661235"
+        }, {
+            "scheme": "tgn",
+            "identifier": "http://vocab.getty.edu/tgn/8703679"
+        }],
     }], [{
         "place": "CERN"
     }], [{
         "description": "Invenio birth place."
     }], [{
         "geometry": {"type": "Point", "coordinates": [6.05, 46.23333]},
-        "identifiers": {
-            "geonames": "2661235",
-            "tgn": "http://vocab.getty.edu/tgn/8703679"
-        },
+        "identifiers": [{
+            "scheme": "geonames",
+            "identifier": "2661235"
+        }, {
+            "scheme": "tgn",
+            "identifier": "http://vocab.getty.edu/tgn/8703679"
+        }],
         "place": "CERN",
         "description": "Invenio birth place."
     }],

--- a/tests/resources/test_publish_errors.py
+++ b/tests/resources/test_publish_errors.py
@@ -47,14 +47,18 @@ def test_nested_field_error(
         client, minimal_record, location, es_clear, headers):
     minimal_record["metadata"]["creators"] = [
         {
-            "name": "Julio Cesar",
-            "type": "personal",
-            "given_name": "Julio",
-            "family_name": "Cesar",
+            "person_or_org": {
+                "name": "Julio Cesar",
+                "type": "personal",
+                "given_name": "Julio",
+                "family_name": "Cesar",
+            }
         },
         # No name even though it is required
         {
-            "type": "organizational",
+            "person_or_org": {
+                "type": "organizational",
+            }
         }
     ]
     response = save_partial_draft(client, minimal_record, headers)
@@ -68,7 +72,7 @@ def test_nested_field_error(
     assert 400 == response.status_code
     expected = [
         {
-            "field": "metadata.creators.1.name",
+            "field": "metadata.creators.1.person_or_org.name",
             "messages": ["Name cannot be blank."]
         }
     ]


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/460

Note that no value (e.g. roles) are made into vocabularies due to cross-works in invenio-vocabularies. In addition, there is a blocker at `Relations` field in `api.py` level. The relation should be set to `metadata.contributors.role` but contributors (and creators) are arrays.