### PR TITLE
jsonschema: remove enum restrictions

### DIFF
--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -9,22 +9,12 @@
 
     "nameType": {
       "description": "Type of name.",
-      "type": "string",
-      "enum": [
-          "organizational",
-          "personal"
-      ]
+      "type": "string"
     },
 
     "titleType": {
       "description": "Type of title.",
-      "type": "string",
-      "enum": [
-          "alternative_title",
-          "subtitle",
-          "translated_title",
-          "other"
-      ]
+      "type": "string"
     },
 
     "contributorType": {
@@ -33,20 +23,7 @@
 
     "dateType": {
       "description": "Type of the date.",
-      "type": "string",
-      "enum": [
-        "accepted",
-        "available",
-        "copyrighted",
-        "collected",
-        "created",
-        "issued",
-        "submitted",
-        "updated",
-        "valid",
-        "withdrawn",
-        "other"
-      ]
+      "type": "string"
     },
 
     "relationType": {
@@ -54,15 +31,7 @@
     },
 
     "descriptionType": {
-      "type": "string",
-      "enum": [
-        "abstract",
-        "methods",
-        "seriesinformation",
-        "tableofcontents",
-        "technicalinfo",
-        "other"
-      ]
+      "type": "string"
     },
 
     "language": {
@@ -143,7 +112,6 @@
         }
       }
     },
-
 
     "resource_type": {
       "type": "object",

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -224,10 +224,6 @@ def test_additional_titles(appctx):
     assert validates_meta({"additional_titles": [
         {"title": "Test", "type": "subtitle", "lang": "dan"},
     ]})
-
-    assert fails_meta({"additional_titles": [
-        {"title": "Test", "type": "invalid", "lang": "toolong"}
-    ]})
     assert fails_meta({"additional_titles": [
         {"title": "Test", "invalid": "invalid"}
     ]})


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/216

Restrictions will be set when migration to vocabularies happens