### PR TITLE
marshmallow: use correct nested type for access

### DIFF
--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -43,7 +43,7 @@ class RDMRecordSchema(RecordSchema):
     # ext = fields.Method('dump_extensions', 'load_extensions')
     # tombstone
     # provenance
-    access = NestedAttribute(AccessSchema)
+    access = fields.Nested(AccessSchema)
     # files = NestedAttribute(FilesSchema, dump_only=True)
     # notes = fields.List(fields.Nested(InternalNoteSchema))
     created = fields.Str(dump_only=True)


### PR DESCRIPTION
should fix the issues described in https://github.com/inveniosoftware/invenio-drafts-resources/pull/94
the issues arose because i used the wrong nested type for the access schema (namely one that resulted in a dump of `record.access` instead of `record["access"]`).