### PR TITLE
bugfix: adds user to the query

### DIFF
--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -89,5 +89,5 @@ class RecordOwners(Generator):
         """Filters for current identity as owner."""
         for need in identity.provides:
             if need.method == 'id':
-                return Q('term', **{'access.owned_by': need.value})
+                return Q("term", **{"access.owned_by.user": need.value})
         return []

--- a/tests/services/test_generators.py
+++ b/tests/services/test_generators.py
@@ -111,4 +111,4 @@ def test_record_owner(mocker):
         )
     )
 
-    assert query_filter.to_dict() == {'term': {'access.owned_by': 15}}
+    assert query_filter.to_dict() == {'term': {'access.owned_by.user': 15}}


### PR DESCRIPTION
@lnielsen this should fix it - I tested , it works for ```can_read = [IfRestricted('record', RecordOwners(), else_=AnyUser())] ```.