### PR TITLE
license-link: checks for valid url

### DIFF
--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2021 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -24,6 +25,11 @@ from .utils import validate_entry
 def _not_blank(error_msg):
     """Returns a non-blank validation rule with custom error message."""
     return validate.Length(min=1, error=error_msg)
+
+
+def _valid_url(error_msg):
+    """Returns a URL validation rule with custom error message."""
+    return validate.URL(error=error_msg)
 
 
 class AffiliationSchema(Schema):
@@ -216,8 +222,7 @@ class RightsSchema(IdentifierSchema):
     title = SanitizedUnicode()
     description = SanitizedUnicode()
     link = SanitizedUnicode(
-        validate=_is_uri,
-        error=_('Wrong URI format. Should follow RFC 3986.')
+        validate=_valid_url(_('Not a valid URL.'))
     )
 
 

--- a/tests/services/schemas/test_right.py
+++ b/tests/services/schemas/test_right.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2021 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -50,6 +51,16 @@ def test_invalid_extra_right():
     }
     with pytest.raises(ValidationError):
         data = RightsSchema().load(invalid_extra)
+
+
+def test_invalid_url():
+    invalid_url = {
+        "title": "Creative Commons Attribution 4.0 International",
+        "description": "A description",
+        "link": "creativecommons.org/licenses/by/4.0/"
+    }
+    with pytest.raises(ValidationError):
+        data = RightsSchema().load(invalid_url)
 
 
 @pytest.mark.skip(reason="idutils cannot validate spdx")


### PR DESCRIPTION
partially closes inveniosoftware/invenio-app-rdm#588

by invalid url - the json will include these errors:
```json
    "errors": [
        {
            "field": "metadata.rights.0.link",
            "messages": [
                "Not a valid URL."
            ]
        }
    ]
```