### PR TITLE
access: silently prevent users from changing record owners

### DIFF
--- a/invenio_rdm_records/services/components.py
+++ b/invenio_rdm_records/services/components.py
@@ -8,6 +8,7 @@
 
 """RDM service components."""
 
+from invenio_access.permissions import Permission, system_process
 from invenio_records_resources.services.records.components import \
     ServiceComponent
 from marshmallow import ValidationError
@@ -38,6 +39,12 @@ class AccessComponent(ServiceComponent):
 
     def _populate_access_and_validate(self, identity, data, record, **kwargs):
         """Populate and validate the record's access field."""
+        if not Permission(system_process).allows(identity):
+            # if it's not a system process doing this operation, ignore the
+            # set record owners -- only system processes are allowed to
+            # explicitly set the record's owners
+            data.get("access", {}).pop("owned_by", None)
+
         if "access" in data:
             # populate the record's access field with the data already
             # validated by marshmallow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -331,10 +331,11 @@ def roles(app, db):
     return [role1, role2]
 
 
-@pytest.fixture(scope="module")
-def identity_simple():
+@pytest.fixture(scope="function")
+def identity_simple(users):
     """Simple identity fixture."""
-    i = Identity(1)
-    i.provides.add(UserNeed(1))
+    user = users[0]
+    i = Identity(user.id)
+    i.provides.add(UserNeed(user.id))
     i.provides.add(Need(method='system_role', value='any_user'))
     return i


### PR DESCRIPTION
* the only exception are system processes, which are allowed to set the
  record owners explicitly