### PR TITLE
run-tests: forward supplied options and arguments to pytest

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,12 +3,20 @@
 #
 # Copyright (C) 2019-2020 CERN.
 # Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C)      2021 TU Wien.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Usage:
-#   env DB=postgresql ./run-tests.sh
+#   ./run-tests.sh [pytest options and args...]
+#
+# Note: the DB, SEARCH and MQ services to use are determined by corresponding environment
+#       variables if they are set -- otherwise, the following defaults are used:
+#       DB=postgresql, SEARCH=elasticsearch and MQ=redis
+#
+# Example for using mysql instead of postgresql:
+#    DB=mysql ./run-tests.sh
 
 # Quit on errors
 set -o errexit
@@ -24,7 +32,7 @@ trap cleanup EXIT
 
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
-eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --mq redis --env)"
-python -m pytest
+eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --mq ${MQ:-redis} --env)"
+python -m pytest $@
 tests_exit_code=$?
 exit "$tests_exit_code"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,7 +9,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 
 # Usage:
-#   ./run-tests.sh [pytest options and args...]
+#   ./run-tests.sh [-K|--keep-services] [pytest options and args...]
 #
 # Note: the DB, SEARCH and MQ services to use are determined by corresponding environment
 #       variables if they are set -- otherwise, the following defaults are used:
@@ -24,15 +24,36 @@ set -o errexit
 # Quit on unbound symbols
 set -o nounset
 
-# Always bring down services
+# Define function for bringing down services
 function cleanup {
   eval "$(docker-services-cli down --env)"
 }
-trap cleanup EXIT
+
+# Check for arguments
+# Note: "-k" would clash with "pytest"
+keep_services=0
+pytest_args=()
+for arg in $@; do
+	# from the CLI args, filter out some known values and forward the rest to "pytest"
+	# note: we don't use "getopts" here b/c of some limitations (e.g. long options),
+	#       which means that we can't combine short options (e.g. "./run-tests -Kk pattern")
+	case ${arg} in
+		-K|--keep-services)
+			keep_services=1
+			;;
+		*)
+			pytest_args+=( ${arg} )
+			;;
+	esac
+done
+
+if [[ ${keep_services} -eq 0 ]]; then
+	trap cleanup EXIT
+fi
 
 python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --mq ${MQ:-redis} --env)"
-python -m pytest $@
+python -m pytest "${pytest_args[@]}"
 tests_exit_code=$?
 exit "$tests_exit_code"


### PR DESCRIPTION
closes inveniosoftware/invenio-app-rdm#675
pretty much the same as inveniosoftware/invenio-app-rdm/pull/690