### PR TITLE
alembic: add recipe to remove PIDRelations tables if they exist

### DIFF
--- a/invenio_rdm_records/alembic/a3957490361d_remove_pidrelations_tables.py
+++ b/invenio_rdm_records/alembic/a3957490361d_remove_pidrelations_tables.py
@@ -1,0 +1,33 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2021 TU Wien.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Remove PIDRelations tables."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.engine.reflection import Inspector
+
+# revision identifiers, used by Alembic.
+revision = "a3957490361d"
+down_revision = "88d1463de5c0"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    try:
+        # The table is not used and has no data.
+        op.drop_table("pidrelations_pidrelation")
+    except Exception:
+        pass
+
+
+def downgrade():
+    """Downgrade database."""
+    # no turning back


### PR DESCRIPTION
closes #444 

there's still a number of issues that need to be addressed, e.g. revision "1d4e361b7586" (from invenio-pidrelations) having no revision script but still being referenced from the DB table `alembic_versions` after uninstalling invenio-pidrelations
also, it seems like `alembic stamp` doesn't seem to work properly with the new revision script (it doesn't seem to find a parent?)