### PR TITLE
search: sort by versions

### DIFF
--- a/invenio_rdm_records/alembic/88d1463de5c0_create_parent_record_table.py
+++ b/invenio_rdm_records/alembic/88d1463de5c0_create_parent_record_table.py
@@ -76,7 +76,7 @@ def upgrade():
     )
     op.add_column(
         'rdm_drafts_metadata',
-        sa.Column('parent_index', sa.Integer, nullable=True)
+        sa.Column('index', sa.Integer, nullable=True)
     )
 
     # Records table FK to parent
@@ -94,7 +94,7 @@ def upgrade():
     )
     op.add_column(
         'rdm_records_metadata',
-        sa.Column('parent_index', sa.Integer, nullable=True)
+        sa.Column('index', sa.Integer, nullable=True)
     )
 
     # Records revisions table FK to parent
@@ -104,7 +104,7 @@ def upgrade():
     )
     op.add_column(
         'rdm_records_metadata_version',
-        sa.Column('parent_index', sa.Integer, nullable=True)
+        sa.Column('index', sa.Integer, nullable=True)
     )
 
     # Create versions state table
@@ -142,19 +142,19 @@ def downgrade():
     """Downgrade database."""
     op.drop_table('rdm_versions_state')
     op.drop_column('rdm_records_metadata_version', 'parent_id')
-    op.drop_column('rdm_records_metadata_version', 'parent_index')
+    op.drop_column('rdm_records_metadata_version', 'index')
     op.drop_constraint(
         op.f('fk_rdm_records_metadata_parent_id_rdm_parents_metadata'),
         'rdm_records_metadata',
         type_='foreignkey'
     )
     op.drop_column('rdm_records_metadata', 'parent_id')
-    op.drop_column('rdm_records_metadata', 'parent_index')
+    op.drop_column('rdm_records_metadata', 'index')
     op.drop_constraint(
         op.f('fk_rdm_drafts_metadata_parent_id_rdm_parents_metadata'),
         'rdm_drafts_metadata',
         type_='foreignkey'
     )
     op.drop_column('rdm_drafts_metadata', 'parent_id')
-    op.drop_column('rdm_drafts_metadata', 'parent_index')
+    op.drop_column('rdm_drafts_metadata', 'index')
     op.drop_table('rdm_parents_metadata')

--- a/invenio_rdm_records/alembic/a3957490361d_remove_pidrelations_tables.py
+++ b/invenio_rdm_records/alembic/a3957490361d_remove_pidrelations_tables.py
@@ -31,3 +31,4 @@ def upgrade():
 def downgrade():
     """Downgrade database."""
     # no turning back
+    pass

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v2.0.0.json
@@ -450,6 +450,28 @@
         },
         "is_published": {
           "type": "boolean"
+        },
+        "versions": {
+          "properties": {
+            "index": {
+              "type": "integer"
+            },
+            "is_latest": {
+              "type": "boolean"
+            },
+            "is_latest_draft": {
+              "type": "boolean"
+            },
+            "latest_id": {
+              "type": "keyword"
+            },
+            "latest_index": {
+              "type": "integer"
+            },
+            "next_draft_id": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v2.0.0.json
@@ -450,6 +450,28 @@
         },
         "is_published": {
           "type": "boolean"
+        },
+        "versions": {
+          "properties": {
+            "index": {
+              "type": "integer"
+            },
+            "is_latest": {
+              "type": "boolean"
+            },
+            "is_latest_draft": {
+              "type": "boolean"
+            },
+            "latest_id": {
+              "type": "keyword"
+            },
+            "latest_index": {
+              "type": "integer"
+            },
+            "next_draft_id": {
+              "type": "keyword"
+            }
+          }
         }
       }
     }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v2.0.0.json
@@ -449,6 +449,28 @@
       },
       "is_published": {
         "type": "boolean"
+      },
+      "versions": {
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "is_latest": {
+            "type": "boolean"
+          },
+          "is_latest_draft": {
+            "type": "boolean"
+          },
+          "latest_id": {
+            "type": "keyword"
+          },
+          "latest_index": {
+            "type": "integer"
+          },
+          "next_draft_id": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v2.0.0.json
@@ -449,6 +449,28 @@
       },
       "is_published": {
         "type": "boolean"
+      },
+      "versions": {
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "is_latest": {
+            "type": "boolean"
+          },
+          "is_latest_draft": {
+            "type": "boolean"
+          },
+          "latest_id": {
+            "type": "keyword"
+          },
+          "latest_index": {
+            "type": "integer"
+          },
+          "next_draft_id": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -35,6 +35,25 @@ class RDMRecordServiceConfig(RecordDraftServiceConfig):
 
     permission_policy_cls = RDMRecordPermissionPolicy
 
+    search_sort_options = {
+        "bestmatch": dict(
+            title=_('Best match'),
+            fields=['_score'],  # ES defaults to desc on `_score` field
+        ),
+        "newest": dict(
+            title=_('Newest'),
+            fields=['-created'],
+        ),
+        "oldest": dict(
+            title=_('Oldest'),
+            fields=['created'],
+        ),
+        "version": dict(
+            title=_('Version'),
+            fields=['-versions.index'],
+        ),
+    }
+
     search_facets_options = dict(
         aggs={
             'resource_type': {
@@ -111,7 +130,10 @@ class RDMUserRecordsServiceConfig(RDMRecordServiceConfig):
             title=_('Oldest'),
             fields=['created'],
         ),
-
+        "version": dict(
+            title=_('Version'),
+            fields=['-versions.index'],
+        ),
     }
 
     search_facets_options = dict(

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.28.8'
+__version__ = '0.28.9'

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -109,10 +109,10 @@ def authenticated_identity():
 
 
 @pytest.fixture(scope="function")
-def superuser_identity():
+def superuser_identity(superuser_role_need):
     """Superuser identity fixture."""
     identity = Identity(1)
-    identity.provides.add(superuser_access)
+    identity.provides.add(superuser_role_need)
     return identity
 
 

--- a/tests/services/test_sort.py
+++ b/tests/services/test_sort.py
@@ -28,9 +28,12 @@ def test_sort_by_versions(
     record = service.publish(draft.id, superuser_identity)
     # Create version 2
     draft = service.new_version(record.id, superuser_identity)
+    # NOTE: needed because publication_date is stripped from draft
+    service.update_draft(draft.id, superuser_identity, minimal_record)
     record_2 = service.publish(draft.id, superuser_identity)
     # Create version 3
     draft = service.new_version(record_2.id, superuser_identity)
+    service.update_draft(draft.id, superuser_identity, minimal_record)
     record_3 = service.publish(draft.id, superuser_identity)
     # NOTE: we swap version 2 and 3, so that "newest" order is different
     #       than "versions" order

--- a/tests/services/test_sort.py
+++ b/tests/services/test_sort.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
+#
+# Invenio-Records-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Sort tests."""
+
+
+import pytest
+
+from invenio_rdm_records.services import RDMRecordService
+
+
+@pytest.fixture()
+def service(app, location):
+    """Service fixture."""
+    return RDMRecordService()
+
+
+def test_sort_by_versions(
+        service, superuser_identity, minimal_record):
+    # Create version 1
+    draft = service.create(superuser_identity, minimal_record)
+    record = service.publish(draft.id, superuser_identity)
+    # Create version 2
+    draft = service.new_version(record.id, superuser_identity)
+    record_2 = service.publish(draft.id, superuser_identity)
+    # Create version 3
+    draft = service.new_version(record_2.id, superuser_identity)
+    record_3 = service.publish(draft.id, superuser_identity)
+    # NOTE: we swap version 2 and 3, so that "newest" order is different
+    #       than "versions" order
+    # Swap version 2 and 3: we have to reach all the way to DB model to do so
+    record_2._record.model.index = 3
+    record_3._record.model.index = 2
+    # Re-index them
+    service.indexer.index(record_2._record)
+    service.indexer.index(record_3._record)
+    record_2._record.index.refresh()  # Needed because not all documents
+                                      # caught by search otherwise
+
+    result = service.search(superuser_identity, sort='version').to_dict()
+
+    expected_order = [record_2.id, record_3.id, record.id]
+    assert expected_order == [h["id"] for h in result['hits']['hits']]

--- a/tests/services/test_sort.py
+++ b/tests/services/test_sort.py
@@ -40,8 +40,9 @@ def test_sort_by_versions(
     # Re-index them
     service.indexer.index(record_2._record)
     service.indexer.index(record_3._record)
-    record_2._record.index.refresh()  # Needed because not all documents
-                                      # caught by search otherwise
+    # refresh() is Needed because not all documents
+    # are caught by search otherwise
+    record_2._record.index.refresh()
 
     result = service.search(superuser_identity, sort='version').to_dict()
 


### PR DESCRIPTION
- ~~:warning: requires versioning PR with ES indexing.~~
- closes #440 

Note: According to RFC

> `versioning_order` (`parent_order`) - Integer (4 bytes) defining the rank of the record among sibling versions.

is defined for the DB and we expect something similar in the ES index. Furthermore, we expect that every new version is from the latest record. That is:

**Good**
Time 1

```
Concept Record
|
|___ Record V1
```

Time 2

```
Concept Record
|
|___ Record V2
|
|___ Record V1
```

Time 3

```
Concept Record
|
|___ Record V3
|
|___ Record V2
|
|___ Record V1
```

Otherwise, it is extremely hard (I don't know how to) order versions. That is:

**Bad**
Time 4

```
Concept Record
|
|___ Record V3
|
|___ Record new version from V2  <-- how could this be ordered?
|
|___ Record V2
|
|___ Record V1
```
 
ES provides a new version field but only for 7.11+ on: https://www.elastic.co/guide/en/elasticsearch/reference/7.11/version.html .

With these constraints in place, what is the difference between sorting by newest and sorting by versions? 
