### PR TITLE
mappings: update ES mappings for the record/parent split

### DIFF
--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/drafts/draft-v2.0.0.json
@@ -15,13 +15,6 @@
             "files" : {
               "type" : "keyword"
             },
-            "owned_by" : {
-              "properties": {
-                "user": {
-                  "type": "keyword"
-                }
-              }
-            },
             "embargo": {
               "properties": {
                 "active": {
@@ -34,27 +27,45 @@
                   "type": "text"
                 }
               }
+            }
+          }
+        },
+        "parent" : {
+          "properties": {
+            "id" : {
+              "type" : "keyword"
             },
-            "grants": {
-              "properties": {
-                "subject": {
+            "access": {
+              "properties" : {
+                "owned_by" : {
+                  "properties": {
+                    "user": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "grants": {
+                  "properties": {
+                    "subject": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "level": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "grant_tokens": {
                   "type": "keyword"
                 },
-                "id": {
-                  "type": "keyword"
-                },
-                "level": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "grant_tokens": {
-              "type": "keyword"
-            },
-            "links": {
-              "properties": {
-                "id": {
-                  "type": "keyword"
+                "links": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v6/rdmrecords/records/record-v2.0.0.json
@@ -15,13 +15,6 @@
             "files" : {
               "type" : "keyword"
             },
-            "owned_by" : {
-              "properties": {
-                "user": {
-                  "type": "keyword"
-                }
-              }
-            },
             "embargo": {
               "properties": {
                 "active": {
@@ -34,27 +27,45 @@
                   "type": "text"
                 }
               }
+            }
+          }
+        },
+        "parent" : {
+          "properties": {
+            "id" : {
+              "type" : "keyword"
             },
-            "grants": {
-              "properties": {
-                "subject": {
+            "access": {
+              "properties" : {
+                "owned_by" : {
+                  "properties": {
+                    "user": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "grants": {
+                  "properties": {
+                    "subject": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "level": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "grant_tokens": {
                   "type": "keyword"
                 },
-                "id": {
-                  "type": "keyword"
-                },
-                "level": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "grant_tokens": {
-              "type": "keyword"
-            },
-            "links": {
-              "properties": {
-                "id": {
-                  "type": "keyword"
+                "links": {
+                  "properties": {
+                    "id": {
+                      "type": "keyword"
+                    }
+                  }
                 }
               }
             }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v2.0.0.json
@@ -14,13 +14,6 @@
           "files" : {
             "type" : "keyword"
           },
-          "owned_by" : {
-            "properties": {
-              "user": {
-                "type": "keyword"
-              }
-            }
-          },
           "embargo": {
             "properties": {
               "active": {
@@ -33,27 +26,45 @@
                 "type": "text"
               }
             }
+          }
+        }
+      },
+      "parent" : {
+        "properties": {
+          "id" : {
+            "type" : "keyword"
           },
-          "grants": {
-            "properties": {
-              "subject": {
+          "access": {
+            "properties" : {
+              "owned_by" : {
+                "properties": {
+                  "user": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grants": {
+                "properties": {
+                  "subject": {
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "type": "keyword"
+                  },
+                  "level": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grant_tokens": {
                 "type": "keyword"
               },
-              "id": {
-                "type": "keyword"
-              },
-              "level": {
-                "type": "keyword"
-              }
-            }
-          },
-          "grant_tokens": {
-            "type": "keyword"
-          },
-          "links": {
-            "properties": {
-              "id": {
-                "type": "keyword"
+              "links": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v2.0.0.json
@@ -14,13 +14,6 @@
           "files" : {
             "type" : "keyword"
           },
-          "owned_by" : {
-            "properties": {
-              "user": {
-                "type": "keyword"
-              }
-            }
-          },
           "embargo": {
             "properties": {
               "active": {
@@ -33,27 +26,45 @@
                 "type": "text"
               }
             }
+          }
+        }
+      },
+      "parent" : {
+        "properties": {
+          "id" : {
+            "type" : "keyword"
           },
-          "grants": {
-            "properties": {
-              "subject": {
+          "access": {
+            "properties" : {
+              "owned_by" : {
+                "properties": {
+                  "user": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grants": {
+                "properties": {
+                  "subject": {
+                    "type": "keyword"
+                  },
+                  "id": {
+                    "type": "keyword"
+                  },
+                  "level": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "grant_tokens": {
                 "type": "keyword"
               },
-              "id": {
-                "type": "keyword"
-              },
-              "level": {
-                "type": "keyword"
-              }
-            }
-          },
-          "grant_tokens": {
-            "type": "keyword"
-          },
-          "links": {
-            "properties": {
-              "id": {
-                "type": "keyword"
+              "links": {
+                "properties": {
+                  "id": {
+                    "type": "keyword"
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
* the properties 'owned_by', 'grants', 'grant_tokens' and 'links' are no
  longer contained in the record's access, but rather in the record's
  parent access field