### PR TITLE
global: add functionality for reindexing everything

### DIFF
--- a/invenio_rdm_records/cli.py
+++ b/invenio_rdm_records/cli.py
@@ -17,8 +17,11 @@ from faker import Faker
 from flask.cli import with_appcontext
 from flask_principal import Identity
 from invenio_access.permissions import system_identity
+from invenio_vocabularies.proxies import \
+    current_service as current_vocabularies_service
 
 from .fixtures import FixturesEngine
+from .proxies import current_rdm_records
 from .services import RDMDraftFilesService, RDMRecordService
 from .vocabularies import Vocabularies
 
@@ -261,3 +264,20 @@ def create_fixtures():
     FixturesEngine(system_identity).run()
 
     click.secho('Created required fixtures!', fg='green')
+
+
+@rdm_records.command("rebuild-index")
+@with_appcontext
+def rebuild_index():
+    """Reindex all drafts, records and vocabularies."""
+    click.secho("Reindexing records and drafts...", fg="green")
+
+    rec_service = current_rdm_records.records_service
+    rec_service.rebuild_index(identity=system_identity)
+
+    click.secho("Reindexing vocabularies...", fg="green")
+
+    vocab_service = current_vocabularies_service
+    vocab_service.rebuild_index(identity=system_identity)
+
+    click.secho("Reindexed everything!", fg="green")

--- a/invenio_rdm_records/cli.py
+++ b/invenio_rdm_records/cli.py
@@ -15,14 +15,12 @@ import click
 from edtf.parser.grammar import level0Expression
 from faker import Faker
 from flask.cli import with_appcontext
-from flask_principal import Identity
 from invenio_access.permissions import system_identity
 from invenio_vocabularies.proxies import \
     current_service as current_vocabularies_service
 
 from .fixtures import FixturesEngine
 from .proxies import current_rdm_records
-from .services import RDMDraftFilesService, RDMRecordService
 from .vocabularies import Vocabularies
 
 
@@ -226,8 +224,8 @@ def create_fake_record():
         }
     }
 
-    service = RDMRecordService()
-    draft_files_service = RDMDraftFilesService()
+    service = current_rdm_records.records_service
+    draft_files_service = current_rdm_records.draft_files_service
 
     draft = service.create(data=data_to_use, identity=system_identity)
     draft_files_service.update_files_options(


### PR DESCRIPTION
closes #441 
requires https://github.com/inveniosoftware/invenio-drafts-resources/pull/112 and inveniosoftware/invenio-records-resources/pull/211

* add service methods for reindexing records and drafts
* add new CLI command for reindexing everything, using the new service
  methods of the records service and the vocabularies service