### PR TITLE
records: change schemas to use local URI scheme

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -79,6 +79,8 @@ class InvenioRDMRecords(object):
         """Initialize configuration."""
         supported_configurations = [
             'FILES_REST_PERMISSION_FACTORY',
+            'RECORDS_REFRESOLVER_CLS',
+            'RECORDS_REFRESOLVER_STORE',
             'RECORDS_UI_ENDPOINTS',
             'THEME_SITEURL',
         ]

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -45,7 +45,7 @@ class RDMParent(ParentRecordBase):
 
     # System fields
     schema = ConstantField(
-        '$schema', 'http://localhost/schemas/records/parent-v1.0.0.json')
+        '$schema', 'local://records/parent-v1.0.0.json')
 
     access = ParentRecordAccessField()
 
@@ -60,7 +60,7 @@ class CommonFieldsMixin:
     parent_record_cls = RDMParent
 
     schema = ConstantField(
-       '$schema', 'http://localhost/schemas/records/record-v2.0.0.json')
+       '$schema', 'local://records/record-v2.0.0.json')
 
     dumper = ElasticsearchDumper(
         extensions=[

--- a/invenio_rdm_records/records/jsonschemas/records/definitions-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/definitions-v1.0.0.json
@@ -1,0 +1,476 @@
+{
+  "nameType": {
+    "description": "Type of name.",
+    "type": "string",
+    "enum": [
+      "personal",
+      "organizational"
+    ]
+  },
+  "titleType": {
+    "description": "Type of title.",
+    "type": "string"
+  },
+  "contributorType": {
+    "type": "string"
+  },
+  "dateType": {
+    "description": "Type of the date.",
+    "type": "string"
+  },
+  "relationType": {
+    "type": "string"
+  },
+  "descriptionType": {
+    "type": "string"
+  },
+  "language": {
+    "type": "object",
+    "properties": {
+      "id": {
+        "type": "string"
+      }
+    }
+  },
+  "longitude": {
+    "type": "number",
+    "minimum": -180,
+    "maximum": 180
+  },
+  "latitude": {
+    "type": "number",
+    "minimum": -90,
+    "maximum": 90
+  },
+  "scheme": {
+    "description": "A scheme.",
+    "type": "string"
+  },
+  "identifier": {
+    "description": "An identifier.",
+    "type": "string"
+  },
+  "identifiers": {
+    "description": "Identifiers object (keys being scheme, value being the identifier).",
+    "type": "object",
+    "additionalProperties": {
+      "$ref": "#/identifier"
+    }
+  },
+  "identifiers_with_scheme": {
+    "description": "Identifiers object with identifier value and scheme in separate keys.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "identifier": {
+        "$ref": "#/identifier"
+      },
+      "scheme": {
+        "$ref": "#/scheme"
+      }
+    }
+  },
+  "internal-pid": {
+    "type": "object",
+    "description": "An internal persistent identifier object.",
+    "additionalProperties": false,
+    "required": [
+      "pk",
+      "status"
+    ],
+    "properties": {
+      "pk": {
+        "description": "Primary key of the PID object.",
+        "type": "integer"
+      },
+      "status": {
+        "description": "The status of the PID (from Invenio-PIDStore).",
+        "type": "string",
+        "enum": [
+          "N",
+          "K",
+          "R",
+          "M",
+          "D"
+        ]
+      },
+      "pid_type": {
+        "description": "The type of the persistent identifier.",
+        "type": "string"
+      },
+      "obj_type": {
+        "description": "The type of the associated object.",
+        "type": "string"
+      }
+    }
+  },
+  "external-pid": {
+    "type": "object",
+    "description": "An external persistent identifier object.",
+    "additionalProperties": false,
+    "required": [
+      "identifier",
+      "provider"
+    ],
+    "properties": {
+      "identifier": {
+        "$ref": "#/identifier"
+      },
+      "provider": {
+        "description": "The provider of the persistent identifier.",
+        "type": "string"
+      },
+      "client": {
+        "description": "Client identifier for the specific PID.",
+        "type": "string"
+      }
+    }
+  },
+  "resource_type": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A resource type.",
+    "properties": {
+      "type": {
+        "description": "The general resource type identifier.",
+        "type": "string"
+      },
+      "subtype": {
+        "description": "The specific resource type identifier.",
+        "type": "string"
+      }
+    },
+    "required": [
+      "type"
+    ]
+  },
+  "person_or_org": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "type"
+    ],
+    "properties": {
+      "name": {
+        "type": "string"
+      },
+      "type": {
+        "$ref": "#/nameType"
+      },
+      "given_name": {
+        "type": "string"
+      },
+      "family_name": {
+        "type": "string"
+      },
+      "identifiers": {
+        "type": "array",
+        "items": {
+          "$ref": "#/identifiers_with_scheme"
+        },
+        "uniqueItems": true
+      }
+    }
+  },
+  "affiliations": {
+    "type": "array",
+    "uniqueItems": true,
+    "items": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/identifiers_with_scheme"
+          },
+          "uniqueItems": true
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "file": {
+    "type": "object",
+    "additionalProperties": false,
+    "description": "A file object.",
+    "properties": {
+      "version_id": {
+        "description": "Object version ID.",
+        "type": "string"
+      },
+      "bucket_id": {
+        "description": "Object verison bucket ID.",
+        "type": "string"
+      },
+      "mimetype": {
+        "description": "File MIMEType.",
+        "type": "string"
+      },
+      "uri": {
+        "description": "File URI.",
+        "type": "string"
+      },
+      "storage_class": {
+        "description": "File storage class.",
+        "type": "string"
+      },
+      "checksum": {
+        "description": "Checksum of the file.",
+        "type": "string"
+      },
+      "size": {
+        "description": "Size of the file in bytes.",
+        "type": "number"
+      },
+      "key": {
+        "description": "Key (filename) of the file.",
+        "type": "string"
+      },
+      "file_id": {
+        "$ref": "#/identifier"
+      }
+    }
+  },
+  "user": {
+    "type": "object",
+    "description": "..",
+    "additionalProperties": false,
+    "properties": {
+      "user": {
+        "type": "integer"
+      }
+    }
+  },
+  "agent": {
+    "description": "An agent (user, software process, community, ...).",
+    "oneOf": [
+      {
+        "$ref": "#/user"
+      }
+    ]
+  },
+  "GeoJSON-Geometry": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://geojson.org/schema/Geometry.json",
+    "title": "GeoJSON Geometry",
+    "oneOf": [
+      {
+        "title": "GeoJSON Point",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Point"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "number"
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON LineString",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "LineString"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 2,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON Polygon",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Polygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiPoint",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPoint"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiLineString",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiLineString"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      {
+        "title": "GeoJSON MultiPolygon",
+        "type": "object",
+        "required": [
+          "type",
+          "coordinates"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "MultiPolygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "minItems": 4,
+                "items": {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          },
+          "bbox": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/invenio_rdm_records/records/jsonschemas/records/parent-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/parent-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://inveniosoftware.org/schemas/rdm/records/parent-v1.0.0.json",
+  "id": "local://records/parent-v1.0.0.json",
   "title": "InvenioRDM Parent Record Schema v1.0.0",
   "type": "object",
   "additionalProperties": false,

--- a/invenio_rdm_records/records/jsonschemas/records/parent-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/parent-v1.0.0.json
@@ -4,59 +4,6 @@
   "title": "InvenioRDM Parent Record Schema v1.0.0",
   "type": "object",
   "additionalProperties": false,
-
-  "definitions": {
-    "user": {
-      "type": "object",
-      "description": "A user, referenced by their ID",
-      "additionalProperties": false,
-      "properties": {
-        "user": {
-          "type": "integer"
-        }
-      }
-    },
-
-    "agent": {
-      "description": "An agent (user, software process, community, ...).",
-      "oneOf": [
-        {"$ref": "#/definitions/user"}
-      ]
-    },
-
-    "internal-pid": {
-      "type": "object",
-      "description": "An internal persistent identifier object.",
-      "additionalProperties": false,
-      "required": ["pk", "status"],
-      "properties": {
-        "pk": {
-          "description": "Primary key of the PID object.",
-          "type": "integer"
-        },
-        "status": {
-          "description": "The status of the PID (from Invenio-PIDStore).",
-          "type": "string",
-          "enum": [
-            "N",
-            "K",
-            "R",
-            "M",
-            "D"
-          ]
-        },
-        "pid_type": {
-          "description": "The type of the persistent identifier.",
-          "type": "string"
-        },
-        "obj_type": {
-          "description": "The type of the associated object.",
-          "type": "string"
-        }
-      }
-    }
-  },
-
   "properties": {
     "$schema": {
       "description": "JSONSchema declaration.",
@@ -68,7 +15,7 @@
       "type": "string"
     },
 
-    "pid": {"$ref": "#/definitions/internal-pid"},
+    "pid": {"$ref": "local://records/definitions-v1.0.0.json#/internal-pid"},
 
     "access": {
       "type": "object",
@@ -80,7 +27,7 @@
           "description": "List of owners of the child records.",
           "type": "array",
           "uniqueItems": true,
-          "items": {"$ref": "#/definitions/agent"}
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/agent"}
         },
 
         "grants": {

--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://inveniosoftware.org/schemas/rdm/records/record-v1.0.0.json",
+  "id": "local://records/record-v1.0.0.json",
   "title": "InvenioRDM Record Schema v1.0.0",
   "type": "object",
   "additionalProperties": false,

--- a/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v1.0.0.json
@@ -4,470 +4,6 @@
   "title": "InvenioRDM Record Schema v1.0.0",
   "type": "object",
   "additionalProperties": false,
-
-  "definitions": {
-
-    "nameType": {
-      "description": "Type of name.",
-      "type": "string",
-      "enum": [
-        "personal",
-        "organizational"
-      ]
-    },
-
-    "titleType": {
-      "description": "Type of title.",
-      "type": "string"
-    },
-
-    "contributorType": {
-      "type": "string"
-    },
-
-    "dateType": {
-      "description": "Type of the date.",
-      "type": "string"
-    },
-
-    "relationType": {
-      "type": "string"
-    },
-
-    "descriptionType": {
-      "type": "string"
-    },
-
-    "language": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      }
-    },
-
-    "longitude": {
-      "type": "number",
-      "minimum": -180,
-      "maximum": 180
-    },
-
-    "latitude": {
-      "type": "number",
-      "minimum": -90,
-      "maximum": 90
-    },
-
-    "scheme": {
-      "description": "A scheme.",
-      "type": "string"
-    },
-
-    "identifier": {
-      "description": "An identifier.",
-      "type": "string"
-    },
-
-    "identifiers": {
-      "description": "Identifiers object (keys being scheme, value being the identifier).",
-      "type": "object",
-      "additionalProperties": {"$ref": "#/definitions/identifier"}
-    },
-
-    "identifiers_with_scheme": {
-      "description": "Identifiers object with identifier value and scheme in separate keys.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "identifier": {"$ref": "#/definitions/identifier"},
-        "scheme": {"$ref": "#/definitions/scheme"}
-      }
-    },
-
-    "internal-pid": {
-      "type": "object",
-      "description": "An internal persistent identifier object.",
-      "additionalProperties": false,
-      "required": ["pk", "status"],
-      "properties": {
-        "pk": {
-          "description": "Primary key of the PID object.",
-          "type": "integer"
-        },
-        "status": {
-          "description": "The status of the PID (from Invenio-PIDStore).",
-          "type": "string",
-          "enum": [
-            "N",
-            "K",
-            "R",
-            "M",
-            "D"
-          ]
-        },
-        "pid_type": {
-          "description": "The type of the persistent identifier.",
-          "type": "string"
-        },
-        "obj_type": {
-          "description": "The type of the associated object.",
-          "type": "string"
-        }
-      }
-    },
-
-    "external-pid": {
-      "type": "object",
-      "description": "An external persistent identifier object.",
-      "additionalProperties": false,
-      "required": ["identifier", "provider"],
-      "properties": {
-        "identifier": {"$ref": "#/definitions/identifier"},
-        "provider": {
-          "description": "The provider of the persistent identifier.",
-          "type": "string"
-        },
-        "client": {
-          "description": "Client identifier for the specific PID.",
-          "type": "string"
-        }
-      }
-    },
-
-    "resource_type": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "A resource type.",
-      "properties": {
-        "type": {
-          "description": "The general resource type identifier.",
-          "type": "string"
-        },
-        "subtype": {
-          "description": "The specific resource type identifier.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-
-    "person_or_org": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["type"],
-      "properties": {
-        "name": {"type": "string"},
-        "type": {"$ref": "#/definitions/nameType"},
-        "given_name": {"type": "string"},
-        "family_name": {"type": "string"},
-        "identifiers": {
-          "type": "array",
-          "items": {"$ref": "#/definitions/identifiers_with_scheme"},
-          "uniqueItems": true
-        }
-      }
-    },
-
-    "affiliations": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": {"type": "string"},
-            "identifiers": {
-              "type": "array",
-              "items": {"$ref": "#/definitions/identifiers_with_scheme"},
-              "uniqueItems": true
-            }
-          },
-          "required": ["name"]
-      }
-    },
-
-    "file": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "A file object.",
-      "properties": {
-        "version_id": {
-          "description": "Object version ID.",
-          "type": "string"
-        },
-        "bucket_id": {
-          "description": "Object verison bucket ID.",
-          "type": "string"
-        },
-        "mimetype": {
-          "description": "File MIMEType.",
-          "type": "string"
-        },
-        "uri": {
-          "description": "File URI.",
-          "type": "string"
-        },
-        "storage_class": {
-          "description": "File storage class.",
-          "type": "string"
-        },
-        "checksum": {
-          "description": "Checksum of the file.",
-          "type": "string"
-        },
-        "size": {
-          "description": "Size of the file in bytes.",
-          "type": "number"
-        },
-        "key": {
-          "description": "Key (filename) of the file.",
-          "type": "string"
-        },
-        "file_id": {"$ref": "#/definitions/identifier"}
-      }
-    },
-
-    "user": {
-      "type": "object",
-      "description": "..",
-      "additionalProperties": false,
-      "properties": {
-        "user": {
-          "type": "integer"
-        }
-      }
-    },
-
-    "agent": {
-      "description": "An agent (user, software process, community, ...).",
-      "oneOf": [
-        {"$ref": "#/definitions/user"}
-      ]
-    },
-
-    "GeoJSON-Geometry": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://geojson.org/schema/Geometry.json",
-      "title": "GeoJSON Geometry",
-      "oneOf": [
-        {
-          "title": "GeoJSON Point",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "Point"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "minItems": 2,
-              "items": {
-                "type": "number"
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON LineString",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "LineString"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "minItems": 2,
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON Polygon",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "Polygon"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 4,
-                "items": {
-                  "type": "array",
-                  "minItems": 2,
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiPoint",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiPoint"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiLineString",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiLineString"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "array",
-                  "minItems": 2,
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiPolygon",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiPolygon"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "minItems": 4,
-                  "items": {
-                    "type": "array",
-                    "minItems": 2,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
-
   "properties": {
     "$schema": {
       "description": "JSONSchema declaration.",
@@ -477,16 +13,16 @@
       "description": "Persistent record identifier (alphanumeric).",
       "type": "string"
     },
-    "pid": {"$ref": "#/definitions/internal-pid"},
+    "pid": {"$ref": "local://records/definitions-v1.0.0.json#/internal-pid"},
 
     "conceptid": {
       "description": "Persistent concept record identifier (alphanumeric).",
       "type": "string"
     },
-    "conceptpid": {"$ref": "#/definitions/internal-pid"},
+    "conceptpid": {"$ref": "local://records/definitions-v1.0.0.json#/internal-pid"},
 
     "pids": {
-      "additionalProperties": {"$ref": "#/definitions/external-pid"},
+      "additionalProperties": {"$ref": "local://records/definitions-v1.0.0.json#/external-pid"},
       "description": "Managed persistent identifiers for a record including e.g. OAI-PMH identifier, minted DOIs and more. Managed PIDs are registered in the PIDStore"
     },
 
@@ -496,7 +32,7 @@
       "additionalProperties": false,
       "properties": {
 
-        "resource_type": {"$ref": "#/definitions/resource_type"},
+        "resource_type": {"$ref": "local://records/definitions-v1.0.0.json#/resource_type"},
 
         "creators": {
           "description": "Creators of the resource.",
@@ -506,9 +42,9 @@
             "additionalProperties": false,
             "required": ["person_or_org"],
             "properties": {
-                "person_or_org": {"$ref": "#/definitions/person_or_org"},
+                "person_or_org": {"$ref": "local://records/definitions-v1.0.0.json#/person_or_org"},
                 "role": {"type": "string"},
-                "affiliations": {"$ref": "#/definitions/affiliations"}
+                "affiliations": {"$ref": "local://records/definitions-v1.0.0.json#/affiliations"}
             }
           }
         },
@@ -529,8 +65,8 @@
                   "description": "Additional title of the record.",
                   "type": "string"
                 },
-                "type": {"$ref": "#/definitions/titleType"},
-                "lang": {"ref": "#/definitions/language"}
+                "type": {"$ref": "local://records/definitions-v1.0.0.json#/titleType"},
+                "lang": {"ref": "local://records/definitions-v1.0.0.json#/language"}
             }
           }
         },
@@ -551,8 +87,8 @@
               "additionalProperties": false,
               "properties": {
                   "subject": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
               },
               "required": ["subject"]
           }
@@ -566,9 +102,9 @@
             "additionalProperties": false,
             "required": ["person_or_org", "role"],
             "properties": {
-              "person_or_org": {"$ref": "#/definitions/person_or_org"},
-              "role": {"$ref": "#/definitions/contributorType"},
-              "affiliations": {"$ref": "#/definitions/affiliations"}
+              "person_or_org": {"$ref": "local://records/definitions-v1.0.0.json#/person_or_org"},
+              "role": {"$ref": "local://records/definitions-v1.0.0.json#/contributorType"},
+              "affiliations": {"$ref": "local://records/definitions-v1.0.0.json#/affiliations"}
             }
           }
         },
@@ -584,7 +120,7 @@
                 "description": "Date or date interval in EDTF level 0 format",
                 "type": "string"
               },
-              "type": {"$ref": "#/definitions/dateType"},
+              "type": {"$ref": "local://records/definitions-v1.0.0.json#/dateType"},
               "description": {
                 "description": "Description of the date or date interval e.g. 'Accepted' or 'Available' (CV).",
                 "type": "string"
@@ -596,13 +132,13 @@
         "languages": {
           "description": "The primary languages of the resource. ISO 639-3 language code.",
           "type": "array",
-          "items": {"$ref": "#/definitions/language"}
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/language"}
         },
 
         "identifiers": {
           "description": "Alternate identifiers for the record.",
           "type": "array",
-          "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/identifiers_with_scheme"},
           "uniqueItems": true
         },
 
@@ -613,10 +149,10 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "identifier": {"$ref": "#/definitions/identifier"},
-                "scheme": {"$ref": "#/definitions/scheme"},
-                "relation_type": {"$ref": "#/definitions/relationType"},
-                "resource_type": {"$ref": "#/definitions/resource_type"}
+                "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"},
+                "relation_type": {"$ref": "local://records/definitions-v1.0.0.json#/relationType"},
+                "resource_type": {"$ref": "local://records/definitions-v1.0.0.json#/resource_type"}
               }
           }
         },
@@ -647,7 +183,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "id": {"$ref": "#/definitions/identifier"},
+              "id": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
               "title": {
                 "description": "The license name or license itself. Free text.",
                 "type": "string"
@@ -679,8 +215,8 @@
                   "description": "Description for record.",
                   "type": "string"
                 },
-                "type": {"$ref": "#/definitions/descriptionType"},
-                "lang": {"ref": "#/definitions/language"}
+                "type": {"$ref": "local://records/definitions-v1.0.0.json#/descriptionType"},
+                "lang": {"ref": "local://records/definitions-v1.0.0.json#/language"}
             }
           }
         },
@@ -702,7 +238,7 @@
                 "properties": {
                   "geometry": {
                     "allOf": [{
-                      "$ref": "#/definitions/GeoJSON-Geometry"
+                      "$ref": "local://records/definitions-v1.0.0.json#/GeoJSON-Geometry"
                     }, {
                       "$comment": "Bounding boxes (`bbox`) are forbidden on our geometries, even though they're allowed on GeoJSON geometries",
                       "properties": {
@@ -714,7 +250,7 @@
                   },
                   "identifiers": {
                     "type": "array",
-                    "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+                    "items": {"$ref": "local://records/definitions-v1.0.0.json#/identifiers_with_scheme"},
                     "uniqueItems": true
                   },
                   "place": {
@@ -751,8 +287,8 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
                 }
               },
               "award": {
@@ -761,8 +297,8 @@
                 "properties": {
                   "title": {"type": "string"},
                   "number": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
                 }
               }
             }
@@ -780,8 +316,8 @@
                 "type": "string",
                 "description": "A reference string."
               },
-              "identifier": {"$ref": "#/definitions/identifier"},
-              "scheme": {"$ref": "#/definitions/scheme"}
+              "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+              "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
             }
           }
         }
@@ -806,7 +342,7 @@
           "type": "string",
           "description": "Category for the removal."
         },
-        "removed_by": {"$ref": "#/definitions/agent"},
+        "removed_by": {"$ref": "local://records/definitions-v1.0.0.json#/agent"},
         "timestamp": {
           "type": "string",
           "description": "ISO8601 formatted timestamp in UTC.",
@@ -820,8 +356,8 @@
       "description": "Record provenance.",
       "additionalProperties": false,
       "properties": {
-        "created_by": {"$ref": "#/definitions/agent"},
-        "on_behalf_of": {"$ref": "#/definitions/agent"}
+        "created_by": {"$ref": "local://records/definitions-v1.0.0.json#/agent"},
+        "on_behalf_of": {"$ref": "local://records/definitions-v1.0.0.json#/agent"}
       }
     },
 
@@ -848,7 +384,7 @@
           "type": "array",
           "minItems": 1,
           "uniqueItems": true,
-          "items": {"$ref": "#/definitions/agent"}
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/agent"}
         },
 
         "embargo": {
@@ -917,7 +453,7 @@
         },
         "entries": {
           "type": "object",
-          "additionalProperties": {"$ref": "#/definitions/file"}
+          "additionalProperties": {"$ref": "local://records/definitions-v1.0.0.json#/file"}
         },
         "meta": {
           "type": "object",

--- a/invenio_rdm_records/records/jsonschemas/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v2.0.0.json
@@ -4,470 +4,6 @@
   "title": "InvenioRDM Record Schema v2.0.0",
   "type": "object",
   "additionalProperties": false,
-
-  "definitions": {
-
-    "nameType": {
-      "description": "Type of name.",
-      "type": "string",
-      "enum": [
-        "personal",
-        "organizational"
-      ]
-    },
-
-    "titleType": {
-      "description": "Type of title.",
-      "type": "string"
-    },
-
-    "contributorType": {
-      "type": "string"
-    },
-
-    "dateType": {
-      "description": "Type of the date.",
-      "type": "string"
-    },
-
-    "relationType": {
-      "type": "string"
-    },
-
-    "descriptionType": {
-      "type": "string"
-    },
-
-    "language": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        }
-      }
-    },
-
-    "longitude": {
-      "type": "number",
-      "minimum": -180,
-      "maximum": 180
-    },
-
-    "latitude": {
-      "type": "number",
-      "minimum": -90,
-      "maximum": 90
-    },
-
-    "scheme": {
-      "description": "A scheme.",
-      "type": "string"
-    },
-
-    "identifier": {
-      "description": "An identifier.",
-      "type": "string"
-    },
-
-    "identifiers": {
-      "description": "Identifiers object (keys being scheme, value being the identifier).",
-      "type": "object",
-      "additionalProperties": {"$ref": "#/definitions/identifier"}
-    },
-
-    "identifiers_with_scheme": {
-      "description": "Identifiers object with identifier value and scheme in separate keys.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "identifier": {"$ref": "#/definitions/identifier"},
-        "scheme": {"$ref": "#/definitions/scheme"}
-      }
-    },
-
-    "internal-pid": {
-      "type": "object",
-      "description": "An internal persistent identifier object.",
-      "additionalProperties": false,
-      "required": ["pk", "status"],
-      "properties": {
-        "pk": {
-          "description": "Primary key of the PID object.",
-          "type": "integer"
-        },
-        "status": {
-          "description": "The status of the PID (from Invenio-PIDStore).",
-          "type": "string",
-          "enum": [
-            "N",
-            "K",
-            "R",
-            "M",
-            "D"
-          ]
-        },
-        "pid_type": {
-          "description": "The type of the persistent identifier.",
-          "type": "string"
-        },
-        "obj_type": {
-          "description": "The type of the associated object.",
-          "type": "string"
-        }
-      }
-    },
-
-    "external-pid": {
-      "type": "object",
-      "description": "An external persistent identifier object.",
-      "additionalProperties": false,
-      "required": ["identifier", "provider"],
-      "properties": {
-        "identifier": {"$ref": "#/definitions/identifier"},
-        "provider": {
-          "description": "The provider of the persistent identifier.",
-          "type": "string"
-        },
-        "client": {
-          "description": "Client identifier for the specific PID.",
-          "type": "string"
-        }
-      }
-    },
-
-    "resource_type": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "A resource type.",
-      "properties": {
-        "type": {
-          "description": "The general resource type identifier.",
-          "type": "string"
-        },
-        "subtype": {
-          "description": "The specific resource type identifier.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-
-    "person_or_org": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["type"],
-      "properties": {
-        "name": {"type": "string"},
-        "type": {"$ref": "#/definitions/nameType"},
-        "given_name": {"type": "string"},
-        "family_name": {"type": "string"},
-        "identifiers": {
-          "type": "array",
-          "items": {"$ref": "#/definitions/identifiers_with_scheme"},
-          "uniqueItems": true
-        }
-      }
-    },
-
-    "affiliations": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "name": {"type": "string"},
-            "identifiers": {
-              "type": "array",
-              "items": {"$ref": "#/definitions/identifiers_with_scheme"},
-              "uniqueItems": true
-            }
-          },
-          "required": ["name"]
-      }
-    },
-
-    "file": {
-      "type": "object",
-      "additionalProperties": false,
-      "description": "A file object.",
-      "properties": {
-        "version_id": {
-          "description": "Object version ID.",
-          "type": "string"
-        },
-        "bucket_id": {
-          "description": "Object verison bucket ID.",
-          "type": "string"
-        },
-        "mimetype": {
-          "description": "File MIMEType.",
-          "type": "string"
-        },
-        "uri": {
-          "description": "File URI.",
-          "type": "string"
-        },
-        "storage_class": {
-          "description": "File storage class.",
-          "type": "string"
-        },
-        "checksum": {
-          "description": "Checksum of the file.",
-          "type": "string"
-        },
-        "size": {
-          "description": "Size of the file in bytes.",
-          "type": "number"
-        },
-        "key": {
-          "description": "Key (filename) of the file.",
-          "type": "string"
-        },
-        "file_id": {"$ref": "#/definitions/identifier"}
-      }
-    },
-
-    "user": {
-      "type": "object",
-      "description": "A user, referenced by their ID",
-      "additionalProperties": false,
-      "properties": {
-        "user": {
-          "type": "integer"
-        }
-      }
-    },
-
-    "agent": {
-      "description": "An agent (user, software process, community, ...).",
-      "oneOf": [
-        {"$ref": "#/definitions/user"}
-      ]
-    },
-
-    "GeoJSON-Geometry": {
-      "$schema": "http://json-schema.org/draft-07/schema#",
-      "$id": "https://geojson.org/schema/Geometry.json",
-      "title": "GeoJSON Geometry",
-      "oneOf": [
-        {
-          "title": "GeoJSON Point",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "Point"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "minItems": 2,
-              "items": {
-                "type": "number"
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON LineString",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "LineString"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "minItems": 2,
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON Polygon",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "Polygon"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 4,
-                "items": {
-                  "type": "array",
-                  "minItems": 2,
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiPoint",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiPoint"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiLineString",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiLineString"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "array",
-                  "minItems": 2,
-                  "items": {
-                    "type": "number"
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        },
-        {
-          "title": "GeoJSON MultiPolygon",
-          "type": "object",
-          "required": [
-            "type",
-            "coordinates"
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "enum": [
-                "MultiPolygon"
-              ]
-            },
-            "coordinates": {
-              "type": "array",
-              "items": {
-                "type": "array",
-                "items": {
-                  "type": "array",
-                  "minItems": 4,
-                  "items": {
-                    "type": "array",
-                    "minItems": 2,
-                    "items": {
-                      "type": "number"
-                    }
-                  }
-                }
-              }
-            },
-            "bbox": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "type": "number"
-              }
-            }
-          }
-        }
-      ]
-    }
-  },
-
   "properties": {
     "$schema": {
       "description": "JSONSchema declaration.",
@@ -477,10 +13,10 @@
       "description": "Persistent record identifier (alphanumeric).",
       "type": "string"
     },
-    "pid": {"$ref": "#/definitions/internal-pid"},
+    "pid": {"$ref": "local://records/definitions-v1.0.0.json#/internal-pid"},
 
     "pids": {
-      "additionalProperties": {"$ref": "#/definitions/external-pid"},
+      "additionalProperties": {"$ref": "local://records/definitions-v1.0.0.json#/external-pid"},
       "description": "Managed persistent identifiers for a record including e.g. OAI-PMH identifier, minted DOIs and more. Managed PIDs are registered in the PIDStore"
     },
 
@@ -490,7 +26,7 @@
       "additionalProperties": false,
       "properties": {
 
-        "resource_type": {"$ref": "#/definitions/resource_type"},
+        "resource_type": {"$ref": "local://records/definitions-v1.0.0.json#/resource_type"},
 
         "creators": {
           "description": "Creators of the resource.",
@@ -500,9 +36,9 @@
             "additionalProperties": false,
             "required": ["person_or_org"],
             "properties": {
-                "person_or_org": {"$ref": "#/definitions/person_or_org"},
+                "person_or_org": {"$ref": "local://records/definitions-v1.0.0.json#/person_or_org"},
                 "role": {"type": "string"},
-                "affiliations": {"$ref": "#/definitions/affiliations"}
+                "affiliations": {"$ref": "local://records/definitions-v1.0.0.json#/affiliations"}
             }
           }
         },
@@ -523,8 +59,8 @@
                   "description": "Additional title of the record.",
                   "type": "string"
                 },
-                "type": {"$ref": "#/definitions/titleType"},
-                "lang": {"ref": "#/definitions/language"}
+                "type": {"$ref": "local://records/definitions-v1.0.0.json#/titleType"},
+                "lang": {"ref": "local://records/definitions-v1.0.0.json#/language"}
             }
           }
         },
@@ -545,8 +81,8 @@
               "additionalProperties": false,
               "properties": {
                   "subject": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
               },
               "required": ["subject"]
           }
@@ -560,9 +96,9 @@
             "additionalProperties": false,
             "required": ["person_or_org", "role"],
             "properties": {
-              "person_or_org": {"$ref": "#/definitions/person_or_org"},
-              "role": {"$ref": "#/definitions/contributorType"},
-              "affiliations": {"$ref": "#/definitions/affiliations"}
+              "person_or_org": {"$ref": "local://records/definitions-v1.0.0.json#/person_or_org"},
+              "role": {"$ref": "local://records/definitions-v1.0.0.json#/contributorType"},
+              "affiliations": {"$ref": "local://records/definitions-v1.0.0.json#/affiliations"}
             }
           }
         },
@@ -578,7 +114,7 @@
                 "description": "Date or date interval in EDTF level 0 format",
                 "type": "string"
               },
-              "type": {"$ref": "#/definitions/dateType"},
+              "type": {"$ref": "local://records/definitions-v1.0.0.json#/dateType"},
               "description": {
                 "description": "Description of the date or date interval e.g. 'Accepted' or 'Available' (CV).",
                 "type": "string"
@@ -590,13 +126,13 @@
         "languages": {
           "description": "The primary languages of the resource. ISO 639-3 language code.",
           "type": "array",
-          "items": {"$ref": "#/definitions/language"}
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/language"}
         },
 
         "identifiers": {
           "description": "Alternate identifiers for the record.",
           "type": "array",
-          "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+          "items": {"$ref": "local://records/definitions-v1.0.0.json#/identifiers_with_scheme"},
           "uniqueItems": true
         },
 
@@ -607,10 +143,10 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "identifier": {"$ref": "#/definitions/identifier"},
-                "scheme": {"$ref": "#/definitions/scheme"},
-                "relation_type": {"$ref": "#/definitions/relationType"},
-                "resource_type": {"$ref": "#/definitions/resource_type"}
+                "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"},
+                "relation_type": {"$ref": "local://records/definitions-v1.0.0.json#/relationType"},
+                "resource_type": {"$ref": "local://records/definitions-v1.0.0.json#/resource_type"}
               }
           }
         },
@@ -641,7 +177,7 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
-              "id": {"$ref": "#/definitions/identifier"},
+              "id": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
               "title": {
                 "description": "The license name or license itself. Free text.",
                 "type": "string"
@@ -673,8 +209,8 @@
                   "description": "Description for record.",
                   "type": "string"
                 },
-                "type": {"$ref": "#/definitions/descriptionType"},
-                "lang": {"ref": "#/definitions/language"}
+                "type": {"$ref": "local://records/definitions-v1.0.0.json#/descriptionType"},
+                "lang": {"ref": "local://records/definitions-v1.0.0.json#/language"}
             }
           }
         },
@@ -696,7 +232,7 @@
                 "properties": {
                   "geometry": {
                     "allOf": [{
-                      "$ref": "#/definitions/GeoJSON-Geometry"
+                      "$ref": "local://records/definitions-v1.0.0.json#/GeoJSON-Geometry"
                     }, {
                       "$comment": "Bounding boxes (`bbox`) are forbidden on our geometries, even though they're allowed on GeoJSON geometries",
                       "properties": {
@@ -708,7 +244,7 @@
                   },
                   "identifiers": {
                     "type": "array",
-                    "items": {"$ref": "#/definitions/identifiers_with_scheme"},
+                    "items": {"$ref": "local://records/definitions-v1.0.0.json#/identifiers_with_scheme"},
                     "uniqueItems": true
                   },
                   "place": {
@@ -745,8 +281,8 @@
                 "additionalProperties": false,
                 "properties": {
                   "name": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
                 }
               },
               "award": {
@@ -755,8 +291,8 @@
                 "properties": {
                   "title": {"type": "string"},
                   "number": {"type": "string"},
-                  "identifier": {"$ref": "#/definitions/identifier"},
-                  "scheme": {"$ref": "#/definitions/scheme"}
+                  "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+                  "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
                 }
               }
             }
@@ -774,8 +310,8 @@
                 "type": "string",
                 "description": "A reference string."
               },
-              "identifier": {"$ref": "#/definitions/identifier"},
-              "scheme": {"$ref": "#/definitions/scheme"}
+              "identifier": {"$ref": "local://records/definitions-v1.0.0.json#/identifier"},
+              "scheme": {"$ref": "local://records/definitions-v1.0.0.json#/scheme"}
             }
           }
         }
@@ -800,7 +336,7 @@
           "type": "string",
           "description": "Category for the removal."
         },
-        "removed_by": {"$ref": "#/definitions/agent"},
+        "removed_by": {"$ref": "local://records/definitions-v1.0.0.json#/agent"},
         "timestamp": {
           "type": "string",
           "description": "ISO8601 formatted timestamp in UTC.",
@@ -814,8 +350,8 @@
       "description": "Record provenance.",
       "additionalProperties": false,
       "properties": {
-        "created_by": {"$ref": "#/definitions/agent"},
-        "on_behalf_of": {"$ref": "#/definitions/agent"}
+        "created_by": {"$ref": "local://records/definitions-v1.0.0.json#/agent"},
+        "on_behalf_of": {"$ref": "local://records/definitions-v1.0.0.json#/agent"}
       }
     },
 
@@ -881,7 +417,7 @@
         },
         "entries": {
           "type": "object",
-          "additionalProperties": {"$ref": "#/definitions/file"}
+          "additionalProperties": {"$ref": "local://records/definitions-v1.0.0.json#/file"}
         },
         "meta": {
           "type": "object",

--- a/invenio_rdm_records/records/jsonschemas/records/record-v2.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v2.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "id": "https://inveniosoftware.org/schemas/rdm/records/record-v2.0.0.json",
+  "id": "local://records/record-v2.0.0.json",
   "title": "InvenioRDM Record Schema v2.0.0",
   "type": "object",
   "additionalProperties": false,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ install_requires = [
     'Faker>=2.0.3',
     'ftfy>=4.4.3,<5.0.0',
     'invenio-drafts-resources>=0.11.1,<0.12.0',
-    'invenio-vocabularies>=0.5.1,<0.6.0',
+    'invenio-vocabularies>=0.5.2,<0.6.0',
     'pytz>=2020.4',
     'pyyaml>=5.4.0',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,12 +46,17 @@ def app_config(app_config):
     supported_configurations = [
         'FILES_REST_PERMISSION_FACTORY',
         'PIDSTORE_RECID_FIELD',
+        'RECORDS_PERMISSIONS_RECORD_POLICY',
         'RECORDS_REST_ENDPOINTS',
-        'RECORDS_PERMISSIONS_RECORD_POLICY'
     ]
 
     for config_key in supported_configurations:
         app_config[config_key] = getattr(config, config_key, None)
+
+    app_config['RECORDS_REFRESOLVER_CLS'] = \
+        "invenio_records.resolver.InvenioRefResolver"
+    app_config['RECORDS_REFRESOLVER_STORE'] = \
+        "invenio_jsonschemas.proxies.current_refresolver_store"
 
     return app_config
 

--- a/tests/records/full-record.json
+++ b/tests/records/full-record.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://localhost/schemas/records/record-v1.0.0.json",
+  "$schema": "local://records/record-v1.0.0.json",
   "id": "abcde-12345",
   "pid": {
     "pk": 1,

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -23,7 +23,7 @@ from invenio_rdm_records.records.api import RDMRecord as Record
 #
 def validates(data):
     """Assertion function used to validate according to the schema."""
-    data["$schema"] = "https://localhost/schemas/records/record-v1.0.0.json"
+    data["$schema"] = "local://records/record-v1.0.0.json"
     Record(data).validate()
     return True
 

--- a/tests/records/tombstone.json
+++ b/tests/records/tombstone.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://localhost/schemas/records/record-v1.0.0.json",
+  "$schema": "local://records/record-v1.0.0.json",
   "id": "abcde-12345",
   "pid": {
     "pk": 1,


### PR DESCRIPTION
Closes #356.

### Test

To test you need to install in the same virtual environment the following packages/PRs:
```
~/invenio-vocabularies/ $ gh pr checkout 31
~/invenio-vocabularies/ $ cd invenio-rdm-records
~/invenio-rdm-records/ $ pyenv virtualenv 3.8.6 i-rdm-records
~/invenio-rdm-records/ $ pip install -e ".[all,elasticsearch7,postgresql]"
~/invenio-rdm-records/ $ ./run-tests.sh
```

Passing locally ✅

