### PR TITLE
schemas: raise on additional fields to schemas [+]

### DIFF
--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -16,14 +16,14 @@ from flask_babelex import gettext as _
 from invenio_i18n.ext import current_i18n
 # TODO
 # from invenio_vocabularies.api import VocabularyRegistry
-from marshmallow import INCLUDE, Schema, fields, missing
+from marshmallow import Schema, fields, missing
 from marshmallow_utils.fields import FormatDate as FormatDate_
 from marshmallow_utils.fields import FormatEDTF as FormatEDTF_
 from marshmallow_utils.fields import StrippedHTML
 
 from invenio_rdm_records.vocabularies import Vocabularies
 
-from .fields import VocabularyField, VocabularyTitleField
+from .fields import VocabularyTitleField
 
 # Partial to make short definitions in below schema.
 FormatEDTF = partial(FormatEDTF_, locale=get_locale)
@@ -151,11 +151,6 @@ class UIObjectSchema(Schema):
 # List schema
 class UIListSchema(Schema):
     """Schema for dumping extra information in the UI."""
-
-    class Meta:
-        """."""
-
-        unknown = INCLUDE
 
     hits = fields.Method('get_hits')
     aggregations = fields.Method('get_aggs')

--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -10,7 +10,7 @@
 """RDM record schemas."""
 
 from invenio_drafts_resources.services.records.schema import RecordSchema
-from marshmallow import EXCLUDE, fields, post_dump
+from marshmallow import fields, post_dump
 from marshmallow_utils.fields import NestedAttribute
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
@@ -23,12 +23,6 @@ from .versions import VersionsSchema
 
 class RDMRecordSchema(RecordSchema, FieldPermissionsMixin):
     """Record schema."""
-
-    class Meta:
-        """Meta class."""
-
-        # TODO: RAISE instead!
-        unknown = EXCLUDE
 
     field_load_permissions = {
         'access': 'manage',

--- a/invenio_rdm_records/services/schemas/communities.py
+++ b/invenio_rdm_records/services/schemas/communities.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """RDM record schemas."""
 
-from marshmallow import INCLUDE, Schema, fields
+from marshmallow import Schema, fields
 from marshmallow_utils.fields import SanitizedUnicode
 
 

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -13,8 +13,8 @@ from functools import partial
 from urllib import parse
 
 from flask_babelex import lazy_gettext as _
-from marshmallow import EXCLUDE, INCLUDE, Schema, ValidationError, fields, \
-    post_load, validate, validates_schema
+from marshmallow import Schema, ValidationError, fields, post_load, validate, \
+    validates_schema
 from marshmallow_utils.fields import EDTFDateString, IdentifierSet, \
     ISOLangString, SanitizedHTML, SanitizedUnicode
 from marshmallow_utils.schemas import GeometryObjectSchema, IdentifierSchema
@@ -428,11 +428,6 @@ class LocationSchema(Schema):
 class LanguageSchema(Schema):
     """Language schema."""
 
-    class Meta:
-        """Meta class to discard unknown fields."""
-
-        unknown = EXCLUDE
-
     id = SanitizedUnicode(required=True)
     title = fields.Raw(dump_only=True)
     description = fields.Raw(dump_only=True)
@@ -448,11 +443,6 @@ class MetadataSchema(Schema):
     field_dump_permissions = {
         # TODO: define "can_admin" action
     }
-
-    class Meta:
-        """Meta class to accept unknwon fields."""
-
-        unknown = INCLUDE
 
     # Metadata fields
     resource_type = ResourceType(required=True)

--- a/invenio_rdm_records/services/schemas/parent/__init__.py
+++ b/invenio_rdm_records/services/schemas/parent/__init__.py
@@ -8,7 +8,7 @@
 """RDM parent record schema."""
 
 from invenio_drafts_resources.services.records.schema import ParentSchema
-from marshmallow import EXCLUDE, fields
+from marshmallow import fields
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
 from .access import ParentAccessSchema
@@ -16,12 +16,6 @@ from .access import ParentAccessSchema
 
 class RDMParentSchema(ParentSchema, FieldPermissionsMixin):
     """Record schema."""
-
-    class Meta:
-        """Meta class."""
-
-        # TODO: RAISE instead!
-        unknown = EXCLUDE
 
     # omit the 'access' field from dumps, except for users with
     # 'manage' permissions

--- a/invenio_rdm_records/services/schemas/pids.py
+++ b/invenio_rdm_records/services/schemas/pids.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
-# Copyright (C) 2020 Northwestern University.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2021 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """RDM record schemas."""
 
-from marshmallow import INCLUDE, Schema, fields, validate
+from marshmallow import Schema, fields
 
 
 #

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -151,6 +151,26 @@ def test_create_partial_draft(
     assert errors == response.json["errors"]
 
 
+def test_create_draft_w_extra_fields_reports_error_doesnt_save_field(
+    client_with_login, location, minimal_record, headers, es_clear
+):
+    """Extra fields are reported in errors but not saved."""
+    client = client_with_login
+    minimal_record["foo"] = "FOO!"
+
+    response = client.post("/records", json=minimal_record, headers=headers)
+
+    assert response.status_code == 201
+    assert "foo" not in response.json
+    errors = [
+        {
+            "field": "foo",
+            "messages": ["Unknown field."]
+        }
+    ]
+    assert errors == response.json["errors"]
+
+
 def test_read_draft(
     client_with_login, location, minimal_record, headers, es_clear
 ):

--- a/tests/services/schemas/test_metadata.py
+++ b/tests/services/schemas/test_metadata.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019-2020 CERN.
-# Copyright (C) 2019-2020 Northwestern University.
+# Copyright (C) 2019-2021 CERN.
+# Copyright (C) 2019-2021 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Tests for Invenio RDM Records MetadataSchema."""
 
-from copy import deepcopy
-
 import pytest
-from marshmallow import Schema, ValidationError, fields
+from marshmallow import ValidationError
 from marshmallow.fields import Bool, Integer, List
 from marshmallow_utils.fields import ISODateString, SanitizedUnicode
 
@@ -120,3 +118,11 @@ def test_minimal_metadata_schema(
     metadata = MetadataSchema().load(minimal_metadata)
 
     assert expected_minimal_metadata == metadata
+
+
+def test_additional_field_raises(vocabulary_clear, minimal_metadata):
+
+    minimal_metadata["foo"] = "FOO"
+
+    with pytest.raises(ValidationError):
+        MetadataSchema().load(minimal_metadata)


### PR DESCRIPTION
closes #496 

Although there was worry about making sure we don't
accept additional fields everywhere, it turns out that
the default is `unknown = RAISE` for any marshmallow Schema.

Some tests were added, but I didn't bother with adding
tests everywhere since this is functionality provided
by marshmallow.

Also note that `unknown` only applies to `load`. So it didn't really make sense for the UISchema which only dumps :).