### PR TITLE
records: ensure files cannot be manipulated

### DIFF
--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -125,6 +125,7 @@ class RDMRecordResourceConfig(RecordResourceConfig):
 class RDMRecordFilesResourceConfig(FileResourceConfig):
     """Bibliographic record files resource config."""
 
+    allow_upload = False
     blueprint_name = "record_files"
     url_prefix = "/records/<pid_value>"
 

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -168,6 +168,7 @@ class RDMFileDraftServiceConfig(FileServiceConfig):
     """Configuration for draft files."""
 
     record_cls = RDMDraft
+    permission_action_prefix = "draft_"
     permission_policy_cls = RDMRecordPermissionPolicy
 
     file_links_list = {

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -57,10 +57,6 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_publish = [RecordOwners(), SystemProcess()]
 
     # Files
-    # TODO: Revisit to distinguish between record files permissions and draft
-    #       files permissions. As it is right now, there is no distinction
-    #       in permission requirements between the two.
-    # Record - files
     # For now, can_read_files means:
     # - can list files
     # - can read a file metadata
@@ -79,9 +75,16 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
         SystemProcess(),
         SecretLinks("read_files"),
     ]
-    # Draft - files
-    # create_files is for 3-step file upload
-    can_create_files = [RecordOwners(), SystemProcess()]
+
+    # Records - files
+    can_create_files = [Disable()]
     # update_files is for updating files options
-    can_update_files = [RecordOwners(), SystemProcess()]
-    can_delete_files = [RecordOwners(), SystemProcess()]
+    can_update_files = [Disable()]
+    can_delete_files = [Disable()]
+
+    # Drafts - files
+    # create_files is for 3-step file upload
+    can_draft_create_files = [RecordOwners(), SystemProcess()]
+    # update_files is for updating files options
+    can_draft_update_files = [RecordOwners(), SystemProcess()]
+    can_draft_delete_files = [RecordOwners(), SystemProcess()]

--- a/tests/resources/test_record_file_permissions.py
+++ b/tests/resources/test_record_file_permissions.py
@@ -149,3 +149,72 @@ def test_only_owners_can_download_restricted_file(
     login_user(client, users[0])
     response = client.get(url, headers=headers)
     assert response.status_code == 200
+
+
+def test_record_files_cannot_be_deleted(
+        client, headers, record_w_restricted_file, users):
+    recid = record_w_restricted_file
+    url = f"/records/{recid}/files/test.pdf"
+
+    # Anonymous user can't delete a file
+    response = client.delete(url, headers=headers)
+    assert response.status_code == 405
+
+    # Different user can't delete file
+    login_user(client, users[1])
+    response = client.delete(url, headers=headers)
+    assert response.status_code == 405
+    logout_user(client)
+
+    # Owner can't delete a file
+    login_user(client, users[0])
+    response = client.delete(url, headers=headers)
+    assert response.status_code == 405
+
+
+def test_files_cannot_be_uploaded_to_records(
+        client, headers, record_w_restricted_file, users):
+    recid = record_w_restricted_file
+    url = f"/records/{recid}/files"
+
+    # Anonymous user can't upload a file
+    response = client.post(url, headers=headers, json=[{'key': 'test.pdf'}])
+    assert response.status_code == 405
+
+    # Different user can't upload a file
+    login_user(client, users[1])
+    response = client.post(url, headers=headers, json=[{'key': 'test.pdf'}])
+    assert response.status_code == 405
+    logout_user(client)
+
+    # Owner can't upload a file
+    login_user(client, users[0])
+    response = client.post(url, headers=headers, json=[{'key': 'test.pdf'}])
+    assert response.status_code == 405
+
+
+def test_record_files_options_cannot_be_modified(
+        client, headers, record_w_restricted_file, users):
+    recid = record_w_restricted_file
+    url = f"/records/{recid}/files"
+
+    # Anonymous user can't modify record file options
+    response = client.put(
+        url, headers=headers, json=[{'default_preview': 'test.pdf'}]
+    )
+    assert response.status_code == 405
+
+    # Different user can't modify record file options
+    login_user(client, users[1])
+    response = client.put(
+        url, headers=headers, json=[{'default_preview': 'test.pdf'}]
+    )
+    assert response.status_code == 405
+    logout_user(client)
+
+    # Owner can't modify record file options
+    login_user(client, users[0])
+    response = client.put(
+        url, headers=headers, json=[{'default_preview': 'test.pdf'}]
+    )
+    assert response.status_code == 405


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/498
- Prevent file manipulations on record resource
- Support differentiated permissions for drafts and records

Tests are failing since it depends on https://github.com/inveniosoftware/invenio-rdm-records/pull/505 PR