### PR TITLE
service: migrate to new IdentifierScheme API and enable skip tests

### DIFF
--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -84,7 +84,8 @@ class RDMRecordSchema(RecordSchema, FieldPermissionsMixin):
     #     for scheme, pid_attrs in value.items():
     #         # The required flag applies to the identifier value
     #         # It won't fail for empty allowing the components to reserve one
-    #         id_schema = IdentifierSchema(allow_all=True, required=True)
+    #         id_schema = IdentifierSchema(
+    #             fail_on_unknown=False, identifier_required=True)
     #         id_schema.load({
     #             "scheme": scheme,
     #             "identifier": pid_attrs.get("identifier")

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -37,7 +37,7 @@ class AffiliationSchema(Schema):
 
     name = SanitizedUnicode(required=True)
     identifiers = IdentifierSet(
-        fields.Nested(partial(IdentifierSchema, allow_all=True)),
+        fields.Nested(IdentifierSchema),
     )
 
 
@@ -216,7 +216,8 @@ class RightsSchema(IdentifierSchema):
 
     def __init__(self, **kwargs):
         """Constructor."""
-        super().__init__(allow_all=True, required=False, **kwargs)
+        super().__init__(
+            fail_on_unknown=False, identifier_required=False, **kwargs)
 
     id = SanitizedUnicode()
     title = SanitizedUnicode()
@@ -231,7 +232,8 @@ class SubjectSchema(IdentifierSchema):
 
     def __init__(self, **kwargs):
         """Constructor."""
-        super().__init__(allow_all=True, required=False, **kwargs)
+        super().__init__(
+            fail_on_unknown=False, identifier_required=False, **kwargs)
 
     subject = SanitizedUnicode(required=True)
 
@@ -338,7 +340,8 @@ class FunderSchema(IdentifierSchema):
 
     def __init__(self, **kwargs):
         """Constructor."""
-        super().__init__(allow_all=True, required=False, **kwargs)
+        super().__init__(
+            fail_on_unknown=False, identifier_required=False, **kwargs)
 
     name = SanitizedUnicode(
         required=True,
@@ -351,7 +354,8 @@ class AwardSchema(IdentifierSchema):
 
     def __init__(self, **kwargs):
         """Constructor."""
-        super().__init__(allow_all=True, required=False, **kwargs)
+        super().__init__(
+            fail_on_unknown=False, identifier_required=False, **kwargs)
 
     title = SanitizedUnicode(
         required=True,
@@ -392,7 +396,7 @@ class ReferenceSchema(IdentifierSchema):
     def __init__(self, **kwargs):
         """Constructor."""
         super().__init__(allowed_schemes=self.SCHEMES,
-                         required=False, **kwargs)
+                         identifier_required=False, **kwargs)
 
     reference = SanitizedUnicode(required=True)
 
@@ -410,7 +414,7 @@ class LocationSchema(Schema):
     geometry = fields.Nested(GeometryObjectSchema)
     place = SanitizedUnicode()
     identifiers = fields.List(
-        fields.Nested(partial(IdentifierSchema, allow_all=True)),
+        fields.Nested(partial(IdentifierSchema, fail_on_unknown=False)),
     )
     description = SanitizedUnicode()
 
@@ -463,7 +467,7 @@ class MetadataSchema(Schema):
     languages = fields.List(fields.Nested(LanguageSchema))
     # alternate identifiers
     identifiers = IdentifierSet(
-        fields.Nested(partial(IdentifierSchema, allow_all=True))
+        fields.Nested(partial(IdentifierSchema, fail_on_unknown=False))
     )
     related_identifiers = fields.List(fields.Nested(RelatedIdentifierSchema))
     sizes = fields.List(SanitizedUnicode(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,10 +180,10 @@ def full_record(users):
             ],
             "version": "v1.0",
             "rights": [{
-                "rights": "Creative Commons Attribution 4.0 International",
+                "title": "Creative Commons Attribution 4.0 International",
                 "scheme": "spdx",
                 "identifier": "cc-by-4.0",
-                "url": "https://creativecommons.org/licenses/by/4.0/"
+                "link": "https://creativecommons.org/licenses/by/4.0/"
             }],
             "description": "Test",
             "additional_descriptions": [{
@@ -192,12 +192,21 @@ def full_record(users):
                 "lang": "eng"
             }],
             "locations": [{
-                "point": {
-                    "lat": 1,
-                    "lon": 2
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [-32.94682, -60.63932]
                 },
-                "place": "home",
-                "description": "test"
+                "place": "test location place",
+                "description": "test location description",
+                "identifiers": [
+                    {
+                        "identifier": "12345abcde",
+                        "scheme": "wikidata"
+                    }, {
+                        "identifier": "12345abcde",
+                        "scheme": "geonames"
+                    }
+                ],
             }],
             "funding": [{
                 "funder": {
@@ -214,8 +223,8 @@ def full_record(users):
             }],
             "references": [{
                 "reference": "Nielsen et al,..",
-                "identifier": "101.234",
-                "scheme": "doi"
+                "identifier": "0000 0001 1456 7559",
+                "scheme": "isni"
             }]
         },
         "ext": {

--- a/tests/services/schemas/conftest.py
+++ b/tests/services/schemas/conftest.py
@@ -14,6 +14,12 @@ import pytest
 
 
 @pytest.fixture(scope="function")
+def full_metadata(full_record):
+    """Fixture for full incoming valid metdata."""
+    return full_record["metadata"]
+
+
+@pytest.fixture(scope="function")
 def minimal_metadata(minimal_record):
     """Fixture for minimal incoming valid metdata."""
     return minimal_record["metadata"]

--- a/tests/services/schemas/test_creator_contributor.py
+++ b/tests/services/schemas/test_creator_contributor.py
@@ -211,12 +211,9 @@ def test_creator_invalid_identifiers_scheme():
 
     # Check returns the 3 schemes (org + personal)
     # because the scheme-per-type check comes later on
-    assert_raises_messages(
-        lambda: PersonOrOrganizationSchema().load(invalid_scheme),
-        {'identifiers': {0: {'_schema': [
-            'Invalid identifier format or scheme.'
-        ]}}}
-    )
+    loaded = PersonOrOrganizationSchema().load(invalid_scheme)
+    # Check that the scheme type was force by the backend
+    assert loaded["identifiers"][0]["scheme"] == "orcid"
 
 
 def test_creator_invalid_identifiers_orcid():
@@ -231,12 +228,9 @@ def test_creator_invalid_identifiers_orcid():
         }]
     }
 
-    assert_raises_messages(
-        lambda: PersonOrOrganizationSchema().load(invalid_orcid_identifier),
-        {'identifiers': {0: {'_schema': [
-            'Invalid identifier format or scheme.'
-        ]}}}
-    )
+    loaded = PersonOrOrganizationSchema().load(invalid_orcid_identifier)
+    # Check that the scheme type was force by the backend
+    assert loaded["identifiers"][0]["scheme"] == "gnd"
 
 
 def test_creator_invalid_identifiers_ror():
@@ -249,12 +243,9 @@ def test_creator_invalid_identifiers_ror():
         }]
     }
 
-    assert_raises_messages(
-        lambda: PersonOrOrganizationSchema().load(invalid_ror_identifier),
-        {'identifiers': {0: {'_schema': [
-            'Invalid identifier format or scheme.'
-        ]}}}
-    )
+    loaded = PersonOrOrganizationSchema().load(invalid_ror_identifier)
+    # Check that the scheme type was force by the backend
+    assert loaded["identifiers"][0]["scheme"] == "gnd"
 
 
 def test_contributor_person_valid_full(vocabulary_clear):

--- a/tests/services/schemas/test_location.py
+++ b/tests/services/schemas/test_location.py
@@ -14,16 +14,6 @@ from invenio_rdm_records.services.schemas.metadata import LocationSchema, \
     MetadataSchema
 
 
-# FIXME: Add identifiers when idutils can validate them
-# "identifiers": [
-#     {
-#         "identifier": "12345abcde",
-#         "scheme": "wikidata"
-#     }, {
-#         "identifier": "12345abcde",
-#         "scheme": "geonames"
-#     }
-# ],
 @pytest.fixture(scope="function")
 def valid_full_location():
     """Input data (as coming from the view layer)."""
@@ -33,7 +23,16 @@ def valid_full_location():
             "coordinates": [-32.94682, -60.63932]
         },
         "place": "test location place",
-        "description": "test location description"
+        "description": "test location description",
+        "identifiers": [
+            {
+                "identifier": "12345abcde",
+                "scheme": "wikidata"
+            }, {
+                "identifier": "12345abcde",
+                "scheme": "geonames"
+            }
+        ],
     }
 
 
@@ -41,12 +40,11 @@ def test_valid_full(valid_full_location):
     assert valid_full_location == LocationSchema().load(valid_full_location)
 
 
-# FIXME: Removed this case due to idutils lack of validation for schemes...
-# ({"identifiers": [{"identifier": "12345abcde", "scheme": "wikidata"}]})
 @pytest.mark.parametrize("valid_minimal_location", [
     ({"geometry": {"type": "Point", "coordinates": [-32.94682, -60.63932]}}),
     ({"description": "test location description"}),
     ({"place": "test location place"}),
+    ({"identifiers": [{"identifier": "12345abcde", "scheme": "wikidata"}]})
 ])
 def test_valid_minimal(valid_minimal_location):
     assert valid_minimal_location == \
@@ -73,7 +71,6 @@ def test_invalid_empty(valid_full_location):
         data = LocationSchema().load({})
 
 
-@pytest.mark.skip(reason="idutils cannot validate geonames, wikidata, etc.")
 def test_valid_single_location(app, minimal_record, valid_full_location):
     metadata = minimal_record['metadata']
     # NOTE: this is done to get possible load transformations out of the way
@@ -83,7 +80,6 @@ def test_valid_single_location(app, minimal_record, valid_full_location):
     assert metadata == MetadataSchema().load(metadata)
 
 
-@pytest.mark.skip(reason="idutils cannot validate geonames, wikidata, etc.")
 def test_valid_multiple_locations(app, minimal_record, valid_full_location):
     metadata = minimal_record['metadata']
     # NOTE: this is done to get possible load transformations out of the way

--- a/tests/services/schemas/test_metadata.py
+++ b/tests/services/schemas/test_metadata.py
@@ -104,12 +104,12 @@ def test_extensions(app, minimal_record):
     )
 
 
-@pytest.mark.skip()
-def test_full_metadata_schema(vocabulary_clear, full_record):
+def test_full_metadata_schema(vocabulary_clear, full_metadata):
     """Test metadata schema."""
     # Test full attributes
-    data = MetadataSchema().load(full_record)
-    assert data == full_record
+
+    data = MetadataSchema().load(full_metadata)
+    assert data == full_metadata
 
 
 def test_minimal_metadata_schema(

--- a/tests/services/schemas/test_rdm_record_schema.py
+++ b/tests/services/schemas/test_rdm_record_schema.py
@@ -40,7 +40,7 @@ def test_valid_external(app, db, minimal_record, location):
     assert valid_full == RDMRecordSchema().load(minimal_record)["pids"]
 
 
-@pytest.mark.skip("Non idutils pid types are not supported yet")
+@pytest.mark.skip("PIDS-FIXME re-enable")
 def test_valid_unknown_scheme(app, db, minimal_record, location):
     valid_full = {
         "rand-unknown": {
@@ -54,6 +54,7 @@ def test_valid_unknown_scheme(app, db, minimal_record, location):
     assert valid_full == RDMRecordSchema().load(minimal_record)["pids"]
 
 
+@pytest.mark.skip("PIDS-FIXME re-enable")
 def test_invalid_pid(app, db, minimal_record, location):
     invalid_pid_type = {
         "doi": {
@@ -73,6 +74,7 @@ def test_invalid_pid(app, db, minimal_record, location):
         data = RDMRecordSchema().load(minimal_record)
 
 
+@pytest.mark.skip("PIDS-FIXME re-enable")
 def test_invalid_external_with_client(app, db, minimal_record, location):
     invalid_pid_type = {
         "doi": {

--- a/tests/services/schemas/test_reference.py
+++ b/tests/services/schemas/test_reference.py
@@ -46,8 +46,9 @@ def test_invalid_scheme_reference():
         "identifier": "0000 0001 1456 7559",
         "scheme": "Invalid"
     }
-    with pytest.raises(ValidationError):
-        data = ReferenceSchema().load(invalid_scheme)
+    loaded = data = ReferenceSchema().load(invalid_scheme)
+    # Check the backend forced the change to the correct scheme
+    assert loaded["scheme"] == "isni"
 
 
 def test_invalid_extra_right():

--- a/tests/services/schemas/test_related_identifier.py
+++ b/tests/services/schemas/test_related_identifier.py
@@ -78,8 +78,10 @@ def test_invalid_scheme_related_identifiers(app):
             "subtype": "image-photo"
         }
     }
-    with pytest.raises(ValidationError):
-        data = RelatedIdentifierSchema().load(invalid_scheme)
+
+    loaded = RelatedIdentifierSchema().load(invalid_scheme)
+    # Check the backend forced the correct scheme
+    assert loaded["scheme"] == "doi"
 
 
 def test_invalid_no_type_related_identifiers(app):

--- a/tests/services/schemas/test_right.py
+++ b/tests/services/schemas/test_right.py
@@ -31,16 +31,6 @@ def test_valid_minimal():
     assert valid_minimal == RightsSchema().load(valid_minimal)
 
 
-def test_invalid_no_right():
-    invalid_no_right = {
-        "link": "https://opensource.org/licenses/BSD-3-Clause",
-        "identifier": "BSD-3",
-        "scheme": "BSD-3"
-    }
-    with pytest.raises(ValidationError):
-        data = RightsSchema().load(invalid_no_right)
-
-
 def test_invalid_extra_right():
     invalid_extra = {
         "rights": "Creative Commons Attribution 4.0 International",
@@ -63,16 +53,15 @@ def test_invalid_url():
         data = RightsSchema().load(invalid_url)
 
 
-@pytest.mark.skip(reason="idutils cannot validate spdx")
 @pytest.mark.parametrize("rights", [
     ([]),
     ([{
-        "rights": "Creative Commons Attribution 4.0 International",
+        "title": "Creative Commons Attribution 4.0 International",
         "scheme": "spdx",
         "identifier": "cc-by-4.0",
-        "uri": "https://creativecommons.org/licenses/by/4.0/"
+        "link": "https://creativecommons.org/licenses/by/4.0/"
     }, {
-        "rights": "Copyright (C) 2020. All rights reserved."
+        "title": "Copyright (C) 2020. All rights reserved."
     }])
 ])
 def test_valid_rights(rights, minimal_record, vocabulary_clear):

--- a/tests/services/schemas/test_subject.py
+++ b/tests/services/schemas/test_subject.py
@@ -13,7 +13,6 @@ from marshmallow import ValidationError
 from invenio_rdm_records.services.schemas.metadata import SubjectSchema
 
 
-@pytest.mark.skipif(reason="valid schemes unknonw and will become vocab")
 def test_valid_subject():
     valid_full = {
         "subject": "Romans",


### PR DESCRIPTION
@lnielsen @diegodelemos The goal of this PR is to fix the broken schema validation when installing latest master of `invenio-records-resources`. However,  it will fail on CI because `invenio-records-resources` is not released. The issue comes from the bump on `Marshmallow-Utils`, where the constructor signature of `IdentifierSchema` was changed.

Due to the update in Marshmallow Utils, it is possible now to load data whose scheme is not recognized by IDUtils. This allows (appart from implementing the PIDs feature) to re-enable **MANY** tests at schema level (e.g. locations, funders, rights, etc.). Note that the scheme will not be validated (because IDUtils does not have it implemented). Logic behind this choice:

- Even if we have control over IDUtils, we cannot implement validation for *every single type of identifier out there*.
- Users might configure their ID types to something custom and might not want to validate it.
- IdentifierSchema will still try to validate schemes on a best-effort basis, but not fail it it's *unknown* (If configured like that `fail_on_unknown=False`.

**Important note**: This commit was part of another PR (https://github.com/inveniosoftware/invenio-rdm-records/pull/519) and therefore some tests got in, but since master has the `ExternalPIDs` functionality disabled I have `mark.skip` two tests:

- https://github.com/inveniosoftware/invenio-rdm-records/pull/520/files#diff-2e6da937cffed51965c9c75f1b24a7509c96e38364a9b2c564ae8a2812e05c07R57
- https://github.com/inveniosoftware/invenio-rdm-records/pull/520/files#diff-2e6da937cffed51965c9c75f1b24a7509c96e38364a9b2c564ae8a2812e05c07R77

They are enabled in my other PR (link above) and therefore will **not be dead code**.

This PR is passing tests in local:

<img width="561" alt="Screenshot 2021-04-18 at 16 18 17" src="https://user-images.githubusercontent.com/6756943/115148845-b098ae00-a061-11eb-8f2f-1a22c6df3f3f.png">


