### PR TITLE
resources: add pid resolver endpoint

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -18,10 +18,11 @@ from invenio_vocabularies.contrib.subjects.subjects import subject_record_type
 from itsdangerous import SignatureExpired
 
 from . import config
-from .resources import RDMDraftFilesResourceConfig, \
-    RDMManagedPIDProviderResource, RDMManagedPIDProviderResourceConfig, \
-    RDMParentRecordLinksResource, RDMParentRecordLinksResourceConfig, \
-    RDMRecordFilesResourceConfig, RDMRecordResource, RDMRecordResourceConfig
+from .resources import PIDResolverResource, PIDResolverResourceConfig, \
+    RDMDraftFilesResourceConfig, RDMManagedPIDProviderResource, \
+    RDMManagedPIDProviderResourceConfig, RDMParentRecordLinksResource, \
+    RDMParentRecordLinksResourceConfig, RDMRecordFilesResourceConfig, \
+    RDMRecordResource, RDMRecordResourceConfig
 from .secret_links import LinkNeed, SecretLink
 from .services import RDMFileDraftServiceConfig, RDMFileRecordServiceConfig, \
     RDMRecordService, RDMRecordServiceConfig
@@ -143,4 +144,10 @@ class InvenioRDMRecords(object):
         self.pid_provider_resource = RDMManagedPIDProviderResource(
             service=self.records_service,
             config=RDMManagedPIDProviderResourceConfig,
+        )
+
+        # PID resolver
+        self.pid_resolver_resource = PIDResolverResource(
+            service=self.records_service,
+            config=PIDResolverResourceConfig,
         )

--- a/invenio_rdm_records/resources/__init__.py
+++ b/invenio_rdm_records/resources/__init__.py
@@ -7,19 +7,21 @@
 
 """Invenio RDM module to create REST APIs."""
 
-from .config import RDMDraftFilesResourceConfig, \
+from .config import PIDResolverResourceConfig, RDMDraftFilesResourceConfig, \
     RDMManagedPIDProviderResourceConfig, RDMParentRecordLinksResourceConfig, \
     RDMRecordFilesResourceConfig, RDMRecordResourceConfig
-from .resources import RDMManagedPIDProviderResource, \
+from .resources import PIDResolverResource, RDMManagedPIDProviderResource, \
     RDMParentRecordLinksResource, RDMRecordResource
 
 __all__ = (
+    "PIDResolverResource",
+    "PIDResolverResourceConfig",
     "RDMDraftFilesResourceConfig",
-    "RDMParentRecordLinksResource",
-    "RDMRecordResource",
-    "RDMParentRecordLinksResourceConfig",
     "RDMManagedPIDProviderResource",
     "RDMManagedPIDProviderResourceConfig",
+    "RDMParentRecordLinksResource",
+    "RDMParentRecordLinksResourceConfig",
     "RDMRecordFilesResourceConfig",
+    "RDMRecordResource",
     "RDMRecordResourceConfig",
 )

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -122,3 +122,26 @@ class RDMManagedPIDProviderResourceConfig(RecordResourceConfig):
     response_handlers = {
         "application/json": ResponseHandler(JSONSerializer())
     }
+
+
+class PIDResolverResourceConfig(RecordResourceConfig):
+    """PID provider resource configuration."""
+
+    blueprint_name = "record_pids_resolver"
+
+    url_prefix = "/pids/<pid_type>"
+
+    routes = {
+        "item-doi": "/<pid_prefix>/<pid_value>",
+        "item": "/<pid_value>"
+    }
+
+    request_view_args = {
+        "pid_prefix": ma.fields.Str(),
+        "pid_type": ma.fields.Str(),
+        "pid_value": ma.fields.Str(),
+    }
+
+    response_handlers = {
+        "application/json": ResponseHandler(JSONSerializer())
+    }

--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -33,7 +33,13 @@ def create_parent_record_links_bp(app):
     return ext.parent_record_links_resource.as_blueprint()
 
 
-def create_pid_resource_bp(app):
+def create_pid_provider_resource_bp(app):
     """Create pid resource blueprint."""
     ext = app.extensions["invenio-rdm-records"]
     return ext.pid_provider_resource.as_blueprint()
+
+
+def create_pid_resolver_resource_bp(app):
+    """Create pid resource blueprint."""
+    ext = app.extensions["invenio-rdm-records"]
+    return ext.pid_resolver_resource.as_blueprint()

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,8 @@ setup(
             'invenio_rdm_records_record_files = invenio_rdm_records.views:create_record_files_bp',
             'invenio_rdm_records_draft_files = invenio_rdm_records.views:create_draft_files_bp',
             'invenio_rdm_records_parent_links = invenio_rdm_records.views:create_parent_record_links_bp',
-            'invenio_rdm_pid_resource = invenio_rdm_records.views:create_pid_resource_bp'
+            'invenio_rdm_pid_provider_resource = invenio_rdm_records.views:create_pid_provider_resource_bp',
+            'invenio_rdm_pid_resolver_resource = invenio_rdm_records.views:create_pid_resolver_resource_bp',
         ],
         'invenio_celery.tasks': [
             'invenio_rdm_records = invenio_rdm_records.fixtures.tasks',

--- a/tests/resources/test_resources.py
+++ b/tests/resources/test_resources.py
@@ -759,3 +759,45 @@ def test_publish_pid_flow(
     assert response.status_code == 202
     assert response.json["pids"]["doi"]["identifier"]
     assert response.json["pids"]["doi"]["client"] == "datacite"  # default
+
+
+def test_resolve_pid_with_login(
+    app, location, es_clear, headers, client_with_login, minimal_record
+):
+    """Test the reserve function with client logged in."""
+    # with client login
+    client = client_with_login
+    # create the draft
+    response = client.post(
+        "/records", data=json.dumps(minimal_record), headers=headers)
+    recid = response.json['id']
+    # publish the record
+    response = client.post(
+        f"/records/{recid}/draft/actions/publish", headers=headers)
+    doi = response.json["pids"]["doi"]["identifier"]
+
+    # test redirection
+    expected_link = f"https://127.0.0.1:5000/api/records/{recid}"
+    response = client.get(f"/pids/doi/{doi}", headers=headers)
+    assert response.status_code == 301
+    assert response.json["location"] == expected_link
+
+
+def test_resolve_non_existing_pid_with_login(
+    app, location, es_clear, headers, client_with_login, minimal_record
+):
+    """Test the reserve function with client logged in."""
+    # with client login
+    client = client_with_login
+    # create the draft
+    response = client.post(
+        "/records", data=json.dumps(minimal_record), headers=headers)
+    recid = response.json['id']
+    # publish the record
+    response = client.post(
+        f"/records/{recid}/draft/actions/publish", headers=headers)
+
+    # test redirection
+    fake_doi = "10.1234/client.12345-abdce"
+    response = client.get(f"/pids/doi/{fake_doi}", headers=headers)
+    assert response.status_code == 404


### PR DESCRIPTION
**Important notes**
- The service part will be refactor at the same time than the `reserve_pid` and `delete_pid` and potentially all PID related operations should be in a sub-service. And be able to do `service.pids.reserve(...)`.
- The resource level is being refactored by @ntarocco, but in principle this will stay as a separate resource since it has nothing to do with `records` (i.e. no `/records/` in the URL).
- There are two endpoint needed, one is specifically meant for DOIs which have a slash (`prefix/client.recid`) in the PID value.
- I **did not** add the `RDM` prefix to all the new classes because I find it unnecessary and making longer names with no extra value. But I can add it if required.