### PR TITLE
 links: doi and other pids links

### DIFF
--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -26,6 +26,7 @@ from invenio_records_resources.services.records.search import \
 from ..records import RDMDraft, RDMRecord
 from .components import AccessComponent, ExternalPIDsComponent, \
     MetadataComponent
+from .links import HiddenLink, RecordPIDsLink
 from .permissions import RDMRecordPermissionPolicy
 from .pids.providers import DOIDataCiteClient, DOIDataCitePIDProvider, \
     UnmanagedPIDProvider
@@ -170,6 +171,11 @@ class RDMRecordServiceConfig(RecordServiceConfig):
             if_=RecordLink("{+ui}/records/{id}"),
             else_=RecordLink("{+ui}/uploads/{id}"),
         ),
+        "self_doi": ConditionalLink(
+            cond=is_record,
+            if_=RecordPIDsLink("{+ui}/doi/{pid_doi}"),
+            else_=HiddenLink(),
+        ),
         "files": ConditionalLink(
             cond=is_record,
             if_=RecordLink("{+api}/records/{id}/files"),
@@ -185,6 +191,7 @@ class RDMRecordServiceConfig(RecordServiceConfig):
         ),
         "versions": RecordLink("{+api}/records/{id}/versions"),
         "access_links": RecordLink("{+api}/records/{id}/access/links"),
+        "reserve_doi": RecordLink("{+api}/records/{id}/draft/pids/doi")
     }
 
 

--- a/invenio_rdm_records/services/links.py
+++ b/invenio_rdm_records/services/links.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Links for RDM-Records."""
+
+from invenio_records_resources.services import RecordLink
+
+
+class RecordPIDsLink(RecordLink):
+    """Short cut for writing links for records with PIDs."""
+
+    @staticmethod
+    def vars(record, vars):
+        """Variables for the URI template."""
+        to_update = {}
+        for scheme, pid in record.pids.items():
+            to_update[f"pid_{scheme}"] = pid["identifier"]
+
+        vars.update(to_update)
+
+
+class HiddenLink:
+    """Utility class for keeping track of and resolve links."""
+
+    def should_render(self, obj, ctx):
+        """Determine if the link should be rendered."""
+        False

--- a/tests/resources/test_serialized_links.py
+++ b/tests/resources/test_serialized_links.py
@@ -65,6 +65,7 @@ def test_draft_links(client, draft_json, minimal_record):
         "latest_html": f"https://127.0.0.1:5000/records/{pid_value}/latest",  # noqa
         "access_links": f"https://127.0.0.1:5000/api/records/{pid_value}/access/links",  # noqa
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/files",
+        "reserve_doi": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/pids/doi",  # noqa
     }
     assert expected_links == created_draft_links == read_draft_links
 
@@ -72,6 +73,7 @@ def test_draft_links(client, draft_json, minimal_record):
 def test_record_links(client, published_json):
     """Tests the links for a published RDM record."""
     pid_value = published_json["id"]
+    doi_value = published_json["pids"]["doi"]["identifier"].replace("/", "%2F")
     published_record_links = published_json["links"]
     response = client.get(f"/records/{pid_value}", headers=HEADERS)
     read_record_links = response.json["links"]
@@ -79,12 +81,14 @@ def test_record_links(client, published_json):
     expected_links = {
         "self": f"https://127.0.0.1:5000/api/records/{pid_value}",
         "self_html": f"https://127.0.0.1:5000/records/{pid_value}",
+        "self_doi": f"https://127.0.0.1:5000/doi/{doi_value}",
         "draft": f"https://127.0.0.1:5000/api/records/{pid_value}/draft",
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/files",
         "versions": f"https://127.0.0.1:5000/api/records/{pid_value}/versions",
         "latest": f"https://127.0.0.1:5000/api/records/{pid_value}/versions/latest",  # noqa
         "latest_html": f"https://127.0.0.1:5000/records/{pid_value}/latest",  # noqa
         "access_links": f"https://127.0.0.1:5000/api/records/{pid_value}/access/links",  # noqa
+        "reserve_doi": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/pids/doi",  # noqa
     }
     assert expected_links == published_record_links == read_record_links
 


### PR DESCRIPTION
Note that the DOI value in the `self_doi` value will come already escaped (i.e. `/` --> `%2F`). However, this is the transformation what internally the browser/api would do and it works.

I tested to access a record through the `self_doi` link and it worked. Since it is UI, we are not expecting any REST endpoint to access it and this escaping should not pose any problem.

This issue comes from `URITemplate` and making a generic solution proved quite cumbersome. So I left the value escaped.