### PR TITLE
tests: add service level pids creation tests

### DIFF
--- a/invenio_rdm_records/services/schemas/__init__.py
+++ b/invenio_rdm_records/services/schemas/__init__.py
@@ -85,7 +85,7 @@ class RDMRecordSchema(RecordSchema, FieldPermissionsMixin):
             # The required flag applies to the identifier value
             # It won't fail for empty allowing the components to reserve one
             id_schema = IdentifierSchema(
-                fail_on_unknown=False, identifier_required=True)
+                fail_on_unknown=True, identifier_required=True)
             id_schema.load({
                 "scheme": scheme,
                 "identifier": pid_attrs.get("identifier")

--- a/tests/services/schemas/test_rdm_record_schema.py
+++ b/tests/services/schemas/test_rdm_record_schema.py
@@ -39,16 +39,3 @@ def test_valid_unmanaged(app, db, minimal_record, location):
 
     minimal_record["pids"] = valid_full
     assert valid_full == RDMRecordSchema().load(minimal_record)["pids"]
-
-
-def test_valid_unknown_scheme(app, db, minimal_record, location):
-    valid_full = {
-        "rand-unknown": {
-            "identifier": "aa::bb::11:::22",
-            "provider": "datacite",
-            "client": "zenodo"
-        }
-    }
-
-    minimal_record["pids"] = valid_full
-    assert valid_full == RDMRecordSchema().load(minimal_record)["pids"]


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/571

`test_valid_unknown_scheme` was removed in favor of "*if there is a custom scheme it should provide a way of validating*"... To be trated later on in https://github.com/inveniosoftware/marshmallow-utils/pull/39
