### PR TITLE
pids: disable reservation and saving of invalid values

### DIFF
--- a/invenio_rdm_records/services/components.py
+++ b/invenio_rdm_records/services/components.py
@@ -198,7 +198,6 @@ class ExternalPIDsComponent(ServiceComponent):
                 provider.reserve(pid, draft)
             else:
                 pid = provider.get(identifier_value)
-                assert pid.is_reserved() or pid.is_registered()
 
             if not pid.is_registered():  # avoid dup registration
                 url = self.service.links_item_tpl.expand(draft)["record"]

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -113,14 +113,16 @@ class DOIDataCitePIDProvider(BasePIDProvider):
             raise PIDAlreadyExists(self.pid_type, doi)
 
     def reserve(self, pid, record, **kwargs):
-        """Reserve a DOI only in the local system.
+        """Constant True.
 
-        It does not reserve the DOI in DataCite.
+        It does not reserve locally, nor externally. This is to avoid storing
+        many PIDs as cause of reserve/discard, which would then be soft
+        deleted. Therefore we want to pass from status.NEW to status.RESERVED.
         :param pid: the PID to reserve.
         :param record: the record.
-        :returns: `True` if is reserved successfully.
+        :returns: `True`
         """
-        return super().reserve(pid, record)
+        return True
 
     def register(self, pid, record, url, **kwargs):
         """Register a DOI via the DataCite API.

--- a/tests/services/pids/providers/test_datacite_pid_provider.py
+++ b/tests/services/pids/providers/test_datacite_pid_provider.py
@@ -67,7 +67,7 @@ def test_datacite_provider_reserve(record, datacite_provider):
     assert created_pid == db_pid
     assert db_pid.pid_value
     assert db_pid.pid_type == "doi"
-    assert db_pid.status == PIDStatus.RESERVED
+    assert db_pid.status == PIDStatus.NEW
 
 
 def test_datacite_provider_register(record, datacite_provider, mocker):
@@ -119,12 +119,13 @@ def test_datacite_provider_unregister_reserved(
     # Unregister NEW is a soft delete
     created_pid = datacite_provider.create(record)
     assert datacite_provider.reserve(pid=created_pid, record=record)
-    assert created_pid.status == PIDStatus.RESERVED
+    assert created_pid.status == PIDStatus.NEW
     assert datacite_provider.delete(created_pid, record)
 
-    deleted_pid = PersistentIdentifier.get(
+    # reserve keeps status as NEW so is hard deleted
+    with pytest.raises(PIDDoesNotExistError):
+        PersistentIdentifier.get(
             pid_value=created_pid.pid_value, pid_type="doi")
-    assert deleted_pid.status == PIDStatus.DELETED
 
 
 def test_datacite_provider_unregister_regitered(

--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -91,15 +91,25 @@ def test_pid_creation_invalid_format_value_managed(
     minimal_record["pids"] = pids
     # create the draft
     # will pass creation since validation is just reported, not hard fail
+    # but it will be removed (not saved)
     draft = service.create(superuser_identity, minimal_record)
-    # publish the record
-    with pytest.raises(ValidationError):
-        record = service.publish(draft.id, superuser_identity)
+    assert draft.to_dict()["pids"] == {}
 
 
 def test_pid_creation_invalid_no_value_managed(
     app, location, es_clear, superuser_identity, minimal_record
 ):
+    # NOTE: This use case is tricky because it will spawn two exceptions
+    # Because a value is missing and is also invalid. Should consider only
+    # second case.
+    # {
+    #   'field': 'pids.doi.value.identifier',
+    #   'messages': ['Missing data for required field.']
+    # }
+    # {
+    #   'field': 'pids._schema',
+    #   'messages': [l'Invalid value for scheme doi']
+    # }
     service = current_rdm_records.records_service
     # set the pids field
     # no value, to get a value from the system it should not send the pid_type
@@ -110,10 +120,10 @@ def test_pid_creation_invalid_no_value_managed(
     pids = {"doi": doi}
     minimal_record["pids"] = pids
     # create the draft
+    # will pass creation since validation is just reported, not hard fail
+    # but it will be removed (not saved)
     draft = service.create(superuser_identity, minimal_record)
-    # publish the record
-    with pytest.raises(ValidationError):
-        service.publish(draft.id, superuser_identity)
+    assert draft.to_dict()["pids"] == {}
 
 
 def test_pid_creation_invalid_scheme_managed(
@@ -168,10 +178,9 @@ def test_pid_creation_invalid_format_unmanaged(
     minimal_record["pids"] = pids
     # create the draft
     # will pass creation since validation is just reported, not hard fail
+    # but it will be removed (not saved)
     draft = service.create(superuser_identity, minimal_record)
-    # publish the record
-    with pytest.raises(ValidationError):
-        record = service.publish(draft.id, superuser_identity)
+    assert draft.to_dict()["pids"] == {}
 
 
 def test_pid_creation_invalid_scheme_unmanaged(


### PR DESCRIPTION
closes #576 
closes #575 

This PR tackles two issues:

**Disable local reservation of DOIs**
Do not reserve locally a DOI, to avoid having many soft deleted ones. I.e. a user reserves and discards, if we set status to `RESERVED` then will be soft deleted. With this change it will pass from `NEW` to `REGISTERED`.

**Bug fix: do not store invalid values for pids**
Avoid saving invalid identifiers. If the validation step notes any scheme as having an invalid value, this one will be stripped of the `pids` so they are not stored in db.

This issue has an extra catch.
- There can be several schemes with errors, so at `__init__.py.Schema:validate_pids` level we need to catch and re-raise at the end with *several* messages.
- This makes us not be able to assign a specific field. i.e. it will always be `field_name=pids` and never `field_name=pids.doi`. This is also not possible due to Marshmallo core. The [`error_store`](https://github.com/marshmallow-code/marshmallow/blob/dev/src/marshmallow/schema.py#L490) would overwrite the `field_name`.
So even if we re-raise something like:

```
raise ValidationError(
    message=_("Invalid value."),
    field_name=f"pids.{scheme}"
)
```

It will be re-set to `pids` in `error_store.store_error(error.messages, field_name, index=index)`, because the schema field that failed is `pids` (since all the inner ones are dynamic).

Errors are properly returned in the API:

![Screenshot 2021-04-29 at 14 20 44](https://user-images.githubusercontent.com/6756943/116552262-1fdf8f00-a8f9-11eb-9f61-95f482010c85.png)

