### PR TITLE
doi: serialize resource type for Datacite

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 CERN.
+# Copyright (C) 2021 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +12,8 @@ from edtf import parse_edtf
 from edtf.parser.grammar import ParseException
 from marshmallow import Schema, ValidationError, fields, missing, post_dump
 from marshmallow_utils.fields import SanitizedUnicode
+
+from invenio_rdm_records.vocabularies import Vocabularies
 
 
 class PersonOrOrgSchema43(Schema):
@@ -177,10 +180,11 @@ class DataCite43Schema(Schema):
     def get_type(self, obj):
         """Get resource type."""
         resource_type = obj["metadata"]["resource_type"]
-
+        vocabulary = Vocabularies.get_vocabulary('resource_type')
+        entry = vocabulary.get_entry_by_dict(resource_type)
         return {
-            'resourceTypeGeneral': "FIXME",
-            'resourceType': "FIXME",
+            'resourceTypeGeneral': entry.get("datacite_general", "Other"),
+            'resourceType': entry.get("datacite_type", "Other"),
         }
 
     def get_titles(self, obj):

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.29.16'
+__version__ = '0.29.17'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2019 CERN.
-# Copyright (C) 2019 Northwestern University.
+# Copyright (C) 2019-2021 CERN.
+# Copyright (C) 2019-2021 Northwestern University.
 # Copyright (C) 2021 TU Wien.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
@@ -22,6 +22,7 @@ from invenio_app.factory import create_app as _create_app
 
 from invenio_rdm_records import config
 from invenio_rdm_records.records.api import RDMParent
+from invenio_rdm_records.vocabularies import Vocabularies
 
 
 @pytest.fixture(scope='module')
@@ -357,3 +358,12 @@ def identity_simple(users):
     i.provides.add(UserNeed(user.id))
     i.provides.add(Need(method='system_role', value='any_user'))
     return i
+
+
+@pytest.fixture(scope='function')
+def vocabulary_clear(app):
+    """Clears the Vocabulary singleton and pushes an application context.
+
+    NOTE: app fixture pushes an application context
+    """
+    Vocabularies.clear()

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -3,23 +3,22 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Caltech.
+# Copyright (C) 2021 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Resources serializers tests."""
 
-import json
-
 from invenio_rdm_records.resources.serializers import DataCite43JSONSerializer
 
 
-def test_datacite43_serializer(app, full_record):
+def test_datacite43_serializer(app, full_record, vocabulary_clear):
     """Test serializer to DayaCide 4.3 JSON"""
     expected_data = {
         "types": {
-            "resourceTypeGeneral": "FIXME",
-            "resourceType": "FIXME"
+            "resourceTypeGeneral": "Text",
+            "resourceType": "Journal article"
         },
         "creators": [
             {

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -24,22 +24,11 @@ from invenio_app.factory import create_api
 from invenio_vocabularies.records.models import VocabularyType
 from invenio_vocabularies.services.service import VocabulariesService
 
-from invenio_rdm_records.vocabularies import Vocabularies
-
 
 @pytest.fixture(scope='module')
 def create_app(instance_path):
     """Application factory fixture."""
     return create_api
-
-
-@pytest.fixture(scope='function')
-def vocabulary_clear(app):
-    """Clears the Vocabulary singleton and pushes an application context.
-
-    NOTE: app fixture pushes an application context
-    """
-    Vocabularies.clear()
 
 
 @pytest.fixture()

--- a/tests/services/schemas/test_resource_type.py
+++ b/tests/services/schemas/test_resource_type.py
@@ -8,12 +8,9 @@
 
 """Test metadata resource type schema."""
 
-import os
 from copy import deepcopy
 
-import pytest
 from flask_babelex import lazy_gettext as _
-from marshmallow import ValidationError
 
 from invenio_rdm_records.services.schemas.metadata import MetadataSchema
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/585

This along with the previous fixes allowed me to register a test DOI successfully!

In Datacite test fabrica (note we use our own resource types):

![serialized_doi](https://user-images.githubusercontent.com/1932651/116914172-03509900-ac10-11eb-8cad-883666c77a0d.png)
  