### PR TITLE
providers: consolidate error handling on validation steps

### DIFF
--- a/invenio_rdm_records/services/components.py
+++ b/invenio_rdm_records/services/components.py
@@ -152,7 +152,9 @@ class ExternalPIDsComponent(ServiceComponent):
         client = pid.get("client")
         provider = self.service.get_provider(scheme, provider_name, client)
         if provider:
-            provider.validate(**pid)
+            success, errors = provider.validate(**pid)
+            if errors:
+                raise ValidationError(message=errors, field_name="pids")
 
     def _validate_pids(self, pids):
         """Validate an iterator of PIDs."""

--- a/invenio_rdm_records/services/pids/providers/base.py
+++ b/invenio_rdm_records/services/pids/providers/base.py
@@ -6,6 +6,7 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """PID Base Provider."""
+from flask_babelex import lazy_gettext as _
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from sqlalchemy.orm.exc import NoResultFound
@@ -152,9 +153,16 @@ class BasePIDProvider:
         return self.get(identifier, **kwargs).status
 
     def validate(self, identifier=None, provider=None, client=None, **kwargs):
-        """Validate the attributes of the identifier."""
-        if provider and provider != self.name:
-            raise ValueError(f"Provider name {provider} does not "
-                             f"match {self.name}")
+        """Validate the attributes of the identifier.
 
-        return True
+        :returns: A tuple (success, errors). The first specifies if the
+                  validation was passed successfully. The second one is an
+                  array of error messages.
+        """
+        if provider and provider != self.name:
+            errors = [
+                _(f"Provider name {provider} does not match {self.name}")
+            ]
+            return False, errors
+
+        return True, []

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -229,9 +229,18 @@ class DOIDataCitePIDProvider(BasePIDProvider):
         return super().delete(pid, record)
 
     def validate(self, identifier=None, provider=None, client=None, **kwargs):
-        """Validate the attributes of the identifier."""
-        super().validate(identifier, provider, client, **kwargs)
-        if identifier and self.is_api_client_setup:
-            self.api_client.check_doi(identifier)
+        """Validate the attributes of the identifier.
 
-        return True
+        :returns: A tuple (success, errors). The first specifies if the
+                  validation was passed successfully. The second one is an
+                  array of error messages.
+        """
+        _, errors = super().validate(identifier, provider, client, **kwargs)
+
+        if identifier and self.is_api_client_setup:
+            try:
+                self.api_client.check_doi(identifier)
+            except ValueError as e:
+                errors.append(str(e))
+
+        return (True, []) if not errors else (False, errors)

--- a/invenio_rdm_records/services/pids/providers/unmanaged.py
+++ b/invenio_rdm_records/services/pids/providers/unmanaged.py
@@ -7,6 +7,7 @@
 
 """PID Base Provider."""
 
+from flask_babelex import lazy_gettext as _
 from invenio_pidstore.models import PIDStatus
 
 from .base import BasePIDProvider
@@ -55,9 +56,16 @@ class UnmanagedPIDProvider(BasePIDProvider):
         raise NotImplementedError
 
     def validate(self, identifier=None, client=None, provider=None, **kwargs):
-        """Validate the attributes of the identifier."""
-        provider_ok = super(
-            UnmanagedPIDProvider, self).validate(provider=provider)
-        client_ok = not client
+        """Validate the attributes of the identifier.
 
-        return provider_ok and client_ok
+        :returns: A tuple (success, errors). The first specifies if the
+                  validation was passed successfully. The second one is an
+                  array of error messages.
+        """
+        success, errors = super().validate(provider=provider)
+
+        if client:
+            errors.append(
+                _(f"Client attribute not supported for provider {self.name}"))
+
+        return (True, []) if not errors else (False, errors)

--- a/tests/services/pids/providers/test_base_pid_provider.py
+++ b/tests/services/pids/providers/test_base_pid_provider.py
@@ -8,6 +8,7 @@
 """Base provider tests."""
 
 import pytest
+from flask_babelex import lazy_gettext as _
 from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
@@ -121,7 +122,18 @@ def test_base_provider_get_status(app, db):
     assert provider.get_status(created_pid.pid_value) == PIDStatus.NEW
 
 
-def test_base_provider_validate(app, db):
+def test_base_provider_validate_no_values_given(app, db):
     provider = BasePIDProvider(pid_type="testid")
-    # NOTE: BasePIDProvider defaults name to None
-    assert provider.validate(identifier=None, client=None, provider=None)
+    # base has name set to None
+    success, errors = provider.validate(
+        identifier=None, client=None, provider=None)
+    assert success
+    assert not errors
+
+
+def test_base_provider_validate_failure(app, db):
+    provider = BasePIDProvider(pid_type="testid")
+    success, errors = provider.validate(
+        identifier=None, client=None, provider="fail")
+    assert not success
+    assert errors == [_("Provider name fail does not match None")]

--- a/tests/services/pids/providers/test_unmanaged_pid_provider.py
+++ b/tests/services/pids/providers/test_unmanaged_pid_provider.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Unmanaged provider tests."""
+
+from flask_babelex import lazy_gettext as _
+
+from invenio_rdm_records.services.pids.providers import UnmanagedPIDProvider
+
+
+def test_unmanaged_provider_validate(app, db):
+    provider = UnmanagedPIDProvider(pid_type="testid")
+    success, errors = provider.validate(provider="unmanaged")
+    assert success
+    assert not errors
+
+
+def test_unmanaged_provider_validate_failure(app, db):
+    provider = UnmanagedPIDProvider(pid_type="testid")
+    success, errors = provider.validate(client="someclient", provider="fail")
+
+    expected_errors = [
+        _("Provider name fail does not match unmanaged"),
+        _("Client attribute not supported for provider unmanaged")
+    ]
+    assert not success
+    assert errors == expected_errors


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-rdm-records/issues/514

**Design decission**:

The `provider.validate` method returns True/False (for success) and a list of errors, in a similar fashion that marshmallow with `raise_errors=False` (see `AccessComponent`). That way only the component needs to know about `ValidationError`.