### PR TITLE
serializers: avoid modifications to the original record/obj

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/__init__.py
+++ b/invenio_rdm_records/resources/serializers/datacite/__init__.py
@@ -7,6 +7,8 @@
 
 """DataCite Serializers for Invenio RDM Records."""
 
+from copy import deepcopy
+
 from flask_resources.serializers import MarshmallowJSONSerializer
 
 from .schema import DataCite43Schema
@@ -21,5 +23,8 @@ class DataCite43JSONSerializer(MarshmallowJSONSerializer):
 
     def dump_one(self, obj):
         """Dump the object with extra information."""
-        obj["metadata"] = self._schema_cls().dump(obj)
-        return obj
+        # Do not change the original record/obj
+        serialized = deepcopy(obj)
+        serialized["metadata"] = self._schema_cls().dump(serialized)
+
+        return serialized

--- a/invenio_rdm_records/resources/serializers/datacite/__init__.py
+++ b/invenio_rdm_records/resources/serializers/datacite/__init__.py
@@ -7,8 +7,6 @@
 
 """DataCite Serializers for Invenio RDM Records."""
 
-from copy import deepcopy
-
 from flask_resources.serializers import MarshmallowJSONSerializer
 
 from .schema import DataCite43Schema
@@ -23,8 +21,4 @@ class DataCite43JSONSerializer(MarshmallowJSONSerializer):
 
     def dump_one(self, obj):
         """Dump the object with extra information."""
-        # Do not change the original record/obj
-        serialized = deepcopy(obj)
-        serialized["metadata"] = self._schema_cls().dump(serialized)
-
-        return serialized
+        return self._schema_cls().dump(obj)

--- a/invenio_rdm_records/resources/serializers/ui/__init__.py
+++ b/invenio_rdm_records/resources/serializers/ui/__init__.py
@@ -8,6 +8,8 @@
 
 """Record response serializers."""
 
+from copy import deepcopy
+
 from flask_resources.serializers import JSONSerializer
 
 from .schema import UIListSchema, UIObjectSchema
@@ -25,8 +27,10 @@ class UIJSONSerializer(JSONSerializer):
     #
     def dump_obj(self, obj):
         """Dump the object with extra information."""
-        obj[self.object_key] = self.object_schema_cls().dump(obj)
-        return obj
+        ser_obj = deepcopy(obj)
+        ser_obj[self.object_key] = self.object_schema_cls().dump(ser_obj)
+
+        return ser_obj
 
     def dump_list(self, obj_list):
         """Dump the list of objects with extra information."""

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -150,9 +150,8 @@ class DOIDataCitePIDProvider(BasePIDProvider):
             # PIDS-FIXME: move to async task, exception handling included
             try:
                 doc = DataCite43JSONSerializer().dump_one(record)
-                metadata = doc["metadata"]
                 self.api_client.public_doi(
-                    metadata=metadata, url=url, doi=pid.pid_value)
+                    metadata=doc, url=url, doi=pid.pid_value)
             except DataCiteError as e:
                 logging.warning("DataCite provider errored when updating " +
                                 f"DOI for {pid.pid_value}")
@@ -180,9 +179,8 @@ class DOIDataCitePIDProvider(BasePIDProvider):
                 # PIDS-FIXME: move to async task, exception handling included
                 # Set metadata
                 doc = DataCite43JSONSerializer().dump_one(record)
-                metadata = doc["metadata"]
                 self.api_client.update_doi(
-                    metadata=metadata, doi=pid.pid_value, url=url)
+                    metadata=doc, doi=pid.pid_value, url=url)
             except DataCiteError as e:
                 logging.warning("DataCite provider errored when updating " +
                                 f"DOI for {pid.pid_value}")

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -147,4 +147,4 @@ def test_datacite43_serializer(app, full_record, vocabulary_clear):
     serializer = DataCite43JSONSerializer()
     serialized_record = serializer.dump_one(full_record)
 
-    assert serialized_record["metadata"] == expected_data
+    assert serialized_record == expected_data


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/812

Changes:

- UI serializer: copy to avoid modifying the original record. Otherwise, we should document and not return, just make the user use the passed record.
- DataCite serializer: return only the metadata since it is what's serializable to DataCite. The rest is data that makes no sense in this format.