### PR TITLE
handlers: implement image opener for iiif

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Handler functions for Invenio-RDM-Records."""
+
+
+import tempfile
+
+import pkg_resources
+from flask import g
+
+try:
+    pkg_resources.get_distribution('wand')
+    from wand.image import Image
+    HAS_IMAGEMAGICK = True
+except pkg_resources.DistributionNotFound:
+    # Python module not installed
+    HAS_IMAGEMAGICK = False
+except ImportError:
+    # ImageMagick notinstalled
+    HAS_IMAGEMAGICK = False
+
+from ..proxies import current_rdm_records
+
+
+def image_opener(key):
+    """Handler to locate file based on key.
+
+    .. note::
+        If the file is a PDF then only the first page will be
+        returned as an image.
+
+    :param key: A key encoded in the format "<recid>:<filename>".
+    :returns: A file-like object.
+    """
+    key_parts = key.split(":")
+    assert len(key_parts) == 2
+
+    recid = key_parts[0]
+    filename = key_parts[1]
+    identity = g.identity
+    service = current_rdm_records.records_service
+    try:
+        file_item = service.files.get_file_content(recid, filename, identity)
+    except KeyError:
+        return None  # FIXME: throw custom exception `FileNotFound`?
+
+    fp = file_item.get_stream('rb')
+
+    # If ImageMagick with Wand is installed, extract first page
+    # for PDF/text.
+    pages_mimetypes = ['application/pdf', 'text/plain']
+    if HAS_IMAGEMAGICK and file_item.data["mimetype"] in pages_mimetypes:
+        first_page = Image(Image(fp).sequence[0])
+        tempfile_ = tempfile.TemporaryFile()
+        with first_page.convert(format='png') as converted:
+            converted.save(file=tempfile_)
+        return tempfile_
+
+    return fp

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ install_requires = [
     'invenio-vocabularies>=0.6.1,<0.7.0',
     'pytz>=2020.4',
     'pyyaml>=5.4.0',
+    'Wand>=0.4.4',
 ]
 
 packages = find_packages()

--- a/tests/resources/test_iiif.py
+++ b/tests/resources/test_iiif.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for the handlers."""
+
+from io import BytesIO
+
+from invenio_rdm_records.proxies import current_rdm_records
+from invenio_rdm_records.resources.iiif import image_opener
+
+
+def _publish_record_with_file(file_id, file_content, identity, record):
+    # client_with_login will push the identity to g
+    # enable files on record
+    record["files"]["enabled"] = True
+    # create a record with a file
+    service = current_rdm_records.records_service
+    draft = service.create(identity, record)
+    # add files
+
+    service.draft_files.init_files(
+        draft.id, identity, data=[{'key': file_id}])
+    service.draft_files.set_file_content(
+        draft.id, file_id, identity, BytesIO(file_content)
+    )
+    service.draft_files.commit_file(draft.id, file_id, identity)
+    # publish the record
+    record = service.publish(draft.id, identity)
+
+    return record.id
+
+
+def test_image_opener(
+    app, location, es_clear, resource_type_item, client_with_login,
+    identity_simple, minimal_record
+):
+
+    file_id = "test_file"
+    file_content = b'test file content'
+    recid = _publish_record_with_file(
+        file_id, file_content, identity_simple, minimal_record)
+
+    key = f"{recid}:{file_id}"
+    fp = image_opener(key)
+    data = fp.read()
+    assert data == file_content
+    fp.close()
+
+
+def test_image_opener_not_found(
+    app, location, es_clear, resource_type_item, client_with_login,
+    identity_simple, minimal_record
+):
+    file_id = "test_file"
+    file_content = b'test file content'
+    recid = _publish_record_with_file(
+        file_id, file_content, identity_simple, minimal_record)
+
+    key = f"{recid}:different"
+    fp = image_opener(key)
+    assert not fp


### PR DESCRIPTION
requires https://github.com/inveniosoftware/invenio-records-resources/pull/247
requires https://github.com/inveniosoftware/invenio-records-resources/pull/249
requires https://github.com/inveniosoftware/invenio-iiif/pull/39
requires https://github.com/inveniosoftware/invenio-rdm-records/pull/602

closes https://github.com/inveniosoftware/invenio-iiif/issues/38

Status with all other PR requirements - working use case e.g. `https://127.0.0.1:5000/api/iiif/v2/eq18w-nhc19:ouroboros.png/full/250,/0/default.jpg`


