### PR TITLE
global: add service registration blueprint to ui app

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,9 @@ setup(
             'invenio_rdm_records_record_files = invenio_rdm_records.views:create_record_files_bp',
             'invenio_vocabularies_subjects = invenio_rdm_records.vocabularies.views:create_subjects_blueprint_from_app',
         ],
+        "invenio_base.blueprints": [
+            'invenio_rdm_records_ext = invenio_rdm_records.views:blueprint',
+        ],
         'invenio_celery.tasks': [
             'invenio_rdm_records = invenio_rdm_records.fixtures.tasks',
         ],


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-records-resources/issues/248

@lnielsen I know this is not optimal AT ALL... but there is no other way (that we know of 😅) at the moment to unblock the fact that we cannot upload a file via UI (`pre_commit` hook fails) 😓