### PR TITLE
[WIP] records: add pids field to parent record

### DIFF
--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -49,6 +49,7 @@ class RDMParent(ParentRecordBase):
 
     access = ParentRecordAccessField()
 
+    pids = DictField("pids")
 
 #
 # Common properties between records and drafts.


### PR DESCRIPTION
This just defines the field in the `RDMParent` record. It is blocked until the previous PR's have been merged due to too much connection in between them.

This PR is missing (apart from the below questions) the redirection upon versioning (i.e. point to latest version doi)

**Open Questions**
- The [creation of the parent record](https://github.com/inveniosoftware/invenio-drafts-resources/blob/cc92ce2455e7e3a6dbaf06cebe9a1869fdcf6c07/invenio_drafts_resources/records/systemfields/parent.py#L38) is done at field level. Therefore, there is no `components` running on it and there is no option to add the pids to it.
    a) Make the component configurable (e.g. `parent=True/False` and make it a partial in the config)
    b) Change the logic and allow components at API level

I would go for a).

-  Should parent pids will have `concept_` as prefix, but they are already inside `parent.pids`... so is a bit redundant
