### PR TITLE
datacite: serialize languages following ISO 639-1

### DIFF
--- a/invenio_rdm_records/fixtures/data/vocabularies/languages.py
+++ b/invenio_rdm_records/fixtures/data/vocabularies/languages.py
@@ -37,6 +37,9 @@ def iter_languages():
             "title": {
                 "en": lang.name
             },
+            "props": {
+                "alpha_2": getattr(lang, "alpha_2", '')
+            },
             "tags": [scope_map[lang.scope], type_map[lang.type]],
         }
         yield record

--- a/invenio_rdm_records/fixtures/data/vocabularies/languages.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/languages.yaml
@@ -1,47080 +1,62774 @@
 - id: aaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghotuo
 - id: aab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alumu-Tesu
 - id: aac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ari
 - id: aad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amal
 - id: aae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arb\xEBresh\xEB Albanian"
 - id: aaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aranadan
 - id: aag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambrak
 - id: aah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abu' Arapesh
 - id: aai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arifama-Miniafia
 - id: aak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ankave
 - id: aal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Afade
 - id: aan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Anamb\xE9"
 - id: aao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Algerian Saharan Arabic
 - id: aap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Par\xE1 Ar\xE1ra"
 - id: aaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Eastern Abnaki
 - id: aar
+  props:
+    alpha_2: aa
   tags:
   - individual
   - living
   title:
     en: Afar
 - id: aas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Aas\xE1x"
 - id: aat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arvanitika Albanian
 - id: aau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abau
 - id: aaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Solong
 - id: aax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandobo Atas
 - id: aaz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amarasi
 - id: aba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ab\xE9"
 - id: abb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bankon
 - id: abc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambala Ayta
 - id: abd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manide
 - id: abe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Abnaki
 - id: abf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abai Sungai
 - id: abg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abaga
 - id: abh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tajiki Arabic
 - id: abi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abidji
 - id: abj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Bea
 - id: abk
+  props:
+    alpha_2: ab
   tags:
   - individual
   - living
   title:
     en: Abkhazian
 - id: abl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lampung Nyo
 - id: abm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abanyom
 - id: abn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abua
 - id: abo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abon
 - id: abp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abellen Ayta
 - id: abq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abaza
 - id: abr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abron
 - id: abs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambonese Malay
 - id: abt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambulas
 - id: abu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abure
 - id: abv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baharna Arabic
 - id: abw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pal
 - id: abx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inabaknon
 - id: aby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aneme Wake
 - id: abz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abui
 - id: aca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achagua
 - id: acb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "\xC1nc\xE1"
 - id: acd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gikyode
 - id: ace
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achinese
 - id: acf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saint Lucian Creole French
 - id: ach
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Acoli
 - id: aci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Cari
 - id: ack
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Kora
 - id: acl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Akar-Bale
 - id: acm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mesopotamian Arabic
 - id: acn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achang
 - id: acp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Acipa
 - id: acq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ta'izzi-Adeni Arabic
 - id: acr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achi
 - id: acs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Acro\xE1"
 - id: act
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achterhoeks
 - id: acu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achuar-Shiwiar
 - id: acv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Achumawi
 - id: acw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hijazi Arabic
 - id: acx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Omani Arabic
 - id: acy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cypriot Arabic
 - id: acz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Acheron
 - id: ada
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adangme
 - id: adb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adabe
 - id: add
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dzodinka
 - id: ade
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adele
 - id: adf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhofari Arabic
 - id: adg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andegerebinha
 - id: adh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adhola
 - id: adi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adi
 - id: adj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adioukrou
 - id: adl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galo
 - id: adn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adang
 - id: ado
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abu
 - id: adq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adangbe
 - id: adr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adonara
 - id: ads
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adamorobe Sign Language
 - id: adt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adnyamathanha
 - id: adu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aduge
 - id: adw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amundava
 - id: adx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amdo Tibetan
 - id: ady
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adyghe
 - id: adz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adzera
 - id: aea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Areba
 - id: aeb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunisian Arabic
 - id: aec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saidi Arabic
 - id: aed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Argentine Sign Language
 - id: aee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northeast Pashai
 - id: aek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haeke
 - id: ael
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambele
 - id: aem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arem
 - id: aen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Armenian Sign Language
 - id: aeq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aer
 - id: aer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Arrernte
 - id: aes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Alsea
 - id: aeu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akeu
 - id: aew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambakich
 - id: aey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amele
 - id: aez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aeka
 - id: afb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gulf Arabic
 - id: afd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andai
 - id: afe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Putukwam
 - id: afg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Afghan Sign Language
 - id: afh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Afrihili
 - id: afi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akrukay
 - id: afk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nanubae
 - id: afn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Defaka
 - id: afo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eloyi
 - id: afp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tapei
 - id: afr
+  props:
+    alpha_2: af
   tags:
   - individual
   - living
   title:
     en: Afrikaans
 - id: afs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Afro-Seminole Creole
 - id: aft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Afitti
 - id: afu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awutu
 - id: afz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Obokuitai
 - id: aga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aguano
 - id: agb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Legbo
 - id: agc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agatu
 - id: agd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agarabi
 - id: age
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angal
 - id: agf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arguni
 - id: agg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angor
 - id: agh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngelima
 - id: agi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agariya
 - id: agj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Argobba
 - id: agk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isarog Agta
 - id: agl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fembe
 - id: agm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angaataha
 - id: agn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agutaynen
 - id: ago
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tainae
 - id: agq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aghem
 - id: agr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aguaruna
 - id: ags
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Esimbi
 - id: agt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Cagayan Agta
 - id: agu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aguacateco
 - id: agv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Remontado Dumagat
 - id: agw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kahua
 - id: agx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aghul
 - id: agy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Alta
 - id: agz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mt. Iriga Agta
 - id: aha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ahanta
 - id: ahb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Axamb
 - id: ahg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qimant
 - id: ahh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aghu
 - id: ahi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiagbamrin Aizi
 - id: ahk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akha
 - id: ahl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Igo
 - id: ahm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mobumrin Aizi
 - id: ahn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "\xC0h\xE0n"
 - id: aho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ahom
 - id: ahp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aproumu Aizi
 - id: ahr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ahirani
 - id: ahs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ashe
 - id: aht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ahtena
 - id: aia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arosi
 - id: aib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ainu (China)
 - id: aic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ainbai
 - id: aid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Alngith
 - id: aie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amara
 - id: aif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agi
 - id: aig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Antigua and Barbuda Creole English
 - id: aih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ai-Cham
 - id: aii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Assyrian Neo-Aramaic
 - id: aij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lishanid Noshan
 - id: aik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ake
 - id: ail
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aimele
 - id: aim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aimol
 - id: ain
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ainu (Japan)
 - id: aio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aiton
 - id: aip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burumakok
 - id: aiq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aimaq
 - id: air
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Airoran
 - id: ais
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nataoran Amis
 - id: ait
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arikem
 - id: aiw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aari
 - id: aix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aighon
 - id: aiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ali
 - id: aja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aja (Sudan)
 - id: ajg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aja (Benin)
 - id: aji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Aji\xEB"
 - id: ajn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andajin
 - id: ajp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Levantine Arabic
 - id: ajt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Tunisian Arabic
 - id: aju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Moroccan Arabic
 - id: ajw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ajawa
 - id: ajz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amri Karbi
 - id: aka
+  props:
+    alpha_2: ak
   tags:
   - macrolanguage
   - living
   title:
     en: Akan
 - id: akb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Angkola
 - id: akc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpur
 - id: akd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukpet-Ehom
 - id: ake
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akawaio
 - id: akf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akpa
 - id: akg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anakalangu
 - id: akh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angal Heneng
 - id: aki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aiome
 - id: akj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Jeru
 - id: akk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Akkadian
 - id: akl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aklanon
 - id: akm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Bo
 - id: ako
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akurio
 - id: akp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siwu
 - id: akq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ak
 - id: akr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Araki
 - id: aks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akaselem
 - id: akt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akolet
 - id: aku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akum
 - id: akv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akhvakh
 - id: akw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akwa
 - id: akx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Kede
 - id: aky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aka-Kol
 - id: akz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alabama
 - id: ala
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alago
 - id: alc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qawasqar
 - id: ald
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alladian
 - id: ale
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aleut
 - id: alf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alege
 - id: alh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alawa
 - id: ali
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amaimon
 - id: alj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alangan
 - id: alk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alak
 - id: all
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Allar
 - id: alm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amblong
 - id: aln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gheg Albanian
 - id: alo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Larike-Wakasihu
 - id: alp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alune
 - id: alq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Algonquin
 - id: alr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alutor
 - id: als
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tosk Albanian
 - id: alt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Altai
 - id: alu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: '''Are''are'
 - id: alw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Alaba-K\u2019abeena"
 - id: alx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amol
 - id: aly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alyawarr
 - id: alz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alur
 - id: ama
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Amanay\xE9"
 - id: amb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambo
 - id: amc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amahuaca
 - id: ame
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yanesha'
 - id: amf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hamer-Banna
 - id: amg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amurdak
 - id: amh
+  props:
+    alpha_2: am
   tags:
   - individual
   - living
   title:
     en: Amharic
 - id: ami
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amis
 - id: amj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amdang
 - id: amk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambai
 - id: aml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: War-Jaintia
 - id: amm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ama (Papua New Guinea)
 - id: amn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amanab
 - id: amo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amo
 - id: amp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alamblak
 - id: amq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amahai
 - id: amr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amarakaeri
 - id: ams
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Amami-Oshima
 - id: amt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amto
 - id: amu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guerrero Amuzgo
 - id: amv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambelau
 - id: amw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Neo-Aramaic
 - id: amx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anmatyerre
 - id: amy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ami
 - id: amz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Atampaya
 - id: ana
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Andaqui
 - id: anb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Andoa
 - id: anc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngas
 - id: and
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ansus
 - id: ane
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "X\xE2r\xE2c\xF9\xF9"
 - id: anf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Animere
 - id: ang
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old English (ca. 450-1100)
 - id: anh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nend
 - id: ani
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andi
 - id: anj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anor
 - id: ank
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Goemai
 - id: anl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anu-Hkongso Chin
 - id: anm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anal
 - id: ann
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Obolo
 - id: ano
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andoque
 - id: anp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angika
 - id: anq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jarawa (India)
 - id: anr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andh
 - id: ans
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Anserma
 - id: ant
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Antakarinya
 - id: anu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anuak
 - id: anv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Denya
 - id: anw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anaang
 - id: anx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andra-Hus
 - id: any
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anyin
 - id: anz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anem
 - id: aoa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angolar
 - id: aob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abom
 - id: aoc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pemon
 - id: aod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andarum
 - id: aoe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angal Enen
 - id: aof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bragat
 - id: aog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angoram
 - id: aoh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arma
 - id: aoi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anindilyakwa
 - id: aoj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mufian
 - id: aok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arh\xF6"
 - id: aol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alor
 - id: aom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "\xD6mie"
 - id: aon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bumbita Arapesh
 - id: aor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aore
 - id: aos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taikat
 - id: aot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atong (India)
 - id: aou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: A'ou
 - id: aox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atorada
 - id: aoz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uab Meto
 - id: apb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sa'a
 - id: apc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Levantine Arabic
 - id: apd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sudanese Arabic
 - id: ape
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukiyip
 - id: apf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pahanan Agta
 - id: apg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ampanang
 - id: aph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Athpariya
 - id: api
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Apiak\xE1"
 - id: apj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jicarilla Apache
 - id: apk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiowa Apache
 - id: apl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lipan Apache
 - id: apm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mescalero-Chiricahua Apache
 - id: apn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Apinay\xE9"
 - id: apo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambul
 - id: app
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Apma
 - id: apq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: A-Pucikwar
 - id: apr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arop-Lokep
 - id: aps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arop-Sissano
 - id: apt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Apatani
 - id: apu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Apurin\xE3"
 - id: apv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Alapmunte
 - id: apw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Apache
 - id: apx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aputai
 - id: apy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Apala\xED"
 - id: apz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Safeyoka
 - id: aqc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Archi
 - id: aqd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ampari Dogon
 - id: aqg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arigidi
 - id: aqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atohwaim
 - id: aqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Alta
 - id: aqp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Atakapa
 - id: aqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arh\xE2"
 - id: aqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Angait\xE9"
 - id: aqz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akuntsu
 - id: ara
+  props:
+    alpha_2: ar
   tags:
   - macrolanguage
   - living
   title:
     en: Arabic
 - id: arb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Standard Arabic
 - id: arc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Official Aramaic (700-300 BCE)
 - id: ard
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arabana
 - id: are
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Arrarnta
 - id: arg
+  props:
+    alpha_2: an
   tags:
   - individual
   - living
   title:
     en: Aragonese
 - id: arh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arhuaco
 - id: ari
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arikara
 - id: arj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arapaso
 - id: ark
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arikap\xFA"
 - id: arl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arabela
 - id: arn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapudungun
 - id: aro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Araona
 - id: arp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arapaho
 - id: arq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Algerian Arabic
 - id: arr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karo (Brazil)
 - id: ars
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Najdi Arabic
 - id: aru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Aru\xE1 (Amazonas State)"
 - id: arv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arbore
 - id: arw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arawak
 - id: arx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Aru\xE1 (Rodonia State)"
 - id: ary
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moroccan Arabic
 - id: arz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Egyptian Arabic
 - id: asa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asu (Tanzania)
 - id: asb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Assiniboine
 - id: asc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Casuarina Coast Asmat
 - id: asd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asas
 - id: ase
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: American Sign Language
 - id: asf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Australian Sign Language
 - id: asg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cishingini
 - id: ash
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Abishira
 - id: asi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buruwai
 - id: asj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sari
 - id: ask
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ashkun
 - id: asl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asilulu
 - id: asm
+  props:
+    alpha_2: as
   tags:
   - individual
   - living
   title:
     en: Assamese
 - id: asn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xing\xFA Asurin\xED"
 - id: aso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dano
 - id: asp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Algerian Sign Language
 - id: asq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Austrian Sign Language
 - id: asr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asuri
 - id: ass
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ipulo
 - id: ast
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asturian
 - id: asu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tocantins Asurini
 - id: asv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asoa
 - id: asw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Australian Aborigines Sign Language
 - id: asx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muratayak
 - id: asy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaosakor Asmat
 - id: asz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: As
 - id: ata
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pele-Ata
 - id: atb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zaiwa
 - id: atc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Atsahuaca
 - id: atd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ata Manobo
 - id: ate
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atemble
 - id: atg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ivbie North-Okpela-Arhe
 - id: ati
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Atti\xE9"
 - id: atj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atikamekw
 - id: atk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ati
 - id: atl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mt. Iraya Agta
 - id: atm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ata
 - id: atn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ashtiani
 - id: ato
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atong (Cameroon)
 - id: atp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pudtol Atta
 - id: atq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aralle-Tabulahan
 - id: atr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waimiri-Atroari
 - id: ats
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gros Ventre
 - id: att
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pamplona Atta
 - id: atu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Reel
 - id: atv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Altai
 - id: atw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atsugewi
 - id: atx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arutani
 - id: aty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aneityum
 - id: atz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arta
 - id: aua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asumboa
 - id: aub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alugu
 - id: auc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waorani
 - id: aud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anuta
 - id: aug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aguna
 - id: auh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aushi
 - id: aui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anuki
 - id: auj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awjilah
 - id: auk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Heyo
 - id: aul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aulua
 - id: aum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asu (Nigeria)
 - id: aun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molmo One
 - id: auo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Auyokawa
 - id: aup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makayam
 - id: auq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anus
 - id: aur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aruek
 - id: aut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Austral
 - id: auu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Auye
 - id: auw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awyi
 - id: aux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Aur\xE1"
 - id: auy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awiyaana
 - id: auz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uzbeki Arabic
 - id: ava
+  props:
+    alpha_2: av
   tags:
   - individual
   - living
   title:
     en: Avaric
 - id: avb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Avau
 - id: avd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alviri-Vidari
 - id: ave
+  props:
+    alpha_2: ae
   tags:
   - individual
   - ancient
   title:
     en: Avestan
 - id: avi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Avikam
 - id: avk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Kotava
 - id: avl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Egyptian Bedawi Arabic
 - id: avm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Angkamuthi
 - id: avn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Avatime
 - id: avo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Agavotaguerra
 - id: avs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aushiri
 - id: avt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Au
 - id: avu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Avokaya
 - id: avv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Av\xE1-Canoeiro"
 - id: awa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awadhi
 - id: awb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awa (Papua New Guinea)
 - id: awc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cicipu
 - id: awe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Awet\xED"
 - id: awg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Anguthimri
 - id: awh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awbono
 - id: awi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aekyom
 - id: awk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Awabakal
 - id: awm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arawum
 - id: awn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awngi
 - id: awo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awak
 - id: awr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awera
 - id: aws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Awyu
 - id: awt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arawet\xE9"
 - id: awu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Awyu
 - id: awv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jair Awyu
 - id: aww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awun
 - id: awx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awara
 - id: awy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Edera Awyu
 - id: axb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Abipon
 - id: axe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ayerrerenge
 - id: axg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Mato Grosso Ar\xE1ra"
 - id: axk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaka (Central African Republic)
 - id: axl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lower Southern Aranda
 - id: axm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Armenian
 - id: axx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "X\xE2r\xE2gur\xE8"
 - id: aya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awar
 - id: ayb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayizo Gbe
 - id: ayc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Aymara
 - id: ayd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ayabadhu
 - id: aye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayere
 - id: ayg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ginyanga
 - id: ayh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hadrami Arabic
 - id: ayi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leyigha
 - id: ayk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akuku
 - id: ayl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Libyan Arabic
 - id: aym
+  props:
+    alpha_2: ay
   tags:
   - macrolanguage
   - living
   title:
     en: Aymara
 - id: ayn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanaani Arabic
 - id: ayo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayoreo
 - id: ayp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Mesopotamian Arabic
 - id: ayq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayi (Papua New Guinea)
 - id: ayr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Aymara
 - id: ays
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sorsogon Ayta
 - id: ayt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Magbukun Ayta
 - id: ayu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayu
 - id: ayy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tayabas Ayta
 - id: ayz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mai Brat
 - id: aza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Azha
 - id: azb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Azerbaijani
 - id: azd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Durango Nahuatl
 - id: aze
+  props:
+    alpha_2: az
   tags:
   - macrolanguage
   - living
   title:
     en: Azerbaijani
 - id: azg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Pedro Amuzgos Amuzgo
 - id: azj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Azerbaijani
 - id: azm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ipalapa Amuzgo
 - id: azn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Durango Nahuatl
 - id: azo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awing
 - id: azt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Faire Atta
 - id: azz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Highland Puebla Nahuatl
 - id: baa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babatana
 - id: bab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Bainouk-Gunyu\xF1o"
 - id: bac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Badui
 - id: bae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Bar\xE9"
 - id: baf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nubaca
 - id: bag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuki
 - id: bah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahamas Creole English
 - id: baj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barakai
 - id: bak
+  props:
+    alpha_2: ba
   tags:
   - individual
   - living
   title:
     en: Bashkir
 - id: bal
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Baluchi
 - id: bam
+  props:
+    alpha_2: bm
   tags:
   - individual
   - living
   title:
     en: Bambara
 - id: ban
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balinese
 - id: bao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waimaha
 - id: bap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bantawa
 - id: bar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bavarian
 - id: bas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Basa (Cameroon)
 - id: bau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bada (Nigeria)
 - id: bav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vengo
 - id: baw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bambili-Bambui
 - id: bax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamun
 - id: bay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batuley
 - id: bba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baatonum
 - id: bbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barai
 - id: bbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Toba
 - id: bbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bau
 - id: bbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangba
 - id: bbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baibai
 - id: bbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barama
 - id: bbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bugan
 - id: bbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barombi
 - id: bbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ghom\xE1l\xE1'"
 - id: bbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babanki
 - id: bbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bats
 - id: bbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babango
 - id: bbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uneapa
 - id: bbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Northern Bobo Madar\xE9"
 - id: bbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Central Banda
 - id: bbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamali
 - id: bbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Girawa
 - id: bbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakpinka
 - id: bbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mburku
 - id: bbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulung (Nigeria)
 - id: bbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karnai
 - id: bbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baba
 - id: bbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bubia
 - id: bby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Befang
 - id: bbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babalia Creole Arabic
 - id: bca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Bai
 - id: bcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bainouk-Samik
 - id: bcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Balochi
 - id: bcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Babar
 - id: bce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamenyam
 - id: bcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamu
 - id: bcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baga Pokur
 - id: bch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bariai
 - id: bci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Baoul\xE9"
 - id: bcj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bardi
 - id: bck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bunaba
 - id: bcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Bikol
 - id: bcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bannoni
 - id: bcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bali (Nigeria)
 - id: bco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaluli
 - id: bcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bali (Democratic Republic of Congo)
 - id: bcq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bench
 - id: bcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babine
 - id: bcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kohumono
 - id: bct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bendi
 - id: bcu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awad Bing
 - id: bcv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shoo-Minda-Nye
 - id: bcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bana
 - id: bcy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bacama
 - id: bcz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bainouk-Gunyaamolo
 - id: bda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bayot
 - id: bdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Basap
 - id: bdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ember\xE1-Baud\xF3"
 - id: bdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bunama
 - id: bde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bade
 - id: bdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biage
 - id: bdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonggi
 - id: bdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baka (Sudan)
 - id: bdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burun
 - id: bdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bai
 - id: bdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budukh
 - id: bdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indonesian Bajau
 - id: bdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buduma
 - id: bdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baldemu
 - id: bdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morom
 - id: bdp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bende
 - id: bdq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahnar
 - id: bdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Coast Bajau
 - id: bds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burunge
 - id: bdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bokoto
 - id: bdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oroko
 - id: bdv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bodo Parja
 - id: bdw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baham
 - id: bdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budong-Budong
 - id: bdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bandjalang
 - id: bdz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Badeshi
 - id: bea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beaver
 - id: beb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bebele
 - id: bec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iceve-Maci
 - id: bed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bedoanas
 - id: bee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Byangsi
 - id: bef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Benabena
 - id: beg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Belait
 - id: beh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biali
 - id: bei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bekati'
 - id: bej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beja
 - id: bek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bebeli
 - id: bel
+  props:
+    alpha_2: be
   tags:
   - individual
   - living
   title:
     en: Belarusian
 - id: bem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bemba (Zambia)
 - id: ben
+  props:
+    alpha_2: bn
   tags:
   - individual
   - living
   title:
     en: Bengali
 - id: beo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beami
 - id: bep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Besoa
 - id: beq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beembe
 - id: bes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Besme
 - id: bet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Guiberoua B\xE9te"
 - id: beu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Blagar
 - id: bev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Daloa B\xE9t\xE9"
 - id: bew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Betawi
 - id: bex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jur Modo
 - id: bey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beli (Papua New Guinea)
 - id: bez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bena (Tanzania)
 - id: bfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bari
 - id: bfb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pauri Bareli
 - id: bfc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panyi Bai
 - id: bfd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bafut
 - id: bfe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Betaf
 - id: bff
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bofi
 - id: bfg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busang Kayan
 - id: bfh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Blafe
 - id: bfi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: British Sign Language
 - id: bfj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bafanji
 - id: bfk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ban Khor Sign Language
 - id: bfl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Banda-Nd\xE9l\xE9"
 - id: bfm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mmen
 - id: bfn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bunak
 - id: bfo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malba Birifor
 - id: bfp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beba
 - id: bfq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Badaga
 - id: bfr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bazigar
 - id: bfs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Bai
 - id: bft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balti
 - id: bfu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gahri
 - id: bfw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bondo
 - id: bfx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bantayanon
 - id: bfy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagheli
 - id: bfz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mahasu Pahari
 - id: bga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwamhi-Wuri
 - id: bgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bobongko
 - id: bgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haryanvi
 - id: bgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rathwi Bareli
 - id: bge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bauria
 - id: bgf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangandu
 - id: bgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bugun
 - id: bgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Giangan
 - id: bgj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangolan
 - id: bgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bit
 - id: bgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bo (Laos)
 - id: bgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Balochi
 - id: bgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baga Koga
 - id: bgp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Balochi
 - id: bgq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagri
 - id: bgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bawm Chin
 - id: bgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagabawa
 - id: bgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bughotu
 - id: bgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbongno
 - id: bgv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warkay-Bipim
 - id: bgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhatri
 - id: bgx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balkan Gagauz Turkish
 - id: bgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Benggoi
 - id: bgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banggai
 - id: bha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bharia
 - id: bhb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhili
 - id: bhc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biga
 - id: bhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhadrawahi
 - id: bhe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhaya
 - id: bhf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Odiai
 - id: bhg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binandere
 - id: bhh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukharic
 - id: bhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhilali
 - id: bhj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahing
 - id: bhl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bimin
 - id: bhm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bathari
 - id: bhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bohtan Neo-Aramaic
 - id: bho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhojpuri
 - id: bhp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bima
 - id: bhq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tukang Besi South
 - id: bhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bara Malagasy
 - id: bhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buwal
 - id: bht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhattiyali
 - id: bhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhunjia
 - id: bhv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahau
 - id: bhw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biak
 - id: bhx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhalay
 - id: bhy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhele
 - id: bhz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bada (Indonesia)
 - id: bia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Badimaya
 - id: bib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bissa
 - id: bic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bikaru
 - id: bid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bidiyo
 - id: bie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bepour
 - id: bif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biafada
 - id: big
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biangai
 - id: bij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vaghat-Ya-Bijim-Legeri
 - id: bik
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Bikol
 - id: bil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bile
 - id: bim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bimoba
 - id: bin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bini
 - id: bio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nai
 - id: bip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bila
 - id: biq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bipi
 - id: bir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bisorio
 - id: bis
+  props:
+    alpha_2: bi
   tags:
   - individual
   - living
   title:
     en: Bislama
 - id: bit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berinomo
 - id: biu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biete
 - id: biv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Birifor
 - id: biw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kol (Cameroon)
 - id: bix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bijori
 - id: biy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birhor
 - id: biz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baloi
 - id: bja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budza
 - id: bjb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Banggarla
 - id: bjc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bariji
 - id: bje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biao-Jiao Mien
 - id: bjf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barzani Jewish Neo-Aramaic
 - id: bjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bidyogo
 - id: bjh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahinemo
 - id: bji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burji
 - id: bjj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanauji
 - id: bjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barok
 - id: bjl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bulu (Papua New Guinea)
 - id: bjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bajelani
 - id: bjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banjar
 - id: bjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mid-Southern Banda
 - id: bjp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fanamaket
 - id: bjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binumarien
 - id: bjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bajan
 - id: bjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balanta-Ganja
 - id: bju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busuu
 - id: bjv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bedjond
 - id: bjw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Bakw\xE9"
 - id: bjx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banao Itneg
 - id: bjy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bayali
 - id: bjz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baruga
 - id: bka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyak
 - id: bkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baka (Cameroon)
 - id: bkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binukid
 - id: bkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beeke
 - id: bkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buraka
 - id: bkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakoko
 - id: bki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baki
 - id: bkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pande
 - id: bkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brokskat
 - id: bkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berik
 - id: bkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kom (Cameroon)
 - id: bkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukitan
 - id: bko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwa'
 - id: bkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boko (Democratic Republic of Congo)
 - id: bkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Bakair\xED"
 - id: bkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakumpai
 - id: bks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Sorsoganon
 - id: bkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boloki
 - id: bku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buhid
 - id: bkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bekwarra
 - id: bkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bekwel
 - id: bkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baikeno
 - id: bky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bokyi
 - id: bkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bungku
 - id: bla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siksika
 - id: blb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilua
 - id: blc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bella Coola
 - id: bld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolango
 - id: ble
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balanta-Kentohe
 - id: blf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buol
 - id: blg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balau
 - id: blh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuwaa
 - id: bli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolia
 - id: blj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolongan
 - id: blk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pa'o Karen
 - id: bll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Biloxi
 - id: blm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beli (Sudan)
 - id: bln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Catanduanes Bikol
 - id: blo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anii
 - id: blp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Blablanga
 - id: blq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baluan-Pam
 - id: blr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Blang
 - id: bls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balaesang
 - id: blt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Dam
 - id: blv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolo
 - id: blw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balangao
 - id: blx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mag-Indi Ayta
 - id: bly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Notre
 - id: blz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balantak
 - id: bma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lame
 - id: bmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bembe
 - id: bmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biem
 - id: bmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baga Manduri
 - id: bme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Limassa
 - id: bmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bom
 - id: bmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamwe
 - id: bmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kein
 - id: bmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagirmi
 - id: bmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bote-Majhi
 - id: bmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghayavi
 - id: bml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bomboli
 - id: bmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Betsimisaraka Malagasy
 - id: bmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bina (Papua New Guinea)
 - id: bmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bambalang
 - id: bmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bulgebi
 - id: bmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bomu
 - id: bmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muinane
 - id: bms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilma Kanuri
 - id: bmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biao Mon
 - id: bmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Somba-Siawari
 - id: bmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bum
 - id: bmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bomwali
 - id: bmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baimak
 - id: bmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baramu
 - id: bna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonerate
 - id: bnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bookan
 - id: bnc
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Bontok
 - id: bnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banda (Indonesia)
 - id: bne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bintauna
 - id: bnf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masiwang
 - id: bng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Benga
 - id: bni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangi
 - id: bnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Tawbuid
 - id: bnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bierebo
 - id: bnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boon
 - id: bnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batanga
 - id: bnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bunun
 - id: bno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bantoanon
 - id: bnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bola
 - id: bnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bantik
 - id: bnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Butmas-Tur
 - id: bns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bundeli
 - id: bnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bentong
 - id: bnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonerif
 - id: bnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bisis
 - id: bnx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangubangu
 - id: bny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bintulu
 - id: bnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beezen
 - id: boa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bora
 - id: bob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aweer
 - id: bod
+  props:
+    alpha_2: bo
   tags:
   - individual
   - living
   title:
     en: Tibetan
 - id: boe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mundabli
 - id: bof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolon
 - id: bog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamako Sign Language
 - id: boh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boma
 - id: boi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Barbare\xF1o"
 - id: boj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anjam
 - id: bok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonjo
 - id: bol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bole
 - id: bom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berom
 - id: bon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bine
 - id: boo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tiemac\xE8w\xE8 Bozo"
 - id: bop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonkiman
 - id: boq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bogaya
 - id: bor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Bor\xF4ro"
 - id: bos
+  props:
+    alpha_2: bs
   tags:
   - individual
   - living
   title:
     en: Bosnian
 - id: bot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bongo
 - id: bou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bondei
 - id: bov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuwuli
 - id: bow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Rema
 - id: box
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buamu
 - id: boy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bodo (Central African Republic)
 - id: boz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ti\xE9yaxo Bozo"
 - id: bpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daakaka
 - id: bpb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Barbacoas
 - id: bpd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banda-Banda
 - id: bpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonggo
 - id: bph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Botlikh
 - id: bpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagupi
 - id: bpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binji
 - id: bpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orowe
 - id: bpl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Broome Pearling Lugger Pidgin
 - id: bpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biyom
 - id: bpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dzao Min
 - id: bpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anasi
 - id: bpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaure
 - id: bpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banda Malay
 - id: bpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koronadal Blaan
 - id: bps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarangani Blaan
 - id: bpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Barrow Point
 - id: bpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bongu
 - id: bpv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bian Marind
 - id: bpw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bo (Papua New Guinea)
 - id: bpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palya Bareli
 - id: bpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bishnupriya
 - id: bpz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilba
 - id: bqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tchumbuli
 - id: bqb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagusa
 - id: bqc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boko (Benin)
 - id: bqd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bung
 - id: bqf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Baga Kaloum
 - id: bqg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bago-Kusuntu
 - id: bqh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baima
 - id: bqi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakhtiari
 - id: bqj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bandial
 - id: bqk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Banda-Mbr\xE8s"
 - id: bql
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilakura
 - id: bqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wumboko
 - id: bqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bulgarian Sign Language
 - id: bqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balo
 - id: bqp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busa
 - id: bqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biritai
 - id: bqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burusu
 - id: bqs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bosngun
 - id: bqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamukumbit
 - id: bqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boguru
 - id: bqv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koro Wachi
 - id: bqw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buru (Nigeria)
 - id: bqx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baangi
 - id: bqy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bengkala Sign Language
 - id: bqz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakaka
 - id: bra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Braj
 - id: brb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lave
 - id: brc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Berbice Creole Dutch
 - id: brd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baraamu
 - id: bre
+  props:
+    alpha_2: br
   tags:
   - individual
   - living
   title:
     en: Breton
 - id: brf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bera
 - id: brg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baure
 - id: brh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brahui
 - id: bri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mokpwe
 - id: brj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bieria
 - id: brk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Birked
 - id: brl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birwa
 - id: brm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barambu
 - id: brn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boruca
 - id: bro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brokkat
 - id: brp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barapasi
 - id: brq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Breri
 - id: brr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birao
 - id: brs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baras
 - id: brt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bitare
 - id: bru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Bru
 - id: brv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Bru
 - id: brw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bellari
 - id: brx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bodo (India)
 - id: bry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burui
 - id: brz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilbil
 - id: bsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abinomn
 - id: bsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brunei Bisaya
 - id: bsc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bassari
 - id: bse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wushi
 - id: bsf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bauchi
 - id: bsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bashkardi
 - id: bsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kati
 - id: bsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bassossi
 - id: bsj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangwinji
 - id: bsk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burushaski
 - id: bsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Basa-Gumna
 - id: bsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busami
 - id: bsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barasana-Eduria
 - id: bso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buso
 - id: bsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baga Sitemu
 - id: bsq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bassa
 - id: bsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bassa-Kontagora
 - id: bss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akoose
 - id: bst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Basketo
 - id: bsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bahonsuai
 - id: bsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Baga Soban\xE9"
 - id: bsw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baiso
 - id: bsx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangkam
 - id: bsy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sabah Bisaya
 - id: bta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bata
 - id: btc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bati (Cameroon)
 - id: btd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Dairi
 - id: bte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gamo-Ningi
 - id: btf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birgit
 - id: btg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Gagnoa B\xE9t\xE9"
 - id: bth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biatah Bidayuh
 - id: bti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burate
 - id: btj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bacanese Malay
 - id: btm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Mandailing
 - id: btn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ratagnon
 - id: bto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rinconada Bikol
 - id: btp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budibud
 - id: btq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batek
 - id: btr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baetora
 - id: bts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Simalungun
 - id: btt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bete-Bendi
 - id: btu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batu
 - id: btv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bateri
 - id: btw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Butuanon
 - id: btx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Karo
 - id: bty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bobot
 - id: btz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak Alas-Kluet
 - id: bua
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Buriat
 - id: bub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bua
 - id: buc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bushi
 - id: bud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ntcham
 - id: bue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Beothuk
 - id: buf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bushoong
 - id: bug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buginese
 - id: buh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Younuo Bunu
 - id: bui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bongili
 - id: buj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Basa-Gurmana
 - id: buk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bugawac
 - id: bul
+  props:
+    alpha_2: bg
   tags:
   - individual
   - living
   title:
     en: Bulgarian
 - id: bum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bulu (Cameroon)
 - id: bun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sherbro
 - id: buo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Terei
 - id: bup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busoa
 - id: buq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brem
 - id: bus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bokobaru
 - id: but
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bungain
 - id: buu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budu
 - id: buv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bun
 - id: buw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bubi
 - id: bux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boghom
 - id: buy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bullom So
 - id: buz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukwen
 - id: bva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barein
 - id: bvb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bube
 - id: bvc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baelelea
 - id: bvd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baeggu
 - id: bve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berau Malay
 - id: bvf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boor
 - id: bvg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonkeng
 - id: bvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bure
 - id: bvi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Belanda Viri
 - id: bvj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baan
 - id: bvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukat
 - id: bvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolivian Sign Language
 - id: bvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bamunka
 - id: bvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buna
 - id: bvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolgo
 - id: bvp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bumang
 - id: bvq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birri
 - id: bvr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burarra
 - id: bvt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bati (Indonesia)
 - id: bvu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukit Malay
 - id: bvv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Baniva
 - id: bvw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boga
 - id: bvx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dibole
 - id: bvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baybayanon
 - id: bvz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bauzi
 - id: bwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwatoo
 - id: bwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namosi-Naitasiri-Serua
 - id: bwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwile
 - id: bwd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwaidoka
 - id: bwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwe Karen
 - id: bwf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boselewa
 - id: bwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barwe
 - id: bwh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bishuo
 - id: bwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baniwa
 - id: bwj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "L\xE1\xE1 L\xE1\xE1 Bwamu"
 - id: bwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bauwaki
 - id: bwl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwela
 - id: bwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biwat
 - id: bwn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wunai Bunu
 - id: bwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boro (Ethiopia)
 - id: bwp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandobo Bawah
 - id: bwq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Southern Bobo Madar\xE9"
 - id: bwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bura-Pabir
 - id: bws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bomboma
 - id: bwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bafaw-Balong
 - id: bwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buli (Ghana)
 - id: bww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwa
 - id: bwx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bu-Nao Bunu
 - id: bwy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cwi Bwamu
 - id: bwz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwisi
 - id: bxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tairaha
 - id: bxb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Belanda Bor
 - id: bxc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molengue
 - id: bxd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pela
 - id: bxe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Birale
 - id: bxf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilur
 - id: bxg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangala
 - id: bxh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buhutu
 - id: bxi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pirlatapa
 - id: bxj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bayungu
 - id: bxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukusu
 - id: bxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jalkunan
 - id: bxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mongolia Buriat
 - id: bxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burduna
 - id: bxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barikanchi
 - id: bxp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bebil
 - id: bxq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beele
 - id: bxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Russia Buriat
 - id: bxs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Busam
 - id: bxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: China Buriat
 - id: bxv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berakou
 - id: bxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bankagooma
 - id: bxz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binahari
 - id: bya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batak
 - id: byb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bikya
 - id: byc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ubaghara
 - id: byd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Benyadu'
 - id: bye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pouye
 - id: byf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bete
 - id: byg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Baygo
 - id: byh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhujel
 - id: byi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buyu
 - id: byj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bina (Nigeria)
 - id: byk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biao
 - id: byl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bayono
 - id: bym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bidyara
 - id: byn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilin
 - id: byo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biyo
 - id: byp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bumaji
 - id: byq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Basay
 - id: byr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baruya
 - id: bys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burak
 - id: byt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Berti
 - id: byv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Medumba
 - id: byw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Belhariya
 - id: byx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qaqet
 - id: byz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banaro
 - id: bza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bandi
 - id: bzb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andio
 - id: bzc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Betsimisaraka Malagasy
 - id: bzd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bribri
 - id: bze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jenaama Bozo
 - id: bzf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boikin
 - id: bzg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Babuza
 - id: bzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapos Buang
 - id: bzi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bisu
 - id: bzj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Belize Kriol English
 - id: bzk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nicaragua Creole English
 - id: bzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boano (Sulawesi)
 - id: bzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolondo
 - id: bzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Boano (Maluku)
 - id: bzo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bozaba
 - id: bzp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kemberano
 - id: bzq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buli (Indonesia)
 - id: bzr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Biri
 - id: bzs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brazilian Sign Language
 - id: bzt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Brithenig
 - id: bzu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burmeso
 - id: bzv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naami
 - id: bzw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Basa (Nigeria)
 - id: bzx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "K\u025Bl\u025Bngaxo Bozo"
 - id: bzy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Obanliku
 - id: bzz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Evant
 - id: caa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Chort\xED"
 - id: cab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garifuna
 - id: cac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuj
 - id: cad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caddo
 - id: cae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lehar
 - id: caf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Carrier
 - id: cag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nivacl\xE9"
 - id: cah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cahuarano
 - id: caj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Chan\xE9"
 - id: cak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaqchikel
 - id: cal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carolinian
 - id: cam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cemuh\xEE"
 - id: can
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chambri
 - id: cao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ch\xE1cobo"
 - id: cap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chipaya
 - id: caq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Car Nicobarese
 - id: car
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galibi Carib
 - id: cas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tsiman\xE9"
 - id: cat
+  props:
+    alpha_2: ca
   tags:
   - individual
   - living
   title:
     en: Catalan
 - id: cav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cavine\xF1a"
 - id: caw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Callawalla
 - id: cax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiquitano
 - id: cay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cayuga
 - id: caz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Canichana
 - id: cbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cabiyar\xED"
 - id: cbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carapana
 - id: cbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carijona
 - id: cbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chimila
 - id: cbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chachi
 - id: cbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ede Cabe
 - id: cbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chavacano
 - id: cbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bualkhaw Chin
 - id: cbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyahkur
 - id: cbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Izora
 - id: cbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsucuba
 - id: cbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cashibo-Cacataibo
 - id: cbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cashinahua
 - id: cbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chayahuita
 - id: cbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Candoshi-Shapra
 - id: cbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cacua
 - id: cbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinabalian
 - id: cby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carabayo
 - id: cca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cauca
 - id: ccc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chamicuro
 - id: ccd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cafundo Creole
 - id: cce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chopi
 - id: ccg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samba Daka
 - id: cch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atsam
 - id: ccj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kasanga
 - id: ccl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cutchi-Swahili
 - id: ccm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malaccan Creole Malay
 - id: cco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Comaltepec Chinantec
 - id: ccp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chakma
 - id: ccr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cacaopera
 - id: cda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Choni
 - id: cde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chenchu
 - id: cdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiru
 - id: cdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chamari
 - id: cdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chambeali
 - id: cdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chodri
 - id: cdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Churahi
 - id: cdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chepang
 - id: cdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chaudangsi
 - id: cdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Min Dong Chinese
 - id: cdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cinda-Regi-Tiyal
 - id: cds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chadian Sign Language
 - id: cdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chadong
 - id: cdz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koda
 - id: cea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lower Chehalis
 - id: ceb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cebuano
 - id: ceg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chamacoco
 - id: cek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Khumi Chin
 - id: cen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cen
 - id: ces
+  props:
+    alpha_2: cs
   tags:
   - individual
   - living
   title:
     en: Czech
 - id: cet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cent\xFA\xFAm"
 - id: cfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dijim-Bwilim
 - id: cfd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cara
 - id: cfg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Como Karim
 - id: cfm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Falam Chin
 - id: cga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Changriwa
 - id: cgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagayanen
 - id: cgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiga
 - id: cgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chocangacakha
 - id: cha
+  props:
+    alpha_2: ch
   tags:
   - individual
   - living
   title:
     en: Chamorro
 - id: chb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chibcha
 - id: chc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Catawba
 - id: chd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Highland Oaxaca Chontal
 - id: che
+  props:
+    alpha_2: ce
   tags:
   - individual
   - living
   title:
     en: Chechen
 - id: chf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabasco Chontal
 - id: chg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chagatai
 - id: chh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinook
 - id: chj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ojitl\xE1n Chinantec"
 - id: chk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuukese
 - id: chl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cahuilla
 - id: chm
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Mari (Russia)
 - id: chn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinook jargon
 - id: cho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Choctaw
 - id: chp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chipewyan
 - id: chq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quiotepec Chinantec
 - id: chr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cherokee
 - id: cht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Chol\xF3n"
 - id: chu
+  props:
+    alpha_2: cu
   tags:
   - individual
   - ancient
   title:
     en: Church Slavic
 - id: chv
+  props:
+    alpha_2: cv
   tags:
   - individual
   - living
   title:
     en: Chuvash
 - id: chw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuwabu
 - id: chx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chantyal
 - id: chy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cheyenne
 - id: chz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ozumac\xEDn Chinantec"
 - id: cia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cia-Cia
 - id: cib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ci Gbe
 - id: cic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chickasaw
 - id: cid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chimariko
 - id: cie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cineni
 - id: cih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinali
 - id: cik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chitkuli Kinnauri
 - id: cim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cimbrian
 - id: cin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cinta Larga
 - id: cip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiapanec
 - id: cir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiri
 - id: ciw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chippewa
 - id: ciy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chaima
 - id: cja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Cham
 - id: cje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chru
 - id: cjh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Upper Chehalis
 - id: cji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chamalal
 - id: cjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chokwe
 - id: cjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Cham
 - id: cjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chenapian
 - id: cjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ash\xE9ninka Pajonal"
 - id: cjp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cab\xE9car"
 - id: cjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shor
 - id: cjv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuave
 - id: cjy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jinyu Chinese
 - id: ckb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Kurdish
 - id: ckh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chak
 - id: ckl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cibak
 - id: ckn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaang Chin
 - id: cko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anufo
 - id: ckq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kajakse
 - id: ckr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kairak
 - id: cks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tayo
 - id: ckt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chukot
 - id: cku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koasati
 - id: ckv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kavalan
 - id: ckx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caka
 - id: cky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cakfem-Mushere
 - id: ckz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cakchiquel-Quich\xE9 Mixed Language"
 - id: cla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ron
 - id: clc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chilcotin
 - id: cld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chaldean Neo-Aramaic
 - id: cle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lealao Chinantec
 - id: clh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chilisso
 - id: cli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chakali
 - id: clj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laitu Chin
 - id: clk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idu-Mishmi
 - id: cll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chala
 - id: clm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Clallam
 - id: clo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lowland Oaxaca Chontal
 - id: clt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lautu Chin
 - id: clu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caluyanun
 - id: clw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chulym
 - id: cly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Highland Chatino
 - id: cma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maa
 - id: cme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cerma
 - id: cmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Mongolian
 - id: cmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ember\xE1-Cham\xED"
 - id: cml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Campalagian
 - id: cmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Michigamea
 - id: cmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandarin Chinese
 - id: cmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Mnong
 - id: cmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mro-Khimi Chin
 - id: cms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Messapic
 - id: cmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Camtho
 - id: cna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Changthang
 - id: cnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinbon Chin
 - id: cnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "C\xF4\xF4ng"
 - id: cng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Qiang
 - id: cnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hakha Chin
 - id: cni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ash\xE1ninka"
 - id: cnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khumi Chin
 - id: cnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lalana Chinantec
 - id: cno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Con
 - id: cns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Asmat
 - id: cnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tepetotutla Chinantec
 - id: cnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chenoua
 - id: cnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngawn Chin
 - id: cnx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Cornish
 - id: coa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cocos Islands Malay
 - id: cob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chicomuceltec
 - id: coc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cocopa
 - id: cod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cocama-Cocamilla
 - id: coe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koreguaje
 - id: cof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Colorado
 - id: cog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chong
 - id: coh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chonyi-Dzihana-Kauma
 - id: coj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cochimi
 - id: cok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santa Teresa Cora
 - id: col
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Columbia-Wenatchi
 - id: com
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Comanche
 - id: con
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cof\xE1n"
 - id: coo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Comox
 - id: cop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Coptic
 - id: coq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Coquille
 - id: cor
+  props:
+    alpha_2: kw
   tags:
   - individual
   - living
   title:
     en: Cornish
 - id: cos
+  props:
+    alpha_2: co
   tags:
   - individual
   - living
   title:
     en: Corsican
 - id: cot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caquinte
 - id: cou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wamey
 - id: cov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cao Miao
 - id: cow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cowlitz
 - id: cox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nanti
 - id: coz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chochotec
 - id: cpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palantla Chinantec
 - id: cpb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ucayali-Yur\xFAa Ash\xE9ninka"
 - id: cpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ajy\xEDninka Apurucayali"
 - id: cpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cappadocian Greek
 - id: cpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinese Pidgin English
 - id: cpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cherepon
 - id: cpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpeego
 - id: cps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Capiznon
 - id: cpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pichis Ash\xE9ninka"
 - id: cpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pu-Xian Chinese
 - id: cpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "South Ucayali Ash\xE9ninka"
 - id: cqd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuanqiandian Cluster Miao
 - id: cra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chara
 - id: crb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Island Carib
 - id: crc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lonwolwol
 - id: crd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coeur d'Alene
 - id: cre
+  props:
+    alpha_2: cr
   tags:
   - macrolanguage
   - living
   title:
     en: Cree
 - id: crf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Caramanta
 - id: crg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Michif
 - id: crh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Crimean Tatar
 - id: cri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "S\xE3otomense"
 - id: crj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern East Cree
 - id: crk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plains Cree
 - id: crl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern East Cree
 - id: crm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moose Cree
 - id: crn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: El Nayar Cora
 - id: cro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Crow
 - id: crq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iyo'wujwa Chorote
 - id: crr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Carolina Algonquian
 - id: crs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seselwa Creole French
 - id: crt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iyojwa'ja Chorote
 - id: crv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chaura
 - id: crw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chrau
 - id: crx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carrier
 - id: cry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cori
 - id: crz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Cruze\xF1o"
 - id: csa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiltepec Chinantec
 - id: csb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kashubian
 - id: csc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Catalan Sign Language
 - id: csd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chiangmai Sign Language
 - id: cse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Czech Sign Language
 - id: csf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cuba Sign Language
 - id: csg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chilean Sign Language
 - id: csh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asho Chin
 - id: csi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Coast Miwok
 - id: csj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Songlai Chin
 - id: csk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jola-Kasa
 - id: csl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chinese Sign Language
 - id: csm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Sierra Miwok
 - id: csn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Colombian Sign Language
 - id: cso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sochiapam Chinantec
 - id: csq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Croatia Sign Language
 - id: csr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Costa Rican Sign Language
 - id: css
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Southern Ohlone
 - id: cst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Ohlone
 - id: csv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumtu Chin
 - id: csw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swampy Cree
 - id: csy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siyin Chin
 - id: csz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coos
 - id: cta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tataltepec Chatino
 - id: ctc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chetco
 - id: ctd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tedim Chin
 - id: cte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tepinapa Chinantec
 - id: ctg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chittagonian
 - id: cth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thaiphum Chin
 - id: ctl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlacoatzintepec Chinantec
 - id: ctm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chitimacha
 - id: ctn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chhintange
 - id: cto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ember\xE1-Cat\xEDo"
 - id: ctp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Highland Chatino
 - id: cts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Catanduanes Bikol
 - id: ctt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wayanad Chetti
 - id: ctu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chol
 - id: ctz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zacatepec Chatino
 - id: cua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cua
 - id: cub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cubeo
 - id: cuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usila Chinantec
 - id: cug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cung
 - id: cuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chuka
 - id: cui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cuiba
 - id: cuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mashco Piro
 - id: cuk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Blas Kuna
 - id: cul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Culina
 - id: cuo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cumanagoto
 - id: cup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Cupe\xF1o"
 - id: cuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cun
 - id: cur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chhulung
 - id: cut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teutila Cuicatec
 - id: cuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Ya
 - id: cuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cuvok
 - id: cuw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chukwa
 - id: cux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tepeuxila Cuicatec
 - id: cvg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chug
 - id: cvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Valle Nacional Chinantec
 - id: cwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabwa
 - id: cwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maindo
 - id: cwd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Woods Cree
 - id: cwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwere
 - id: cwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chewong
 - id: cwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuwaataay
 - id: cya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nopala Chatino
 - id: cyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cayubaba
 - id: cym
+  props:
+    alpha_2: cy
   tags:
   - individual
   - living
   title:
     en: Welsh
 - id: cyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cuyonon
 - id: czh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huizhou Chinese
 - id: czk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Knaanic
 - id: czn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zenzontepec Chatino
 - id: czo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Min Zhong Chinese
 - id: czt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zotung Chin
 - id: daa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Dangal\xE9at"
 - id: dac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dambi
 - id: dad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marik
 - id: dae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duupa
 - id: dag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dagbani
 - id: dah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwahatike
 - id: dai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Day
 - id: daj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dar Fur Daju
 - id: dak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dakota
 - id: dal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dahalo
 - id: dam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Damakawa
 - id: dan
+  props:
+    alpha_2: da
   tags:
   - individual
   - living
   title:
     en: Danish
 - id: dao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daai Chin
 - id: daq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dandami Maria
 - id: dar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dargwa
 - id: das
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daho-Doo
 - id: dau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dar Sila Daju
 - id: dav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taita
 - id: daw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Davawenyo
 - id: dax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dayi
 - id: daz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dao
 - id: dba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangime
 - id: dbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Deno
 - id: dbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dadiya
 - id: dbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dabe
 - id: dbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Edopi
 - id: dbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dogul Dom Dogon
 - id: dbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doka
 - id: dbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ida'an
 - id: dbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dyirbal
 - id: dbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duguri
 - id: dbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duriankere
 - id: dbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dulbu
 - id: dbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duwai
 - id: dbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daba
 - id: dbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dabarre
 - id: dbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ben Tey Dogon
 - id: dbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bondum Dom Dogon
 - id: dbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dungu
 - id: dbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bankan Tey Dogon
 - id: dby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dibiyaso
 - id: dcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Deccan
 - id: dcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Negerhollands
 - id: dda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dadi Dadi
 - id: ddd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dongotono
 - id: dde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doondo
 - id: ddg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fataluku
 - id: ddi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Goodenough
 - id: ddj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jaru
 - id: ddn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dendi (Benin)
 - id: ddo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dido
 - id: ddr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dhudhuroa
 - id: dds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Donno So Dogon
 - id: ddw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dawera-Daweloor
 - id: dec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dagik
 - id: ded
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dedua
 - id: dee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dewoin
 - id: def
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dezfuli
 - id: deg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Degema
 - id: deh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dehwari
 - id: dei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Demisa
 - id: dek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dek
 - id: del
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Delaware
 - id: dem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dem
 - id: den
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Slave (Athapascan)
 - id: dep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pidgin Delaware
 - id: deq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dendi (Central African Republic)
 - id: der
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Deori
 - id: des
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Desano
 - id: deu
+  props:
+    alpha_2: de
   tags:
   - individual
   - living
   title:
     en: German
 - id: dev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Domung
 - id: dez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dengese
 - id: dga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Dagaare
 - id: dgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bunoge Dogon
 - id: dgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Casiguran Dumagat Agta
 - id: dgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dagaari Dioula
 - id: dge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Degenan
 - id: dgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doga
 - id: dgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dghwede
 - id: dgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Dagara
 - id: dgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dagba
 - id: dgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andaandi
 - id: dgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dagoman
 - id: dgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dogri (individual language)
 - id: dgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dogrib
 - id: dgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dogoso
 - id: dgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ndra'ngith
 - id: dgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Degaru
 - id: dgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Daungwurrung
 - id: dgx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doghoro
 - id: dgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daga
 - id: dhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhundari
 - id: dhg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhangu-Djangu
 - id: dhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhimal
 - id: dhl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhalandji
 - id: dhm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zemba
 - id: dhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhanki
 - id: dho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhodia
 - id: dhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhargari
 - id: dhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhaiso
 - id: dhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dhurga
 - id: dhv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dehu
 - id: dhw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhanwar (Nepal)
 - id: dhx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhungaloo
 - id: dia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dia
 - id: dib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Central Dinka
 - id: dic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakota Dida
 - id: did
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Didinga
 - id: dif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dieri
 - id: dig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Digo
 - id: dih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumiai
 - id: dii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dimbong
 - id: dij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dai
 - id: dik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Dinka
 - id: dil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dilling
 - id: dim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dime
 - id: din
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Dinka
 - id: dio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dibo
 - id: dip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northeastern Dinka
 - id: diq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dimli (individual language)
 - id: dir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dirim
 - id: dis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dimasa
 - id: dit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dirari
 - id: diu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Diriku
 - id: div
+  props:
+    alpha_2: dv
   tags:
   - individual
   - living
   title:
     en: Dhivehi
 - id: diw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Dinka
 - id: dix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dixon Reef
 - id: diy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Diuwe
 - id: diz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ding
 - id: dja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Djadjawurrung
 - id: djb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djinba
 - id: djc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dar Daju Daju
 - id: djd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djamindjung
 - id: dje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zarma
 - id: djf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Djangun
 - id: dji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djinang
 - id: djj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djeebbana
 - id: djk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Maroon Creole
 - id: djm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jamsay Dogon
 - id: djn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djauan
 - id: djo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jangkang
 - id: djr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djambarrpuyngu
 - id: dju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kapriman
 - id: djw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Djawi
 - id: dka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dakpakha
 - id: dkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dakka
 - id: dkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuijau
 - id: dks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Dinka
 - id: dkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mazagway
 - id: dlg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dolgan
 - id: dlk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dahalik
 - id: dlm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dalmatian
 - id: dln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Darlong
 - id: dma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duma
 - id: dmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mombo Dogon
 - id: dmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gavak
 - id: dmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Madhi Madhi
 - id: dme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dugwor
 - id: dmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Kinabatangan
 - id: dmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Domaaki
 - id: dml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dameli
 - id: dmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dama
 - id: dmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kemedzung
 - id: dmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Damar
 - id: dms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dampelas
 - id: dmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dubu
 - id: dmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dumpas
 - id: dmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mudburra
 - id: dmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dema
 - id: dmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Demta
 - id: dna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Grand Valley Dani
 - id: dnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daonda
 - id: dne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndendeule
 - id: dng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dungan
 - id: dni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lower Grand Valley Dani
 - id: dnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dan
 - id: dnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dengka
 - id: dnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Dz\xF9\xF9ngoo"
 - id: dnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Danaru
 - id: dnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mid Grand Valley Dani
 - id: dnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Danau
 - id: dnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Danu
 - id: dnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Dani
 - id: dny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Den\xED"
 - id: doa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dom
 - id: dob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dobu
 - id: doc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Dong
 - id: doe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doe
 - id: dof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Domu
 - id: doh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dong
 - id: doi
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Dogri (macrolanguage)
 - id: dok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dondo
 - id: dol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doso
 - id: don
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toura (Papua New Guinea)
 - id: doo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dongo
 - id: dop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lukpa
 - id: doq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dominican Sign Language
 - id: dor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dori'o
 - id: dos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Dogos\xE9"
 - id: dot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dass
 - id: dov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dombe
 - id: dow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doyayo
 - id: dox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bussa
 - id: doy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dompo
 - id: doz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dorze
 - id: dpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papar
 - id: drb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dair
 - id: drc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minderico
 - id: drd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Darmiya
 - id: dre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dolpo
 - id: drg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rungus
 - id: dri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: C'lela
 - id: drl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paakantyi
 - id: drn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Damar
 - id: dro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daro-Matu Melanau
 - id: drq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dura
 - id: drr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dororo
 - id: drs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gedeo
 - id: drt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Drents
 - id: dru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rukai
 - id: dry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Darai
 - id: dsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lower Sorbian
 - id: dse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dutch Sign Language
 - id: dsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daasanach
 - id: dsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Disa
 - id: dsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Danish Sign Language
 - id: dsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dusner
 - id: dso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Desiya
 - id: dsq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tadaksahak
 - id: dta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daur
 - id: dtb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Labuk-Kinabatangan Kadazan
 - id: dtd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ditidaht
 - id: dth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Adithinngithigh
 - id: dti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ana Tinga Dogon
 - id: dtk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tene Kan Dogon
 - id: dtm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tomo Kan Dogon
 - id: dtn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Daats\u02BCi\u0301in"
 - id: dto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tommo So Dogon
 - id: dtp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kadazan Dusun
 - id: dtr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lotud
 - id: dts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toro So Dogon
 - id: dtt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toro Tegu Dogon
 - id: dtu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tebul Ure Dogon
 - id: dty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dotyali
 - id: dua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duala
 - id: dub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dubli
 - id: duc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duna
 - id: dud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hun-Saare
 - id: due
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umiray Dumaget Agta
 - id: duf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dumbea
 - id: dug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duruma
 - id: duh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dungra Bhil
 - id: dui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dumun
 - id: duk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uyajitaya
 - id: dul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alabat Island Agta
 - id: dum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Dutch (ca. 1050-1350)
 - id: dun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dusun Deyah
 - id: duo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dupaninan Agta
 - id: dup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duano
 - id: duq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dusun Malang
 - id: dur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dii
 - id: dus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dumi
 - id: duu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Drung
 - id: duv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duvle
 - id: duw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dusun Witu
 - id: dux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duungooma
 - id: duy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dicamay Agta
 - id: duz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Duli-Gey
 - id: dva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duau
 - id: dwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Diri
 - id: dwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dawro
 - id: dws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Dutton World Speedwords
 - id: dwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhuwal
 - id: dww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dawawa
 - id: dwy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhuwaya
 - id: dya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dyan
 - id: dyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dyaberdyaber
 - id: dyd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dyugun
 - id: dyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Villa Viciosa Agta
 - id: dyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djimini Senoufo
 - id: dym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yanda Dom Dogon
 - id: dyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dyangadi
 - id: dyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jola-Fonyi
 - id: dyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dyula
 - id: dyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dyaabugay
 - id: dza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunzu
 - id: dze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Djiwarli
 - id: dzg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dazaga
 - id: dzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dzalakha
 - id: dzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dzando
 - id: dzo
+  props:
+    alpha_2: dz
   tags:
   - individual
   - living
   title:
     en: Dzongkha
 - id: eaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karenggapa
 - id: ebg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ebughu
 - id: ebk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Bontok
 - id: ebo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Ebo
 - id: ebr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ebri\xE9"
 - id: ebu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Embu
 - id: ecr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Eteocretan
 - id: ecs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ecuadorian Sign Language
 - id: ecy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Eteocypriot
 - id: eee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: E
 - id: efa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Efai
 - id: efe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Efe
 - id: efi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Efik
 - id: ega
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ega
 - id: egl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emilian
 - id: ego
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eggon
 - id: egy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Egyptian (Ancient)
 - id: ehu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ehueun
 - id: eip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eipomek
 - id: eit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eitiep
 - id: eiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Askopan
 - id: eja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ejamat
 - id: eka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ekajuk
 - id: ekc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Eastern Karnic
 - id: eke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ekit
 - id: ekg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ekari
 - id: eki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eki
 - id: ekk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Standard Estonian
 - id: ekl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kol (Bangladesh)
 - id: ekm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elip
 - id: eko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koti
 - id: ekp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ekpeye
 - id: ekr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yace
 - id: eky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Kayah
 - id: ele
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elepi
 - id: elh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: El Hugeirat
 - id: eli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nding
 - id: elk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elkei
 - id: ell
+  props:
+    alpha_2: el
   tags:
   - individual
   - living
   title:
     en: Modern Greek (1453-)
 - id: elm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eleme
 - id: elo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: El Molo
 - id: elu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elu
 - id: elx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Elamite
 - id: ema
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emai-Iuleha-Ora
 - id: emb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Embaloh
 - id: eme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emerillon
 - id: emg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Meohang
 - id: emi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mussau-Emira
 - id: emk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Maninkakan
 - id: emm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mamulique
 - id: emn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eman
 - id: emp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Northern Ember\xE1"
 - id: ems
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pacific Gulf Yupik
 - id: emu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Muria
 - id: emw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emplawas
 - id: emx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Erromintxela
 - id: emy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Epigraphic Mayan
 - id: ena
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Apali
 - id: enb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Markweeta
 - id: enc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: En
 - id: end
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ende
 - id: enf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Forest Enets
 - id: eng
+  props:
+    alpha_2: en
   tags:
   - individual
   - living
   title:
     en: English
 - id: enh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tundra Enets
 - id: enl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enlhet
 - id: enm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle English (1100-1500)
 - id: enn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Engenni
 - id: eno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enggano
 - id: enq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enga
 - id: enr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emumu
 - id: enu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enu
 - id: env
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enwan (Edu State)
 - id: enw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enwan (Akwa Ibom State)
 - id: enx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enxet
 - id: eot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Beti (C\xF4te d'Ivoire)"
 - id: epi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Epie
 - id: epo
+  props:
+    alpha_2: eo
   tags:
   - individual
   - constructed
   title:
     en: Esperanto
 - id: era
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eravallan
 - id: erg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sie
 - id: erh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eruwa
 - id: eri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ogea
 - id: erk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Efate
 - id: ero
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Horpa
 - id: err
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Erre
 - id: ers
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ersu
 - id: ert
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eritai
 - id: erw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Erokwanas
 - id: ese
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ese Ejja
 - id: esg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aheri Gondi
 - id: esh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eshtehardi
 - id: esi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Alaskan Inupiatun
 - id: esk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwest Alaska Inupiatun
 - id: esl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Egypt Sign Language
 - id: esm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Esuma
 - id: esn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salvadoran Sign Language
 - id: eso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Estonian Sign Language
 - id: esq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Esselen
 - id: ess
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Siberian Yupik
 - id: est
+  props:
+    alpha_2: et
   tags:
   - macrolanguage
   - living
   title:
     en: Estonian
 - id: esu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Yupik
 - id: esy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eskayan
 - id: etb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Etebi
 - id: etc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Etchemin
 - id: eth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ethiopian Sign Language
 - id: etn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eton (Vanuatu)
 - id: eto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eton (Cameroon)
 - id: etr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Edolo
 - id: ets
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yekhee
 - id: ett
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Etruscan
 - id: etu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ejagham
 - id: etx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eten
 - id: etz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semimi
 - id: eus
+  props:
+    alpha_2: eu
   tags:
   - individual
   - living
   title:
     en: Basque
 - id: eve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Even
 - id: evh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uvbie
 - id: evn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Evenki
 - id: ewe
+  props:
+    alpha_2: ee
   tags:
   - individual
   - living
   title:
     en: Ewe
 - id: ewo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ewondo
 - id: ext
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Extremaduran
 - id: eya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Eyak
 - id: eyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keiyo
 - id: eza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ezaa
 - id: eze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uzekwe
 - id: faa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fasu
 - id: fab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fa d'Ambu
 - id: fad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wagi
 - id: faf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fagani
 - id: fag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Finongan
 - id: fah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baissa Fali
 - id: fai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Faiwol
 - id: faj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Faita
 - id: fak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fang (Cameroon)
 - id: fal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Fali
 - id: fam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fam
 - id: fan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fang (Equatorial Guinea)
 - id: fao
+  props:
+    alpha_2: fo
   tags:
   - individual
   - living
   title:
     en: Faroese
 - id: fap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palor
 - id: far
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fataleka
 - id: fas
+  props:
+    alpha_2: fa
   tags:
   - macrolanguage
   - living
   title:
     en: Persian
 - id: fat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fanti
 - id: fau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fayu
 - id: fax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fala
 - id: fay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Fars
 - id: faz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Fars
 - id: fbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Albay Bikol
 - id: fcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quebec Sign Language
 - id: fer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Feroge
 - id: ffi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Foia Foia
 - id: ffm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maasina Fulfulde
 - id: fgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fongoro
 - id: fia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nobiin
 - id: fie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fyer
 - id: fij
+  props:
+    alpha_2: fj
   tags:
   - individual
   - living
   title:
     en: Fijian
 - id: fil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Filipino
 - id: fin
+  props:
+    alpha_2: fi
   tags:
   - individual
   - living
   title:
     en: Finnish
 - id: fip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fipa
 - id: fir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Firan
 - id: fit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tornedalen Finnish
 - id: fiw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fiwaga
 - id: fkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kirya-Konz\u0259l"
 - id: fkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kven Finnish
 - id: fla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalispel-Pend d'Oreille
 - id: flh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Foau
 - id: fli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fali
 - id: fll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Fali
 - id: fln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Flinders Island
 - id: flr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fuliiru
 - id: fly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Flaaitaal
 - id: fmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fe'fe'
 - id: fmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Far Western Muria
 - id: fnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fanbak
 - id: fng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fanagalo
 - id: fni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fania
 - id: fod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Foodo
 - id: foi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Foi
 - id: fom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Foma
 - id: fon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fon
 - id: for
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fore
 - id: fos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Siraya
 - id: fpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fernando Po Creole English
 - id: fqs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fas
 - id: fra
+  props:
+    alpha_2: fr
   tags:
   - individual
   - living
   title:
     en: French
 - id: frc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cajun French
 - id: frd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fordata
 - id: frk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Frankish
 - id: frm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle French (ca. 1400-1600)
 - id: fro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old French (842-ca. 1400)
 - id: frp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arpitan
 - id: frq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Forak
 - id: frr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Frisian
 - id: frs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Frisian
 - id: frt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fortsenal
 - id: fry
+  props:
+    alpha_2: fy
   tags:
   - individual
   - living
   title:
     en: Western Frisian
 - id: fse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Finnish Sign Language
 - id: fsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: French Sign Language
 - id: fss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Finland-Swedish Sign Language
 - id: fub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adamawa Fulfulde
 - id: fuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pulaar
 - id: fud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Futuna
 - id: fue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Borgu Fulfulde
 - id: fuf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pular
 - id: fuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Niger Fulfulde
 - id: fui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagirmi Fulfulde
 - id: fuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ko
 - id: ful
+  props:
+    alpha_2: ff
   tags:
   - macrolanguage
   - living
   title:
     en: Fulah
 - id: fum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fum
 - id: fun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Fulni\xF4"
 - id: fuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central-Eastern Niger Fulfulde
 - id: fur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Friulian
 - id: fut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Futuna-Aniwa
 - id: fuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Furu
 - id: fuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nigerian Fulfulde
 - id: fuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fuyug
 - id: fvr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fur
 - id: fwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Fw\xE2i"
 - id: fwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fwe
 - id: gaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ga
 - id: gab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gabri
 - id: gac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mixed Great Andamanese
 - id: gad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaddang
 - id: gae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guarequena
 - id: gaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gende
 - id: gag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gagauz
 - id: gah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alekano
 - id: gai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Borei
 - id: gaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gadsup
 - id: gak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gamkonora
 - id: gal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galolen
 - id: gam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kandawo
 - id: gan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gan Chinese
 - id: gao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gants
 - id: gap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gal
 - id: gaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gata'
 - id: gar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galeya
 - id: gas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adiwasi Garasia
 - id: gat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenati
 - id: gau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mudhili Gadaba
 - id: gaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nobonob
 - id: gax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Borana-Arsi-Guji Oromo
 - id: gay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gayo
 - id: gaz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Central Oromo
 - id: gba
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Gbaya (Central African Republic)
 - id: gbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaytetye
 - id: gbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karadjeri
 - id: gbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Niksek
 - id: gbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaikundi
 - id: gbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbanziri
 - id: gbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Defi Gbe
 - id: gbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galela
 - id: gbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bodo Gadaba
 - id: gbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaddi
 - id: gbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gamit
 - id: gbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garhwali
 - id: gbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mo'da
 - id: gbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Grebo
 - id: gbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbaya-Bossangoa
 - id: gbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbaya-Bozoum
 - id: gbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbagyi
 - id: gbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbesi Gbe
 - id: gbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gagadu
 - id: gbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbanu
 - id: gbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gabi-Gabi
 - id: gbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Xwla Gbe
 - id: gby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbari
 - id: gbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zoroastrian Dari
 - id: gcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mali
 - id: gcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ganggalida
 - id: gce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Galice
 - id: gcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guadeloupean Creole French
 - id: gcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Grenadian Creole English
 - id: gcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaina
 - id: gcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guianese Creole French
 - id: gct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Colonia Tovar German
 - id: gda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gade Lohar
 - id: gdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pottangi Ollar Gadaba
 - id: gdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gugu Badhun
 - id: gdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gedaged
 - id: gde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gude
 - id: gdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guduf-Gava
 - id: gdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ga'dang
 - id: gdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gadjerawang
 - id: gdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gundi
 - id: gdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurdjar
 - id: gdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gadang
 - id: gdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dirasha
 - id: gdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laal
 - id: gdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umanakaina
 - id: gdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghodoberi
 - id: gdq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mehri
 - id: gdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wipi
 - id: gds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghandruk Sign Language
 - id: gdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kungardutyi
 - id: gdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gudu
 - id: gdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Godwari
 - id: gea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geruma
 - id: geb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kire
 - id: gec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gboloo Grebo
 - id: ged
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gade
 - id: geg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gengle
 - id: geh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hutterite German
 - id: gei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gebe
 - id: gej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gen
 - id: gek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ywom
 - id: gel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: ut-Ma'in
 - id: geq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geme
 - id: ges
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geser-Gorom
 - id: gev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eviya
 - id: gew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gera
 - id: gex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garre
 - id: gey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enya
 - id: gez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Geez
 - id: gfk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Patpatar
 - id: gft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gafat
 - id: gga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gao
 - id: ggb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbii
 - id: ggd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gugadj
 - id: gge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guragone
 - id: ggg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurgula
 - id: ggk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kungarakany
 - id: ggl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ganglau
 - id: ggt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gitua
 - id: ggu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gagu
 - id: ggw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gogodala
 - id: gha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ghadam\xE8s"
 - id: ghc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Hiberno-Scottish Gaelic
 - id: ghe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Ghale
 - id: ghh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Ghale
 - id: ghk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geko Karen
 - id: ghl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghulfan
 - id: ghn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghanongga
 - id: gho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ghomara
 - id: ghr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghera
 - id: ghs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guhu-Samane
 - id: ght
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuke
 - id: gia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kitja
 - id: gib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gibanawa
 - id: gic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gail
 - id: gid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gidar
 - id: gig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Goaria
 - id: gih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Githabul
 - id: gil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gilbertese
 - id: gim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gimi (Eastern Highlands)
 - id: gin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hinukh
 - id: gip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gimi (West New Britain)
 - id: giq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Green Gelao
 - id: gir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Red Gelao
 - id: gis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Giziga
 - id: git
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gitxsan
 - id: giu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mulao
 - id: giw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: White Gelao
 - id: gix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gilima
 - id: giy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Giyug
 - id: giz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Giziga
 - id: gji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geji
 - id: gjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kachi Koli
 - id: gjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gunditjmara
 - id: gjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gonja
 - id: gjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurindji Kriol
 - id: gju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gujari
 - id: gka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guya
 - id: gke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndai
 - id: gkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gokana
 - id: gko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kok-Nar
 - id: gkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guinea Kpelle
 - id: gku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "\u01C2Ungkue"
 - id: gla
+  props:
+    alpha_2: gd
   tags:
   - individual
   - living
   title:
     en: Scottish Gaelic
 - id: glc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bon Gula
 - id: gld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nanai
 - id: gle
+  props:
+    alpha_2: ga
   tags:
   - individual
   - living
   title:
     en: Irish
 - id: glg
+  props:
+    alpha_2: gl
   tags:
   - individual
   - living
   title:
     en: Galician
 - id: glh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwest Pashai
 - id: gli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guliguli
 - id: glj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gula Iro
 - id: glk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gilaki
 - id: gll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Garlali
 - id: glo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Galambu
 - id: glr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Glaro-Twabo
 - id: glu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gula (Chad)
 - id: glv
+  props:
+    alpha_2: gv
   tags:
   - individual
   - living
   title:
     en: Manx
 - id: glw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Glavda
 - id: gly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gule
 - id: gma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gambera
 - id: gmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gula'alaa
 - id: gmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xE1ghd\xEC"
 - id: gmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mag\u0268yi"
 - id: gmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle High German (ca. 1050-1500)
 - id: gml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Low German
 - id: gmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbaya-Mbodomo
 - id: gmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gimnime
 - id: gmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gumalu
 - id: gmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gamo
 - id: gmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Magoma
 - id: gmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Mycenaean Greek
 - id: gmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mgbolizhia
 - id: gna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaansa
 - id: gnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gangte
 - id: gnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guanche
 - id: gnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zulgo-Gemzek
 - id: gne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ganang
 - id: gng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngangam
 - id: gnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lere
 - id: gni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gooniyandi
 - id: gnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: //Gana
 - id: gnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gangulu
 - id: gnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ginuman
 - id: gnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gumatj
 - id: gno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Gondi
 - id: gnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gana
 - id: gnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gureng Gureng
 - id: gnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guntai
 - id: gnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gnau
 - id: gnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Western Bolivian Guaran\xED"
 - id: gnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ganzi
 - id: goa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guro
 - id: gob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Playero
 - id: goc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gorakor
 - id: god
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Godi\xE9"
 - id: goe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gongduk
 - id: gof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gofa
 - id: gog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gogo
 - id: goh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old High German (ca. 750-1050)
 - id: goi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gobasi
 - id: goj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gowlan
 - id: gok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gowli
 - id: gol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gola
 - id: gom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Goan Konkani
 - id: gon
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Gondi
 - id: goo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gone Dau
 - id: gop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yeretuar
 - id: goq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gorap
 - id: gor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gorontalo
 - id: gos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gronings
 - id: got
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Gothic
 - id: gou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gavar
 - id: gow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gorowa
 - id: gox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gobu
 - id: goy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Goundo
 - id: goz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gozarkhani
 - id: gpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gupa-Abawa
 - id: gpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghanaian Pidgin English
 - id: gpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taiap
 - id: gqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ga'anda
 - id: gqi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guiqiong
 - id: gqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guana (Brazil)
 - id: gqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gor
 - id: gqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qau
 - id: gra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rajput Garasia
 - id: grb
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Grebo
 - id: grc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Ancient Greek (to 1453)
 - id: grd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guruntum-Mbaaru
 - id: grg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Madi
 - id: grh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbiri-Niragu
 - id: gri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghari
 - id: grj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Grebo
 - id: grm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kota Marudu Talantang
 - id: grn
+  props:
+    alpha_2: gn
   tags:
   - macrolanguage
   - living
   title:
     en: Guarani
 - id: gro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Groma
 - id: grq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gorovu
 - id: grr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taznatit
 - id: grs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gresi
 - id: grt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garo
 - id: gru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kistane
 - id: grv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Grebo
 - id: grw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gweda
 - id: grx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guriaso
 - id: gry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barclayville Grebo
 - id: grz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guramalum
 - id: gse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ghanaian Sign Language
 - id: gsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: German Sign Language
 - id: gsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gusilay
 - id: gsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guatemalan Sign Language
 - id: gsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nema
 - id: gso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwest Gbaya
 - id: gsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wasembo
 - id: gss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Greek Sign Language
 - id: gsw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swiss German
 - id: gta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Guat\xF3"
 - id: gtu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aghu-Tharnggala
 - id: gua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shiki
 - id: gub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Guajaj\xE1ra"
 - id: guc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wayuu
 - id: gud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yocobou\xE9 Dida"
 - id: gue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurinji
 - id: guf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gupapuyngu
 - id: gug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Paraguayan Guaran\xED"
 - id: guh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guahibo
 - id: gui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Eastern Bolivian Guaran\xED"
 - id: guj
+  props:
+    alpha_2: gu
   tags:
   - individual
   - living
   title:
     en: Gujarati
 - id: guk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gumuz
 - id: gul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sea Island Creole English
 - id: gum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guambiano
 - id: gun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mby\xE1 Guaran\xED"
 - id: guo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guayabero
 - id: gup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gunwinggu
 - id: guq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ach\xE9"
 - id: gur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Farefare
 - id: gus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guinean Sign Language
 - id: gut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mal\xE9ku Ja\xEDka"
 - id: guu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yanomam\xF6"
 - id: guw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gun
 - id: gux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Gourmanch\xE9ma"
 - id: guz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gusii
 - id: gva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guana (Paraguay)
 - id: gvc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guanano
 - id: gve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duwet
 - id: gvf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Golin
 - id: gvj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Guaj\xE1"
 - id: gvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gulay
 - id: gvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurmana
 - id: gvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuku-Yalanji
 - id: gvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Gavi\xE3o Do Jiparan\xE1"
 - id: gvp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Par\xE1 Gavi\xE3o"
 - id: gvr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurung
 - id: gvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gumawana
 - id: gvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guyani
 - id: gwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbato
 - id: gwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwa
 - id: gwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalami
 - id: gwd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gawwada
 - id: gwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gweno
 - id: gwf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gowro
 - id: gwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moo
 - id: gwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Gwich\u02BCin"
 - id: gwj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: /Gwi
 - id: gwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Awngthim
 - id: gwn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwandara
 - id: gwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwere
 - id: gwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gawar-Bati
 - id: gwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guwamu
 - id: gww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwini
 - id: gwx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gua
 - id: gxx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "W\xE8 Southern"
 - id: gya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwest Gbaya
 - id: gyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garus
 - id: gyd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayardild
 - id: gye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gyem
 - id: gyf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gungabula
 - id: gyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbayi
 - id: gyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gyele
 - id: gyl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gayil
 - id: gym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ng\xE4bere"
 - id: gyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guyanese Creole English
 - id: gyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guarayu
 - id: gyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gunya
 - id: gza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ganza
 - id: gzi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gazi
 - id: gzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gane
 - id: haa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Han
 - id: hab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hanoi Sign Language
 - id: hac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gurani
 - id: had
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hatam
 - id: hae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Oromo
 - id: haf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haiphong Sign Language
 - id: hag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hanga
 - id: hah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hahon
 - id: hai
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Haida
 - id: haj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hajong
 - id: hak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hakka Chinese
 - id: hal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halang
 - id: ham
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hewa
 - id: han
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hangaza
 - id: hao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hak\xF6"
 - id: hap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hupla
 - id: haq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ha
 - id: har
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Harari
 - id: has
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haisla
 - id: hat
+  props:
+    alpha_2: ht
   tags:
   - individual
   - living
   title:
     en: Haitian
 - id: hau
+  props:
+    alpha_2: ha
   tags:
   - individual
   - living
   title:
     en: Hausa
 - id: hav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Havu
 - id: haw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hawaiian
 - id: hax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Haida
 - id: hay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haya
 - id: haz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hazaragi
 - id: hba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hamba
 - id: hbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huba
 - id: hbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Heiban
 - id: hbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Ancient Hebrew
 - id: hbs
+  props:
+    alpha_2: sh
   tags:
   - macrolanguage
   - living
   title:
     en: Serbo-Croatian
 - id: hbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Habu
 - id: hca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Andaman Creole Hindi
 - id: hch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huichol
 - id: hdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Haida
 - id: hds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Honduras Sign Language
 - id: hdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hadiyya
 - id: hea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Qiandong Miao
 - id: heb
+  props:
+    alpha_2: he
   tags:
   - individual
   - living
   title:
     en: Hebrew
 - id: hed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Herd\xE9"
 - id: heg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Helong
 - id: heh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hehe
 - id: hei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Heiltsuk
 - id: hem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hemba
 - id: her
+  props:
+    alpha_2: hz
   tags:
   - individual
   - living
   title:
     en: Herero
 - id: hgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hai//om
 - id: hgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haigwai
 - id: hhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hoia Hoia
 - id: hhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kerak
 - id: hhy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hoyahoya
 - id: hia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamang
 - id: hib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Hibito
 - id: hid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hidatsa
 - id: hif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fiji Hindi
 - id: hig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamwe
 - id: hih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pamosu
 - id: hii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hinduri
 - id: hij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hijuk
 - id: hik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seit-Kaitetu
 - id: hil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hiligaynon
 - id: hin
+  props:
+    alpha_2: hi
   tags:
   - individual
   - living
   title:
     en: Hindi
 - id: hio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsoa
 - id: hir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Himarim\xE3"
 - id: hit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hittite
 - id: hiw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hiw
 - id: hix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hixkary\xE1na"
 - id: hji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haji
 - id: hka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kahe
 - id: hke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hunde
 - id: hkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hunjara-Kaina Ke
 - id: hks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hong Kong Sign Language
 - id: hla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halia
 - id: hlb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halbi
 - id: hld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halang Doan
 - id: hle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hlersu
 - id: hlt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matu Chin
 - id: hlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hieroglyphic Luwian
 - id: hma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Mashan Hmong
 - id: hmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Humburi Senni Songhay
 - id: hmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Huishui Hmong
 - id: hmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Large Flowery Miao
 - id: hme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Huishui Hmong
 - id: hmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmong Don
 - id: hmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Guiyang Hmong
 - id: hmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Huishui Hmong
 - id: hmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Huishui Hmong
 - id: hmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ge
 - id: hmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Maek
 - id: hml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luopohe Hmong
 - id: hmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Mashan Hmong
 - id: hmn
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Hmong
 - id: hmo
+  props:
+    alpha_2: ho
   tags:
   - individual
   - living
   title:
     en: Hiri Motu
 - id: hmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Mashan Hmong
 - id: hmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Qiandong Miao
 - id: hmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmar
 - id: hms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Qiandong Miao
 - id: hmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hamtai
 - id: hmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hamap
 - id: hmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hmong D\xF4"
 - id: hmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Mashan Hmong
 - id: hmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Guiyang Hmong
 - id: hmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmong Shua
 - id: hna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mina (Cameroon)
 - id: hnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Hindko
 - id: hne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chhattisgarhi
 - id: hnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: //Ani
 - id: hni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hani
 - id: hnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmong Njua
 - id: hnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hanunoo
 - id: hno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Hindko
 - id: hns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caribbean Hindustani
 - id: hnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hung
 - id: hoa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hoava
 - id: hob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mari (Madang Province)
 - id: hoc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ho
 - id: hod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Holma
 - id: hoe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Horom
 - id: hoh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hoby\xF3t"
 - id: hoi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Holikachuk
 - id: hoj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hadothi
 - id: hol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Holu
 - id: hom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Homa
 - id: hoo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Holoholo
 - id: hop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hopi
 - id: hor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Horo
 - id: hos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ho Chi Minh City Sign Language
 - id: hot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hote
 - id: hov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hovongan
 - id: how
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Honi
 - id: hoy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Holiya
 - id: hoz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hozo
 - id: hpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hpon
 - id: hps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hawai'i Sign Language (HSL)
 - id: hra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hrangkhol
 - id: hrc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Niwer Mil
 - id: hre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hre
 - id: hrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haruku
 - id: hrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Horned Miao
 - id: hro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haroi
 - id: hrp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nhirrpi
 - id: hrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "H\xE9rtevin"
 - id: hru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hruso
 - id: hrv
+  props:
+    alpha_2: hr
   tags:
   - individual
   - living
   title:
     en: Croatian
 - id: hrw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warwar Feni
 - id: hrx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hunsrik
 - id: hrz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Harzani
 - id: hsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Sorbian
 - id: hsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hungarian Sign Language
 - id: hsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hausa Sign Language
 - id: hsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xiang Chinese
 - id: hss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Harsusi
 - id: hti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hoti
 - id: hto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minica Huitoto
 - id: hts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hadza
 - id: htu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hitu
 - id: htx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Middle Hittite
 - id: hub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huambisa
 - id: huc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: =/Hua
 - id: hud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huaulu
 - id: hue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Francisco Del Mar Huave
 - id: huf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Humene
 - id: hug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huachipaeri
 - id: huh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huilliche
 - id: hui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huli
 - id: huj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Guiyang Hmong
 - id: huk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hulung
 - id: hul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hula
 - id: hum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hungana
 - id: hun
+  props:
+    alpha_2: hu
   tags:
   - individual
   - living
   title:
     en: Hungarian
 - id: huo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hu
 - id: hup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hupa
 - id: huq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsat
 - id: hur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halkomelem
 - id: hus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huastec
 - id: hut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Humla
 - id: huu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murui Huitoto
 - id: huv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Mateo Del Mar Huave
 - id: huw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Hukumina
 - id: hux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "N\xFCpode Huitoto"
 - id: huy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hulaul\xE1"
 - id: huz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hunzib
 - id: hvc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haitian Vodoun Culture Language
 - id: hve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Dionisio Del Mar Huave
 - id: hvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haveke
 - id: hvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sabu
 - id: hvv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa Mar\xEDa Del Mar Huave"
 - id: hwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Wan\xE9"
 - id: hwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hawai'i Creole English
 - id: hwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hwana
 - id: hya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hya
 - id: hye
+  props:
+    alpha_2: hy
   tags:
   - individual
   - living
   title:
     en: Armenian
 - id: iai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iaai
 - id: ian
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iatmul
 - id: iar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Purari
 - id: iba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iban
 - id: ibb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibibio
 - id: ibd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iwaidja
 - id: ibe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akpes
 - id: ibg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibanag
 - id: ibl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibaloi
 - id: ibm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agoi
 - id: ibn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibino
 - id: ibo
+  props:
+    alpha_2: ig
   tags:
   - individual
   - living
   title:
     en: Igbo
 - id: ibr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibuoro
 - id: ibu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibu
 - id: iby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibani
 - id: ica
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ede Ica
 - id: ich
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Etkywan
 - id: icl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Icelandic Sign Language
 - id: icr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Islander Creole English
 - id: ida
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idakho-Isukha-Tiriki
 - id: idb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indo-Portuguese
 - id: idc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idon
 - id: idd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ede Idaca
 - id: ide
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idere
 - id: idi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idi
 - id: ido
+  props:
+    alpha_2: io
   tags:
   - individual
   - constructed
   title:
     en: Ido
 - id: idr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indri
 - id: ids
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idesa
 - id: idt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Idat\xE9"
 - id: idu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Idoma
 - id: ifa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amganad Ifugao
 - id: ifb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batad Ifugao
 - id: ife
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "If\xE8"
 - id: iff
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ifo
 - id: ifk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuwali Ifugao
 - id: ifm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Fuumu
 - id: ifu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayoyao Ifugao
 - id: ify
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keley-I Kallahan
 - id: igb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ebira
 - id: ige
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Igede
 - id: igg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Igana
 - id: igl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Igala
 - id: igm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanggape
 - id: ign
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ignaciano
 - id: igo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isebe
 - id: igs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Interglossa
 - id: igw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Igwe
 - id: ihb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iha Based Pidgin
 - id: ihi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ihievbe
 - id: ihp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iha
 - id: ihw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bidhawal
 - id: iii
+  props:
+    alpha_2: ii
   tags:
   - individual
   - living
   title:
     en: Sichuan Yi
 - id: iin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Thiin
 - id: ijc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Izon
 - id: ije
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Biseni
 - id: ijj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ede Ije
 - id: ijn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalabari
 - id: ijs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeast Ijo
 - id: ike
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Canadian Inuktitut
 - id: iki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iko
 - id: ikk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ika
 - id: ikl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikulu
 - id: iko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Olulumo-Ikom
 - id: ikp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikpeshi
 - id: ikr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ikaranggal
 - id: iks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inuit Sign Language
 - id: ikt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inuinnaqtun
 - id: iku
+  props:
+    alpha_2: iu
   tags:
   - macrolanguage
   - living
   title:
     en: Inuktitut
 - id: ikv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iku-Gora-Ankwa
 - id: ikw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikwere
 - id: ikx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ik
 - id: ikz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikizu
 - id: ila
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ile Ape
 - id: ilb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ila
 - id: ile
+  props:
+    alpha_2: ie
   tags:
   - individual
   - constructed
   title:
     en: Interlingue
 - id: ilg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Garig-Ilgar
 - id: ili
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ili Turki
 - id: ilk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ilongot
 - id: ilm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iranun (Malaysia)
 - id: ilo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iloko
 - id: ilp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iranun (Philippines)
 - id: ils
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: International Sign
 - id: ilu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ili'uun
 - id: ilv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ilue
 - id: ima
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mala Malasar
 - id: imi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anamgura
 - id: iml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Miluk
 - id: imn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Imonda
 - id: imo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Imbongu
 - id: imr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Imroing
 - id: ims
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Marsian
 - id: imy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Milyan
 - id: ina
+  props:
+    alpha_2: ia
   tags:
   - individual
   - constructed
   title:
     en: Interlingua (International Auxiliary Language Association)
 - id: inb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inga
 - id: ind
+  props:
+    alpha_2: id
   tags:
   - individual
   - living
   title:
     en: Indonesian
 - id: ing
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Degexit'an
 - id: inh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ingush
 - id: inj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jungle Inga
 - id: inl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indonesian Sign Language
 - id: inm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Minaean
 - id: inn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isinai
 - id: ino
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inoke-Yate
 - id: inp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "I\xF1apari"
 - id: ins
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indian Sign Language
 - id: int
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Intha
 - id: inz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Inese\xF1o"
 - id: ior
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inor
 - id: iou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuma-Irumu
 - id: iow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Iowa-Oto
 - id: ipi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ipili
 - id: ipk
+  props:
+    alpha_2: ik
   tags:
   - macrolanguage
   - living
   title:
     en: Inupiaq
 - id: ipo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ipiko
 - id: iqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iquito
 - id: iqw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikwo
 - id: ire
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iresim
 - id: irh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Irarutu
 - id: iri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Irigwe
 - id: irk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iraqw
 - id: irn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ir\xE1ntxe"
 - id: irr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ir
 - id: iru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Irula
 - id: irx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamberau
 - id: iry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iraya
 - id: isa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isabi
 - id: isc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isconahua
 - id: isd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isnag
 - id: ise
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Italian Sign Language
 - id: isg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Irish Sign Language
 - id: ish
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Esan
 - id: isi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkem-Nkum
 - id: isk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ishkashimi
 - id: isl
+  props:
+    alpha_2: is
   tags:
   - individual
   - living
   title:
     en: Icelandic
 - id: ism
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masimasi
 - id: isn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isanzu
 - id: iso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isoko
 - id: isr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Israeli Sign Language
 - id: ist
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Istriot
 - id: isu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isu (Menchum Division)
 - id: ita
+  props:
+    alpha_2: it
   tags:
   - individual
   - living
   title:
     en: Italian
 - id: itb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Binongan Itneg
 - id: itd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Tidung
 - id: ite
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Itene
 - id: iti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inlaod Itneg
 - id: itk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Italian
 - id: itl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itelmen
 - id: itm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itu Mbon Uzo
 - id: ito
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itonama
 - id: itr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iteri
 - id: its
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isekiri
 - id: itt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maeng Itneg
 - id: itv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itawit
 - id: itw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ito
 - id: itx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itik
 - id: ity
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moyadan Itneg
 - id: itz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Itz\xE1"
 - id: ium
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iu Mien
 - id: ivb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibatan
 - id: ivv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ivatan
 - id: iwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: I-Wak
 - id: iwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iwam
 - id: iwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iwur
 - id: iws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sepik Iwam
 - id: ixc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ixcatec
 - id: ixl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ixil
 - id: iya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iyayu
 - id: iyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mesaka
 - id: iyx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaka (Congo)
 - id: izh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ingrian
 - id: izr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Izere
 - id: izz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Izii
 - id: jaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Jamamad\xED"
 - id: jab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hyam
 - id: jac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Popti'
 - id: jad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jahanka
 - id: jae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yabem
 - id: jaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jara
 - id: jah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jah Hut
 - id: jaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zazao
 - id: jak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jakun
 - id: jal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yalahatan
 - id: jam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jamaican Creole English
 - id: jan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Jandai
 - id: jao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yanyuwa
 - id: jaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaqay
 - id: jas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: New Caledonian Javanese
 - id: jat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jakati
 - id: jau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaur
 - id: jav
+  props:
+    alpha_2: jv
   tags:
   - individual
   - living
   title:
     en: Javanese
 - id: jax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jambi Malay
 - id: jay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yan-nhangu
 - id: jaz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jawe
 - id: jbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Berber
 - id: jbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Badjiri
 - id: jbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arandai
 - id: jbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barikewa
 - id: jbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nafusi
 - id: jbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Lojban
 - id: jbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jofotek-Bromnya
 - id: jbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Jabut\xED"
 - id: jbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jukun Takum
 - id: jbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yawijibaya
 - id: jcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jamaican Country Sign Language
 - id: jct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krymchak
 - id: jda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jad
 - id: jdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jadgali
 - id: jdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Tat
 - id: jeb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jebero
 - id: jee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jerung
 - id: jeg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jeng
 - id: jeh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jeh
 - id: jei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yei
 - id: jek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jeri Kuo
 - id: jel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yelmek
 - id: jen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dza
 - id: jer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jere
 - id: jet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manem
 - id: jeu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jonkor Bourmataguil
 - id: jgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngbee
 - id: jge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Georgian
 - id: jgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gwak
 - id: jgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngomba
 - id: jhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jehai
 - id: jhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jhankot Sign Language
 - id: jia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jina
 - id: jib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jibu
 - id: jic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tol
 - id: jid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bu
 - id: jie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jilbe
 - id: jig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djingili
 - id: jih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: sTodsde
 - id: jii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiiddu
 - id: jil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jilim
 - id: jim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jimi (Cameroon)
 - id: jio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiamao
 - id: jiq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guanyinqiao
 - id: jit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jita
 - id: jiu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Youle Jinuo
 - id: jiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shuar
 - id: jiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buyuan Jinuo
 - id: jje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jejueo
 - id: jjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bankal
 - id: jka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaera
 - id: jkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mobwa Karen
 - id: jko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kubo
 - id: jkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paku Karen
 - id: jkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koro (India)
 - id: jku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Labir
 - id: jle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngile
 - id: jls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jamaican Sign Language
 - id: jma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dima
 - id: jmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zumbun
 - id: jmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Machame
 - id: jmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamdena
 - id: jmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jimi (Nigeria)
 - id: jml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jumli
 - id: jmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makuri Naga
 - id: jmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamara
 - id: jms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mashi (Nigeria)
 - id: jmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mouwase
 - id: jmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Juxtlahuaca Mixtec
 - id: jna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jangshung
 - id: jnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jandavra
 - id: jng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yangman
 - id: jni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Janji
 - id: jnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yemsa
 - id: jnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rawat
 - id: jns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jaunsari
 - id: job
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Joba
 - id: jod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wojenaka
 - id: jog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jogi
 - id: jor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Jor\xE1"
 - id: jos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jordanian Sign Language
 - id: jow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jowulu
 - id: jpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Jewish Palestinian Aramaic
 - id: jpn
+  props:
+    alpha_2: ja
   tags:
   - individual
   - living
   title:
     en: Japanese
 - id: jpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Persian
 - id: jqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jaqaru
 - id: jra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jarai
 - id: jrb
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Judeo-Arabic
 - id: jrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiru
 - id: jrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jorto
 - id: jru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Japrer\xEDa"
 - id: jsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Japanese Sign Language
 - id: jua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "J\xFAma"
 - id: jub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wannu
 - id: juc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Jurchen
 - id: jud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Worodougou
 - id: juh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "H\xF5ne"
 - id: jui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngadjuri
 - id: juk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wapan
 - id: jul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jirel
 - id: jum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jumjum
 - id: jun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Juang
 - id: juo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiba
 - id: jup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Hupd\xEB"
 - id: jur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Jur\xFAna"
 - id: jus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jumla Sign Language
 - id: jut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Jutish
 - id: juu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ju
 - id: juw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "W\xE3pha"
 - id: juy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Juray
 - id: jvd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Javindo
 - id: jvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caribbean Javanese
 - id: jwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jwira-Pepesa
 - id: jya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiarong
 - id: jye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Yemeni Arabic
 - id: jyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jaya
 - id: kaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kara-Kalpak
 - id: kab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabyle
 - id: kac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kachin
 - id: kad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adara
 - id: kae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ketangalan
 - id: kaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katso
 - id: kag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kajaman
 - id: kah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kara (Central African Republic)
 - id: kai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karekare
 - id: kaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jju
 - id: kak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalanguya
 - id: kal
+  props:
+    alpha_2: kl
   tags:
   - individual
   - living
   title:
     en: Kalaallisut
 - id: kam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamba (Kenya)
 - id: kan
+  props:
+    alpha_2: kn
   tags:
   - individual
   - living
   title:
     en: Kannada
 - id: kao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xaasongaxango
 - id: kap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bezhta
 - id: kaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Capanahua
 - id: kas
+  props:
+    alpha_2: ks
   tags:
   - individual
   - living
   title:
     en: Kashmiri
 - id: kat
+  props:
+    alpha_2: ka
   tags:
   - individual
   - living
   title:
     en: Georgian
 - id: kau
+  props:
+    alpha_2: kr
   tags:
   - macrolanguage
   - living
   title:
     en: Kanuri
 - id: kav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Katuk\xEDna"
 - id: kaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Kawi
 - id: kax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kao
 - id: kay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kamayur\xE1"
 - id: kaz
+  props:
+    alpha_2: kk
   tags:
   - individual
   - living
   title:
     en: Kazakh
 - id: kba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kalarko
 - id: kbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kaxui\xE2na"
 - id: kbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kadiw\xE9u"
 - id: kbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabardian
 - id: kbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanju
 - id: kbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khamba
 - id: kbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cams\xE1"
 - id: kbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaptiau
 - id: kbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kari
 - id: kbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Grass Koiari
 - id: kbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanembu
 - id: kbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iwal
 - id: kbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kare (Central African Republic)
 - id: kbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keliko
 - id: kbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kabiy\xE8"
 - id: kbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamano
 - id: kbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kafa
 - id: kbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kande
 - id: kbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abadi
 - id: kbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabutra
 - id: kbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dera (Indonesia)
 - id: kbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaiep
 - id: kbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ap Ma
 - id: kby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manga Kanuri
 - id: kbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duhwa
 - id: kca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khanty
 - id: kcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kawacha
 - id: kcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lubila
 - id: kcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ngk\xE2lmpw Kanum"
 - id: kce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaivi
 - id: kcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukaan
 - id: kcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tyap
 - id: kch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vono
 - id: kci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamantan
 - id: kcj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kobiana
 - id: kck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalanga
 - id: kcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kela (Papua New Guinea)
 - id: kcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gula (Central African Republic)
 - id: kcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nubi
 - id: kco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinalakna
 - id: kcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanga
 - id: kcq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamo
 - id: kcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katla
 - id: kcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koenoem
 - id: kct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaian
 - id: kcu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kami (Tanzania)
 - id: kcv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kete
 - id: kcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabwari
 - id: kcx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kachama-Ganjule
 - id: kcy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korandje
 - id: kcz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konongo
 - id: kda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Worimi
 - id: kdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kutu
 - id: kdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yankunytjatjara
 - id: kde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makonde
 - id: kdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamusi
 - id: kdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seba
 - id: kdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tem
 - id: kdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumam
 - id: kdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karamojong
 - id: kdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Num\xE8\xE8"
 - id: kdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsikimba
 - id: kdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagoma
 - id: kdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunda
 - id: kdp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaningdon-Nindem
 - id: kdq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koch
 - id: kdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karaim
 - id: kdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuy
 - id: kdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kadaru
 - id: kdw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koneraw
 - id: kdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kam
 - id: kdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keder
 - id: kdz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwaja
 - id: kea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabuverdianu
 - id: keb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "K\xE9l\xE9"
 - id: kec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keiga
 - id: ked
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kerewe
 - id: kee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Keres
 - id: kef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpessi
 - id: keg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tese
 - id: keh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keak
 - id: kei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kei
 - id: kej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kadar
 - id: kek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kekch\xED"
 - id: kel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kela (Democratic Republic of Congo)
 - id: kem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kemak
 - id: ken
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenyang
 - id: keo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kakwa
 - id: kep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaikadi
 - id: keq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamar
 - id: ker
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kera
 - id: kes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kugbo
 - id: ket
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ket
 - id: keu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akebu
 - id: kev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanikkaran
 - id: kew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Kewa
 - id: kex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kukna
 - id: key
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kupia
 - id: kez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kukele
 - id: kfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kodava
 - id: kfb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Kolami
 - id: kfc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konda-Dora
 - id: kfd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korra Koraga
 - id: kfe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kota (India)
 - id: kff
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koya
 - id: kfg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kudiya
 - id: kfh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurichiya
 - id: kfi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kannada Kurumba
 - id: kfj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kemiehua
 - id: kfk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinnauri
 - id: kfl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kung
 - id: kfm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khunsari
 - id: kfn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuk
 - id: kfo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Koro (C\xF4te d'Ivoire)"
 - id: kfp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korwa
 - id: kfq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korku
 - id: kfr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kachhi
 - id: kfs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bilaspuri
 - id: kft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanjari
 - id: kfu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katkari
 - id: kfv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurmukar
 - id: kfw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kharam Naga
 - id: kfx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kullu Pahari
 - id: kfy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumaoni
 - id: kfz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Koromf\xE9"
 - id: kga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koyaga
 - id: kgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kawe
 - id: kgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kataang
 - id: kge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komering
 - id: kgf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kube
 - id: kgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kusunda
 - id: kgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selangor Sign Language
 - id: kgj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gamale Kham
 - id: kgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kaiw\xE1"
 - id: kgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kunggari
 - id: kgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Karip\xFAna"
 - id: kgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karingani
 - id: kgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krongo
 - id: kgp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaingang
 - id: kgq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamoro
 - id: kgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abun
 - id: kgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumbainggar
 - id: kgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Somyev
 - id: kgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kobol
 - id: kgv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karas
 - id: kgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karon Dori
 - id: kgx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamaru
 - id: kgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyerung
 - id: kha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khasi
 - id: khb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "L\xFC"
 - id: khc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tukang Besi North
 - id: khd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "B\xE4di Kanum"
 - id: khe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korowai
 - id: khf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khuen
 - id: khg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khams Tibetan
 - id: khh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kehu
 - id: khj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuturmi
 - id: khk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Halh Mongolian
 - id: khl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lusi
 - id: khm
+  props:
+    alpha_2: km
   tags:
   - individual
   - living
   title:
     en: Central Khmer
 - id: khn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khandesi
 - id: kho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Khotanese
 - id: khp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kapori
 - id: khq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koyra Chiini Songhay
 - id: khr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kharia
 - id: khs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kasua
 - id: kht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khamti
 - id: khu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkhumbi
 - id: khv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khvarshi
 - id: khw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khowar
 - id: khx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanu
 - id: khy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kele (Democratic Republic of Congo)
 - id: khz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keapara
 - id: kia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kim
 - id: kib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koalib
 - id: kic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kickapoo
 - id: kid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koshin
 - id: kie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kibet
 - id: kif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Parbate Kham
 - id: kig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kimaama
 - id: kih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kilmeri
 - id: kii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kitsai
 - id: kij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kilivila
 - id: kik
+  props:
+    alpha_2: ki
   tags:
   - individual
   - living
   title:
     en: Kikuyu
 - id: kil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kariya
 - id: kim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karagas
 - id: kin
+  props:
+    alpha_2: rw
   tags:
   - individual
   - living
   title:
     en: Kinyarwanda
 - id: kio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiowa
 - id: kip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sheshi Kham
 - id: kiq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kosadle
 - id: kir
+  props:
+    alpha_2: ky
   tags:
   - individual
   - living
   title:
     en: Kirghiz
 - id: kis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kis
 - id: kit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agob
 - id: kiu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kirmanjki (individual language)
 - id: kiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kimbu
 - id: kiw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northeast Kiwai
 - id: kix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khiamniungan Naga
 - id: kiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kirikiri
 - id: kiz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kisi
 - id: kja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mlap
 - id: kjb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Q'anjob'al
 - id: kjc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coastal Konjo
 - id: kjd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Kiwai
 - id: kje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kisar
 - id: kjf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khalaj
 - id: kjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khmu
 - id: kjh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khakas
 - id: kji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zabana
 - id: kjj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khinalugh
 - id: kjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Highland Konjo
 - id: kjl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Parbate Kham
 - id: kjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kh\xE1ng"
 - id: kjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunjen
 - id: kjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Harijan Kinnauri
 - id: kjp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pwo Eastern Karen
 - id: kjq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Keres
 - id: kjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurudu
 - id: kjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Kewa
 - id: kjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phrae Pwo Karen
 - id: kju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kashaya
 - id: kjv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Kaikavian Literary Language
 - id: kjx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ramopa
 - id: kjy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Erave
 - id: kjz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bumthangkha
 - id: kka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kakanda
 - id: kkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwerisa
 - id: kkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Odoodee
 - id: kkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinuku
 - id: kke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kakabe
 - id: kkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalaktang Monpa
 - id: kkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mabaka Valley Kalinga
 - id: kkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kh\xFCn"
 - id: kki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagulu
 - id: kkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kako
 - id: kkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kokota
 - id: kkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kosarek Yale
 - id: kkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiong
 - id: kkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kon Keu
 - id: kko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karko
 - id: kkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gugubera
 - id: kkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaiku
 - id: kkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kir-Balar
 - id: kks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Giiwo
 - id: kkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koi
 - id: kku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumi
 - id: kkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kangean
 - id: kkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Kukuya
 - id: kkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kohin
 - id: kky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guguyimidjir
 - id: kkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaska
 - id: kla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Klamath-Modoc
 - id: klb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiliwa
 - id: klc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kolbila
 - id: kld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gamilaraay
 - id: kle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulung (Nepal)
 - id: klf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kendeje
 - id: klg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagakaulo
 - id: klh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Weliki
 - id: kli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalumpang
 - id: klj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turkic Khalaj
 - id: klk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kono (Nigeria)
 - id: kll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagan Kalagan
 - id: klm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Migum
 - id: kln
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Kalenjin
 - id: klo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kapya
 - id: klp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamasa
 - id: klq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rumu
 - id: klr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khaling
 - id: kls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalasha
 - id: klt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nukna
 - id: klu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Klao
 - id: klv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maskelynes
 - id: klw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lindu
 - id: klx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koluwawa
 - id: kly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalao
 - id: klz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabola
 - id: kma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konni
 - id: kmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kimbundu
 - id: kmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Dong
 - id: kmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Majukayang Kalinga
 - id: kme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bakole
 - id: kmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kare (Papua New Guinea)
 - id: kmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "K\xE2te"
 - id: kmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalam
 - id: kmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kami (Nigeria)
 - id: kmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumarbhag Paharia
 - id: kmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Limos Kalinga
 - id: kml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanudan Kalinga
 - id: kmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kom (India)
 - id: kmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awtuw
 - id: kmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwoma
 - id: kmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gimme
 - id: kmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwama
 - id: kmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Kurdish
 - id: kms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamasau
 - id: kmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kemtuik
 - id: kmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanite
 - id: kmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Karip\xFAna Creole French"
 - id: kmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komo (Democratic Republic of Congo)
 - id: kmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waboda
 - id: kmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koma
 - id: kmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khorasani Turkish
 - id: kna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dera (Nigeria)
 - id: knb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lubuagan Kalinga
 - id: knc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Kanuri
 - id: knd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konda
 - id: kne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kankanaey
 - id: knf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mankanya
 - id: kng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koongo
 - id: kni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanufi
 - id: knj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Kanjobal
 - id: knk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuranko
 - id: knl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keninjal
 - id: knm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kanamar\xED"
 - id: knn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konkani (individual language)
 - id: kno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kono (Sierra Leone)
 - id: knp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwanja
 - id: knq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kintaq
 - id: knr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaningra
 - id: kns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kensiu
 - id: knt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Panoan Katuk\xEDna"
 - id: knu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kono (Guinea)
 - id: knv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabo
 - id: knw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kung-Ekoka
 - id: knx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kendayan
 - id: kny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanyok
 - id: knz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kalams\xE9"
 - id: koa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konomala
 - id: koc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kpati
 - id: kod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kodi
 - id: koe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kacipo-Balesi
 - id: kof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kubi
 - id: kog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cogui
 - id: koh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koyo
 - id: koi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komi-Permyak
 - id: kok
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Konkani (macrolanguage)
 - id: kol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kol (Papua New Guinea)
 - id: kom
+  props:
+    alpha_2: kv
   tags:
   - macrolanguage
   - living
   title:
     en: Komi
 - id: kon
+  props:
+    alpha_2: kg
   tags:
   - macrolanguage
   - living
   title:
     en: Kongo
 - id: koo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konzo
 - id: kop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waube
 - id: koq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kota (Gabon)
 - id: kor
+  props:
+    alpha_2: ko
   tags:
   - individual
   - living
   title:
     en: Korean
 - id: kos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kosraean
 - id: kot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lagwan
 - id: kou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koke
 - id: kov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kudu-Camo
 - id: kow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kugama
 - id: koy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koyukon
 - id: koz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korak
 - id: kpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kutto
 - id: kpb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mullu Kurumba
 - id: kpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Curripaco
 - id: kpd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koba
 - id: kpe
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Kpelle
 - id: kpf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komba
 - id: kpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kapingamarangi
 - id: kph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kplang
 - id: kpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kofei
 - id: kpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Karaj\xE1"
 - id: kpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpan
 - id: kpl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpala
 - id: kpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koho
 - id: kpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kepkiriw\xE1t"
 - id: kpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikposo
 - id: kpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korupun-Sela
 - id: kpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korafe-Yegha
 - id: kps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tehit
 - id: kpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karata
 - id: kpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kafoa
 - id: kpv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komi-Zyrian
 - id: kpw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kobon
 - id: kpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mountain Koiali
 - id: kpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koryak
 - id: kpz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kupsabiny
 - id: kqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mum
 - id: kqb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kovai
 - id: kqc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doromu-Koki
 - id: kqd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koy Sanjaq Surat
 - id: kqe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalagan
 - id: kqf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kakabai
 - id: kqg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khe
 - id: kqh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kisankasa
 - id: kqi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koitabu
 - id: kqj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koromira
 - id: kqk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kotafon Gbe
 - id: kql
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyenele
 - id: kqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khisa
 - id: kqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaonde
 - id: kqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Krahn
 - id: kqp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kimr\xE9"
 - id: kqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krenak
 - id: kqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kimaragang
 - id: kqs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Kissi
 - id: kqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Klias River Kadazan
 - id: kqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Seroa
 - id: kqv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okolod
 - id: kqw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kandas
 - id: kqx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mser
 - id: kqy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koorete
 - id: kqz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Korana
 - id: kra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumhali
 - id: krb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karkin
 - id: krc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karachay-Balkar
 - id: krd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kairui-Midiki
 - id: kre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Panar\xE1"
 - id: krf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koro (Vanuatu)
 - id: krh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurama
 - id: kri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krio
 - id: krj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinaray-A
 - id: krk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kerek
 - id: krl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karelian
 - id: krm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krim
 - id: krn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sapo
 - id: krp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korop
 - id: krr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kru'ng 2
 - id: krs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gbaya (Sudan)
 - id: krt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumari Kanuri
 - id: kru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurukh
 - id: krv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kavet
 - id: krw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Krahn
 - id: krx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karon
 - id: kry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kryts
 - id: krz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sota Kanum
 - id: ksa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shuwa-Zamani
 - id: ksb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shambala
 - id: ksc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Kalinga
 - id: ksd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuanua
 - id: kse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuni
 - id: ksf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bafia
 - id: ksg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kusaghe
 - id: ksh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "K\xF6lsch"
 - id: ksi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krisa
 - id: ksj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uare
 - id: ksk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kansa
 - id: ksl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumalu
 - id: ksm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumba
 - id: ksn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kasiguranin
 - id: kso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kofa
 - id: ksp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaba
 - id: ksq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwaami
 - id: ksr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Borong
 - id: kss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Kisi
 - id: kst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Winy\xE9"
 - id: ksu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khamyang
 - id: ksv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kusu
 - id: ksw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: S'gaw Karen
 - id: ksx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kedang
 - id: ksy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kharia Thar
 - id: ksz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kodaku
 - id: kta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katua
 - id: ktb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kambaata
 - id: ktc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kholok
 - id: ktd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kokata
 - id: kte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nubri
 - id: ktf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwami
 - id: ktg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kalkutung
 - id: kth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karanga
 - id: kti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Muyu
 - id: ktj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plapo Krumen
 - id: ktk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kaniet
 - id: ktl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koroshi
 - id: ktm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurti
 - id: ktn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kariti\xE2na"
 - id: kto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuot
 - id: ktp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaduo
 - id: ktq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Katabaga
 - id: kts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Muyu
 - id: ktt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ketum
 - id: ktu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kituba (Democratic Republic of Congo)
 - id: ktv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Katu
 - id: ktw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kato
 - id: ktx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kaxarar\xED"
 - id: kty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kango (Bas-U\xE9l\xE9 District)"
 - id: ktz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ju/'hoan
 - id: kua
+  props:
+    alpha_2: kj
   tags:
   - individual
   - living
   title:
     en: Kuanyama
 - id: kub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kutep
 - id: kuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwinsu
 - id: kud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: '''Auhelawa'
 - id: kue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuman (Papua New Guinea)
 - id: kuf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Katu
 - id: kug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kupa
 - id: kuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kushi
 - id: kui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kuik\xFAro-Kalap\xE1lo"
 - id: kuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuria
 - id: kuk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kepo'
 - id: kul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulere
 - id: kum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumyk
 - id: kun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunama
 - id: kuo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumukio
 - id: kup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunimaipa
 - id: kuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karipuna
 - id: kur
+  props:
+    alpha_2: ku
   tags:
   - macrolanguage
   - living
   title:
     en: Kurdish
 - id: kus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kusaal
 - id: kut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kutenai
 - id: kuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Kuskokwim
 - id: kuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kur
 - id: kuw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpagua
 - id: kux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kukatja
 - id: kuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuuku-Ya'u
 - id: kuz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kunza
 - id: kva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bagvalal
 - id: kvb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kubu
 - id: kvc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kove
 - id: kvd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kui (Indonesia)
 - id: kve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalabakan
 - id: kvf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabalai
 - id: kvg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuni-Boazi
 - id: kvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komodo
 - id: kvi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwang
 - id: kvj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Psikye
 - id: kvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korean Sign Language
 - id: kvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayaw
 - id: kvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kendem
 - id: kvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Border Kuna
 - id: kvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dobel
 - id: kvp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kompane
 - id: kvq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Geba Karen
 - id: kvr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kerinci
 - id: kvt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lahta Karen
 - id: kvu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yinbaw Karen
 - id: kvv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kola
 - id: kvw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wersing
 - id: kvx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parkari Koli
 - id: kvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yintale Karen
 - id: kvz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsakwambo
 - id: kwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "D\xE2w"
 - id: kwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwa
 - id: kwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Likwala
 - id: kwd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwaio
 - id: kwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwerba
 - id: kwf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwara'ae
 - id: kwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sara Kaba Deme
 - id: kwh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kowiai
 - id: kwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awa-Cuaiquer
 - id: kwj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwanga
 - id: kwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwakiutl
 - id: kwl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kofyar
 - id: kwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwambi
 - id: kwn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwangali
 - id: kwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwomtari
 - id: kwp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kodia
 - id: kwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwer
 - id: kws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwese
 - id: kwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwesten
 - id: kwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwakum
 - id: kwv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sara Kaba N\xE1\xE0"
 - id: kww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwinti
 - id: kwx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khirwar
 - id: kwy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Salvador Kongo
 - id: kwz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kwadi
 - id: kxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kairiru
 - id: kxb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krobu
 - id: kxc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konso
 - id: kxd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brunei
 - id: kxf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manumanaw Karen
 - id: kxh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karo (Ethiopia)
 - id: kxi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keningau Murut
 - id: kxj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulfa
 - id: kxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zayein Karen
 - id: kxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nepali Kurux
 - id: kxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Khmer
 - id: kxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanowit-Tanjong Melanau
 - id: kxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kano\xE9"
 - id: kxp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wadiyara Koli
 - id: kxq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sm\xE4rky Kanum"
 - id: kxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koro (Papua New Guinea)
 - id: kxs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kangjia
 - id: kxt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koiwat
 - id: kxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kui (India)
 - id: kxv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuvi
 - id: kxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konai
 - id: kxx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Likuba
 - id: kxy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayong
 - id: kxz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kerewo
 - id: kya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwaya
 - id: kyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Butbut Kalinga
 - id: kyc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyaka
 - id: kyd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karey
 - id: kye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krache
 - id: kyf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kouya
 - id: kyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keyagana
 - id: kyh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karok
 - id: kyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiput
 - id: kyj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karao
 - id: kyk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamayo
 - id: kyl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalapuya
 - id: kym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpatili
 - id: kyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Binukidnon
 - id: kyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kelon
 - id: kyp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kang
 - id: kyq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenga
 - id: kyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kuru\xE1ya"
 - id: kys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baram Kayan
 - id: kyt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayagar
 - id: kyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Kayah
 - id: kyv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayort
 - id: kyw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kudmali
 - id: kyx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rapoisi
 - id: kyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kambaira
 - id: kyz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kayab\xED"
 - id: kza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Karaboro
 - id: kzb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaibobo
 - id: kzc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bondoukou Kulango
 - id: kzd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kadai
 - id: kze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kosena
 - id: kzf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Da'a Kaili
 - id: kzg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kikai
 - id: kzi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kelabit
 - id: kzk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kazukuru
 - id: kzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayeli
 - id: kzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kais
 - id: kzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kokola
 - id: kzo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaningi
 - id: kzp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaidipang
 - id: kzq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaike
 - id: kzr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karang
 - id: kzs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sugut Dusun
 - id: kzu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayupulau
 - id: kzv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komyandaret
 - id: kzw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Karir\xED-Xoc\xF3"
 - id: kzx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamarian
 - id: kzy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kango (Tshopo District)
 - id: kzz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalabra
 - id: laa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Subanen
 - id: lab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Linear A
 - id: lac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lacandon
 - id: lad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ladino
 - id: lae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pattani
 - id: laf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lafofa
 - id: lag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Langi
 - id: lah
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Lahnda
 - id: lai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lambya
 - id: laj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lango (Uganda)
 - id: lak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laka (Nigeria)
 - id: lal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lalia
 - id: lam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamba
 - id: lan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laru
 - id: lao
+  props:
+    alpha_2: lo
   tags:
   - individual
   - living
   title:
     en: Lao
 - id: lap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laka (Chad)
 - id: laq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qabiao
 - id: lar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Larteh
 - id: las
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lama (Togo)
 - id: lat
+  props:
+    alpha_2: la
   tags:
   - individual
   - ancient
   title:
     en: Latin
 - id: lau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laba
 - id: lav
+  props:
+    alpha_2: lv
   tags:
   - macrolanguage
   - living
   title:
     en: Latvian
 - id: law
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lauje
 - id: lax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiwa
 - id: lay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lama Bai
 - id: laz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aribwatsa
 - id: lba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lui
 - id: lbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Label
 - id: lbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakkia
 - id: lbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lak
 - id: lbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tinani
 - id: lbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laopang
 - id: lbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: La'bi
 - id: lbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ladakhi
 - id: lbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Bontok
 - id: lbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Libon Bikol
 - id: lbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lodhi
 - id: lbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamet
 - id: lbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laven
 - id: lbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wampar
 - id: lbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lohorung
 - id: lbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Libyan Sign Language
 - id: lbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lachi
 - id: lbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Labu
 - id: lbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lavatbura-Lamusong
 - id: lbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tolaki
 - id: lbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lawangan
 - id: lby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lamu-Lamu
 - id: lbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lardil
 - id: lcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Legenyem
 - id: lcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lola
 - id: lce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loncong
 - id: lcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lubu
 - id: lch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luchazi
 - id: lcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lisela
 - id: lcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tungag
 - id: lcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Lawa
 - id: lcq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luhu
 - id: lcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lisabata-Nuniali
 - id: lda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kla-Dan
 - id: ldb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Du\u0303ya"
 - id: ldd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luri
 - id: ldg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lenyima
 - id: ldh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamja-Dengsa-Tola
 - id: ldi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laari
 - id: ldj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lemoro
 - id: ldk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leelau
 - id: ldl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaan
 - id: ldm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Landoma
 - id: ldn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: "L\xE1adan"
 - id: ldo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loo
 - id: ldp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tso
 - id: ldq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lufu
 - id: lea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lega-Shabunda
 - id: leb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lala-Bisa
 - id: lec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leco
 - id: led
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lendu
 - id: lee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ly\xE9l\xE9"
 - id: lef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lelemi
 - id: leh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lenje
 - id: lei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lemio
 - id: lej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lengola
 - id: lek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leipon
 - id: lel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lele (Democratic Republic of Congo)
 - id: lem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nomaande
 - id: len
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lenca
 - id: leo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leti (Cameroon)
 - id: lep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lepcha
 - id: leq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lembena
 - id: ler
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lenkau
 - id: les
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lese
 - id: let
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lesing-Gelimi
 - id: leu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kara (Papua New Guinea)
 - id: lev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamma
 - id: lew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ledo Kaili
 - id: lex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luang
 - id: ley
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lemolang
 - id: lez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lezghian
 - id: lfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lefa
 - id: lfn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Lingua Franca Nova
 - id: lga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lungga
 - id: lgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laghu
 - id: lgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lugbara
 - id: lgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laghuu
 - id: lgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lengilu
 - id: lgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lingarak
 - id: lgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wala
 - id: lgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lega-Mwenga
 - id: lgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Opuuo
 - id: lgq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logba
 - id: lgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lengo
 - id: lgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pahi
 - id: lgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Longgu
 - id: lgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ligenza
 - id: lha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laha (Viet Nam)
 - id: lhh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laha (Indonesia)
 - id: lhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lahu Shi
 - id: lhl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lahul Lohar
 - id: lhm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lhomi
 - id: lhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lahanan
 - id: lhp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lhokpu
 - id: lhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Mlahs\xF6"
 - id: lht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lo-Toga
 - id: lhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lahu
 - id: lia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West-Central Limba
 - id: lib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Likum
 - id: lic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hlai
 - id: lid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyindrou
 - id: lie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Likila
 - id: lif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Limbu
 - id: lig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ligbi
 - id: lih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lihir
 - id: lij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ligurian
 - id: lik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lika
 - id: lil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lillooet
 - id: lim
+  props:
+    alpha_2: li
   tags:
   - individual
   - living
   title:
     en: Limburgan
 - id: lin
+  props:
+    alpha_2: ln
   tags:
   - individual
   - living
   title:
     en: Lingala
 - id: lio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liki
 - id: lip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sekpele
 - id: liq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Libido
 - id: lir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liberian English
 - id: lis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lisu
 - id: lit
+  props:
+    alpha_2: lt
   tags:
   - individual
   - living
   title:
     en: Lithuanian
 - id: liu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logorik
 - id: liv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liv
 - id: liw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Col
 - id: lix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liabuku
 - id: liy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banda-Bambari
 - id: liz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Libinza
 - id: lja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Golpa
 - id: lje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rampi
 - id: lji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laiyolo
 - id: ljl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Li'o
 - id: ljp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lampung Api
 - id: ljw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yirandali
 - id: ljx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yuru
 - id: lka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakalei
 - id: lkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabras
 - id: lkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kucong
 - id: lkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Lakond\xEA"
 - id: lke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenyi
 - id: lkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakha
 - id: lki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laki
 - id: lkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Remun
 - id: lkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laeko-Libuat
 - id: lkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kalaamaya
 - id: lkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakon
 - id: lko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khayo
 - id: lkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xE4ri"
 - id: lks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kisa
 - id: lkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lakota
 - id: lku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kungkari
 - id: lky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lokoya
 - id: lla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lala-Roba
 - id: llb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lolo
 - id: llc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lele (Guinea)
 - id: lld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ladin
 - id: lle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lele (Papua New Guinea)
 - id: llf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Hermit
 - id: llg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lole
 - id: llh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamu
 - id: lli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Laali
 - id: llj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ladji Ladji
 - id: llk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lelak
 - id: lll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lilau
 - id: llm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lasalimu
 - id: lln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lele (Chad)
 - id: llo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khlor
 - id: llp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Efate
 - id: llq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lolak
 - id: lls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lithuanian Sign Language
 - id: llu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lau
 - id: llx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lauan
 - id: lma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Limba
 - id: lmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Merei
 - id: lmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Limilngan
 - id: lmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lumun
 - id: lme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xE9v\xE9"
 - id: lmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Lembata
 - id: lmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamogai
 - id: lmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lambichhong
 - id: lmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lombi
 - id: lmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Lembata
 - id: lmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamkang
 - id: lml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hano
 - id: lmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lambadi
 - id: lmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lombard
 - id: lmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Limbum
 - id: lmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamatuka
 - id: lmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamalera
 - id: lmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamenu
 - id: lmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lomaiviti
 - id: lmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lake Miwok
 - id: lmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laimbue
 - id: lmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamboya
 - id: lmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lumbee
 - id: lna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Langbashe
 - id: lnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbalanhu
 - id: lnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lundayeh
 - id: lng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Langobardic
 - id: lnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lanoh
 - id: lni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Daantanai'
 - id: lnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Leningitij
 - id: lnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Central Banda
 - id: lnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Langam
 - id: lnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lorediakarkar
 - id: lno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lango (Sudan)
 - id: lns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamnso'
 - id: lnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Longuda
 - id: lnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lanima
 - id: lnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lonzo
 - id: loa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loloda
 - id: lob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lobi
 - id: loc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inonhan
 - id: loe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saluan
 - id: lof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logol
 - id: log
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logo
 - id: loh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Narim
 - id: loi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Loma (C\xF4te d'Ivoire)"
 - id: loj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lou
 - id: lok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loko
 - id: lol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mongo
 - id: lom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loma (Liberia)
 - id: lon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malawi Lomwe
 - id: loo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lombo
 - id: lop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lopa
 - id: loq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lobala
 - id: lor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "T\xE9\xE9n"
 - id: los
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loniu
 - id: lot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Otuho
 - id: lou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Louisiana Creole
 - id: lov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lopi
 - id: low
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tampias Lobu
 - id: lox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loun
 - id: loy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loke
 - id: loz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lozi
 - id: lpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lelepa
 - id: lpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lepki
 - id: lpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Long Phuri Naga
 - id: lpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lipo
 - id: lpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lopit
 - id: lra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rara Bakati'
 - id: lrc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Luri
 - id: lre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Laurentian
 - id: lrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Laragia
 - id: lri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marachi
 - id: lrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loarki
 - id: lrl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lari
 - id: lrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marama
 - id: lrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lorang
 - id: lro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laro
 - id: lrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Yamphu
 - id: lrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Larantuka Malay
 - id: lrv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Larevat
 - id: lrz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lemerig
 - id: lsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lasgerdi
 - id: lsd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lishana Deni
 - id: lse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lusengo
 - id: lsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lyons Sign Language
 - id: lsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lish
 - id: lsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lashi
 - id: lsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Latvian Sign Language
 - id: lsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saamia
 - id: lso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laos Sign Language
 - id: lsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panamanian Sign Language
 - id: lsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aruop
 - id: lss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lasi
 - id: lst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trinidad and Tobago Sign Language
 - id: lsy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mauritian Sign Language
 - id: ltc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Late Middle Chinese
 - id: ltg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Latgalian
 - id: lti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leti (Indonesia)
 - id: ltn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Latund\xEA"
 - id: lto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsotso
 - id: lts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tachoni
 - id: ltu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Latu
 - id: ltz
+  props:
+    alpha_2: lb
   tags:
   - individual
   - living
   title:
     en: Luxembourgish
 - id: lua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luba-Lulua
 - id: lub
+  props:
+    alpha_2: lu
   tags:
   - individual
   - living
   title:
     en: Luba-Katanga
 - id: luc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aringa
 - id: lud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ludian
 - id: lue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luvale
 - id: luf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laua
 - id: lug
+  props:
+    alpha_2: lg
   tags:
   - individual
   - living
   title:
     en: Ganda
 - id: lui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luiseno
 - id: luj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luna
 - id: luk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lunanakha
 - id: lul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Olu'bo
 - id: lum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luimbi
 - id: lun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lunda
 - id: luo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luo (Kenya and Tanzania)
 - id: lup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lumbu
 - id: luq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lucumi
 - id: lur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laura
 - id: lus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lushai
 - id: lut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lushootseed
 - id: luu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lumba-Yakkha
 - id: luv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luwati
 - id: luw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luo (Cameroon)
 - id: luy
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Luyia
 - id: luz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Luri
 - id: lva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maku'a
 - id: lvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lavukaleve
 - id: lvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Standard Latvian
 - id: lvu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Levuka
 - id: lwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lwalu
 - id: lwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lewo Eleng
 - id: lwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanga
 - id: lwh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: White Lachi
 - id: lwl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Lawa
 - id: lwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laomian
 - id: lwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luwo
 - id: lwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lewotobi
 - id: lwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lawu
 - id: lww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lewo
 - id: lya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Layakha
 - id: lyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lyngngam
 - id: lyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luyana
 - id: lzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Literary Chinese
 - id: lzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Litzlitz
 - id: lzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Leinong Naga
 - id: lzz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Laz
 - id: maa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Jer\xF3nimo Tec\xF3atl Mazatec"
 - id: mab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yutanduchi Mixtec
 - id: mad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Madurese
 - id: mae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bo-Rukul
 - id: maf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mafa
 - id: mag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Magahi
 - id: mah
+  props:
+    alpha_2: mh
   tags:
   - individual
   - living
   title:
     en: Marshallese
 - id: mai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maithili
 - id: maj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Jalapa De D\xEDaz Mazatec"
 - id: mak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makasar
 - id: mal
+  props:
+    alpha_2: ml
   tags:
   - individual
   - living
   title:
     en: Malayalam
 - id: mam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mam
 - id: man
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Mandingo
 - id: maq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Chiquihuitl\xE1n Mazatec"
 - id: mar
+  props:
+    alpha_2: mr
   tags:
   - individual
   - living
   title:
     en: Marathi
 - id: mas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masai
 - id: mat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Francisco Matlatzinca
 - id: mau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huautla Mazatec
 - id: mav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sater\xE9-Maw\xE9"
 - id: maw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mampruli
 - id: max
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Moluccan Malay
 - id: maz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Mazahua
 - id: mba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Higaonon
 - id: mbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Bukidnon Manobo
 - id: mbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Macushi
 - id: mbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dibabawon Manobo
 - id: mbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Molale
 - id: mbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baba Malay
 - id: mbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangseng
 - id: mbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ilianen Manobo
 - id: mbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nad\xEBb"
 - id: mbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malol
 - id: mbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Maxakal\xED"
 - id: mbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ombamba
 - id: mbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Macagu\xE1n"
 - id: mbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbo (Cameroon)
 - id: mbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malayo
 - id: mbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maisin
 - id: mbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nukak Mak\xFA"
 - id: mbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarangani Manobo
 - id: mbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matigsalug Manobo
 - id: mbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbula-Bwazza
 - id: mbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbulungish
 - id: mbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maring
 - id: mbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mari (East Sepik Province)
 - id: mby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Memoni
 - id: mbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amoltepec Mixtec
 - id: mca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maca
 - id: mcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Machiguenga
 - id: mcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bitur
 - id: mcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sharanahua
 - id: mce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Itundujia Mixtec
 - id: mcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mats\xE9s"
 - id: mcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapoyo
 - id: mch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maquiritari
 - id: mci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mese
 - id: mcj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mvanip
 - id: mck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbunda
 - id: mcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Macaguaje
 - id: mcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malaccan Creole Portuguese
 - id: mcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masana
 - id: mco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Coatl\xE1n Mixe"
 - id: mcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makaa
 - id: mcq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ese
 - id: mcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Menya
 - id: mcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mambai
 - id: mct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mengisa
 - id: mcu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cameroon Mambila
 - id: mcv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minanibai
 - id: mcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawa (Chad)
 - id: mcx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpiemo
 - id: mcy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Watut
 - id: mcz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawan
 - id: mda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mada (Nigeria)
 - id: mdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morigi
 - id: mdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Male (Papua New Guinea)
 - id: mdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbum
 - id: mde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maba (Chad)
 - id: mdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moksha
 - id: mdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Massalat
 - id: mdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maguindanaon
 - id: mdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamvu
 - id: mdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangbetu
 - id: mdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangbutu
 - id: mdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maltese Sign Language
 - id: mdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayogo
 - id: mdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbati
 - id: mdp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbala
 - id: mdq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbole
 - id: mdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandar
 - id: mds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maria (Papua New Guinea)
 - id: mdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbere
 - id: mdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mboko
 - id: mdv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa Luc\xEDa Monteverde Mixtec"
 - id: mdw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbosi
 - id: mdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dizin
 - id: mdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Male (Ethiopia)
 - id: mdz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Suru\xED Do Par\xE1"
 - id: mea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Menka
 - id: meb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikobi
 - id: mec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mara
 - id: med
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Melpa
 - id: mee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mengen
 - id: mef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Megam
 - id: meh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Tlaxiaco Mixtec
 - id: mei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Midob
 - id: mej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meyah
 - id: mek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mekeo
 - id: mel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Melanau
 - id: mem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mangala
 - id: men
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mende (Sierra Leone)
 - id: meo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kedah Malay
 - id: mep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miriwung
 - id: meq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Merey
 - id: mer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meru
 - id: mes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masmaje
 - id: met
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mato
 - id: meu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Motu
 - id: mev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mano
 - id: mew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maaka
 - id: mey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hassaniyya
 - id: mez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Menominee
 - id: mfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pattani Malay
 - id: mfb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bangka
 - id: mfc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mba
 - id: mfd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mendankwe-Nkwen
 - id: mfe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morisyen
 - id: mff
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naki
 - id: mfg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mogofin
 - id: mfh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matal
 - id: mfi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wandala
 - id: mfj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mefele
 - id: mfk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Mofu
 - id: mfl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Putai
 - id: mfm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marghi South
 - id: mfn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cross River Mbembe
 - id: mfo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbe
 - id: mfp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makassar Malay
 - id: mfq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moba
 - id: mfr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marithiel
 - id: mfs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mexican Sign Language
 - id: mft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mokerang
 - id: mfu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbwela
 - id: mfv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandjak
 - id: mfw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mulaha
 - id: mfx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Melo
 - id: mfy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayo
 - id: mfz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mabaan
 - id: mga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Irish (900-1200)
 - id: mgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mararit
 - id: mgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morokodo
 - id: mgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moru
 - id: mge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mango
 - id: mgf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maklew
 - id: mgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpumpong
 - id: mgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa-Meetto
 - id: mgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lijili
 - id: mgj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abureni
 - id: mgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawes
 - id: mgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maleu-Kilenge
 - id: mgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mambae
 - id: mgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbangi
 - id: mgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meta'
 - id: mgp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Magar
 - id: mgq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malila
 - id: mgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mambwe-Lungu
 - id: mgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manda (Tanzania)
 - id: mgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mongol
 - id: mgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mailu
 - id: mgv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matengo
 - id: mgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matumbi
 - id: mgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbunga
 - id: mgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbugwe
 - id: mha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manda (India)
 - id: mhb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mahongwe
 - id: mhc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mocho
 - id: mhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbugu
 - id: mhe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Besisi
 - id: mhf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamaa
 - id: mhg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Margu
 - id: mhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma'di
 - id: mhj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mogholi
 - id: mhk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mungaka
 - id: mhl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mauwake
 - id: mhm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa-Moniga
 - id: mhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xF3cheno"
 - id: mho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mashi (Zambia)
 - id: mhp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balinese Malay
 - id: mhq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandan
 - id: mhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Mari
 - id: mhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buru (Indonesia)
 - id: mht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandahuaca
 - id: mhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Digaro-Mishmi
 - id: mhw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbukushu
 - id: mhx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maru
 - id: mhy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma'anyan
 - id: mhz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mor (Mor Islands)
 - id: mia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miami
 - id: mib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Atatl\xE1huca Mixtec"
 - id: mic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mi'kmaq
 - id: mid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandaic
 - id: mie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ocotepec Mixtec
 - id: mif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mofu-Gudur
 - id: mig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Miguel El Grande Mixtec
 - id: mih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chayuco Mixtec
 - id: mii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Chigmecatitl\xE1n Mixtec"
 - id: mij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Abar
 - id: mik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mikasuki
 - id: mil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pe\xF1oles Mixtec"
 - id: mim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alacatlatzala Mixtec
 - id: min
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minangkabau
 - id: mio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pinotepa Nacional Mixtec
 - id: mip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Apasco-Apoala Mixtec
 - id: miq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xEDskito"
 - id: mir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isthmus Mixe
 - id: mis
+  props:
+    alpha_2: ''
   tags:
   - special-scope
   - special-type
   title:
     en: Uncoded languages
 - id: mit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Puebla Mixtec
 - id: miu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cacaloxtepec Mixtec
 - id: miw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akoye
 - id: mix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mixtepec Mixtec
 - id: miy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayutla Mixtec
 - id: miz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coatzospan Mixtec
 - id: mjb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makalero
 - id: mjc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Juan Colorado Mixtec
 - id: mjd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwest Maidu
 - id: mje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Muskum
 - id: mjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tu
 - id: mjh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwera (Nyasa)
 - id: mji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kim Mun
 - id: mjj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawak
 - id: mjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matukar
 - id: mjl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandeali
 - id: mjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Medebur
 - id: mjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma (Papua New Guinea)
 - id: mjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malankuravan
 - id: mjp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malapandaram
 - id: mjq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Malaryan
 - id: mjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malavedan
 - id: mjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miship
 - id: mjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sauria Paharia
 - id: mju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manna-Dora
 - id: mjv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mannan
 - id: mjw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karbi
 - id: mjx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mahali
 - id: mjy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mahican
 - id: mjz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Majhi
 - id: mka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbre
 - id: mkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mal Paharia
 - id: mkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siliput
 - id: mkd
+  props:
+    alpha_2: mk
   tags:
   - individual
   - living
   title:
     en: Macedonian
 - id: mke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawchi
 - id: mkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miya
 - id: mkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mak (China)
 - id: mki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhatki
 - id: mkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mokilese
 - id: mkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Byep
 - id: mkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mokole
 - id: mkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moklen
 - id: mkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kupang Malay
 - id: mko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mingang Doso
 - id: mkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moikodi
 - id: mkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bay Miwok
 - id: mkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malas
 - id: mks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Silacayoapan Mixtec
 - id: mkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vamale
 - id: mku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konyanka Maninka
 - id: mkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mafea
 - id: mkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kituba (Congo)
 - id: mkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinamiging Manobo
 - id: mky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Makian
 - id: mkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makasae
 - id: mla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malo
 - id: mlb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbule
 - id: mlc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cao Lan
 - id: mle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manambu
 - id: mlf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mal
 - id: mlg
+  props:
+    alpha_2: mg
   tags:
   - macrolanguage
   - living
   title:
     en: Malagasy
 - id: mlh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mape
 - id: mli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malimpung
 - id: mlj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miltu
 - id: mlk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ilwana
 - id: mll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malua Bay
 - id: mlm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mulam
 - id: mln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malango
 - id: mlo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mlomp
 - id: mlp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bargam
 - id: mlq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Maninkakan
 - id: mlr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vame
 - id: mls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masalit
 - id: mlt
+  props:
+    alpha_2: mt
   tags:
   - individual
   - living
   title:
     en: Maltese
 - id: mlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: To'abaita
 - id: mlv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Motlav
 - id: mlw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moloko
 - id: mlx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malfaxal
 - id: mlz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malaynon
 - id: mma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mama
 - id: mmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Momina
 - id: mmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Michoac\xE1n Mazahua"
 - id: mmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maonan
 - id: mme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mae
 - id: mmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mundat
 - id: mmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Ambrym
 - id: mmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mehin\xE1ku"
 - id: mmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musar
 - id: mmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Majhwar
 - id: mmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mukha-Dora
 - id: mml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Man Met
 - id: mmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maii
 - id: mmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamanwa
 - id: mmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangga Buang
 - id: mmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siawi
 - id: mmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musak
 - id: mmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Xiangxi Miao
 - id: mmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malalamai
 - id: mmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mmaala
 - id: mmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Miriti
 - id: mmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Emae
 - id: mmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Madak
 - id: mmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Migaama
 - id: mmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mabaale
 - id: mna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbula
 - id: mnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muna
 - id: mnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manchu
 - id: mnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mond\xE9"
 - id: mne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naba
 - id: mnf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mundani
 - id: mng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Mnong
 - id: mnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mono (Democratic Republic of Congo)
 - id: mni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manipuri
 - id: mnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Munji
 - id: mnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandinka
 - id: mnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiale
 - id: mnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapena
 - id: mnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Mnong
 - id: mnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Min Bei Chinese
 - id: mnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minriq
 - id: mnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mono (USA)
 - id: mns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mansi
 - id: mnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mer
 - id: mnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rennell-Bellona
 - id: mnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mon
 - id: mnx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manikion
 - id: mny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manyawa
 - id: mnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moni
 - id: moa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwan
 - id: moc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mocov\xED"
 - id: mod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mobilian
 - id: moe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Montagnais
 - id: mog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mongondow
 - id: moh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mohawk
 - id: moi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mboi
 - id: moj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Monzombo
 - id: mok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morori
 - id: mom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mangue
 - id: mon
+  props:
+    alpha_2: mn
   tags:
   - macrolanguage
   - living
   title:
     en: Mongolian
 - id: moo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Monom
 - id: mop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mop\xE1n Maya"
 - id: moq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mor (Bomberai Peninsula)
 - id: mor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moro
 - id: mos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mossi
 - id: mot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Bar\xED"
 - id: mou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mogum
 - id: mov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mohave
 - id: mow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moi (Congo)
 - id: mox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molima
 - id: moy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shekkacho
 - id: moz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mukulu
 - id: mpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpoto
 - id: mpb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mullukmulluk
 - id: mpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangarayi
 - id: mpd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Machinere
 - id: mpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Majang
 - id: mpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marba
 - id: mph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maung
 - id: mpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpade
 - id: mpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Martu Wangka
 - id: mpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbara (Chad)
 - id: mpl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Middle Watut
 - id: mpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yosond\xFAa Mixtec"
 - id: mpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mindiri
 - id: mpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miu
 - id: mpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Migabac
 - id: mpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mat\xEDs"
 - id: mpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vangunu
 - id: mps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dadibi
 - id: mpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mian
 - id: mpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Makur\xE1p"
 - id: mpv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mungkip
 - id: mpw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapidian
 - id: mpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Misima-Panaeati
 - id: mpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapia
 - id: mpz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpi
 - id: mqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maba (Indonesia)
 - id: mqb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbuko
 - id: mqc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangole
 - id: mqe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matepi
 - id: mqf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Momuna
 - id: mqg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kota Bangun Kutai Malay
 - id: mqh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlazoyaltepec Mixtec
 - id: mqi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mariri
 - id: mqj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamasa
 - id: mqk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rajah Kabunsuwan Manobo
 - id: mql
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbelime
 - id: mqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Marquesan
 - id: mqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moronene
 - id: mqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Modole
 - id: mqp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manipa
 - id: mqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minokok
 - id: mqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mander
 - id: mqs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Makian
 - id: mqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mok
 - id: mqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandari
 - id: mqv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mosimo
 - id: mqw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murupi
 - id: mqx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamuju
 - id: mqy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manggarai
 - id: mqz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pano
 - id: mra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mlabri
 - id: mrb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marino
 - id: mrc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maricopa
 - id: mrd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Magar
 - id: mre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Martha's Vineyard Sign Language
 - id: mrf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elseng
 - id: mrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mising
 - id: mrh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mara Chin
 - id: mri
+  props:
+    alpha_2: mi
   tags:
   - individual
   - living
   title:
     en: Maori
 - id: mrj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Mari
 - id: mrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmwaveke
 - id: mrl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mortlockese
 - id: mrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Merlav
 - id: mrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cheke Holo
 - id: mro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mru
 - id: mrp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morouas
 - id: mrq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Marquesan
 - id: mrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maria (India)
 - id: mrs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maragus
 - id: mrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marghi Central
 - id: mru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mono (Cameroon)
 - id: mrv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangareva
 - id: mrw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maranao
 - id: mrx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maremgi
 - id: mry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandaya
 - id: mrz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marind
 - id: msa
+  props:
+    alpha_2: ms
   tags:
   - macrolanguage
   - living
   title:
     en: Malay (macrolanguage)
 - id: msb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masbatenyo
 - id: msc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sankaran Maninka
 - id: msd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yucatec Maya Sign Language
 - id: mse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musey
 - id: msf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mekwei
 - id: msg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moraid
 - id: msh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masikoro Malagasy
 - id: msi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sabah Malay
 - id: msj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma (Democratic Republic of Congo)
 - id: msk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mansaka
 - id: msl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molof
 - id: msm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agusan Manobo
 - id: msn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Vur\xEBs"
 - id: mso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mombum
 - id: msp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Maritsau\xE1"
 - id: msq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Caac
 - id: msr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mongolian Sign Language
 - id: mss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Masela
 - id: msu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musom
 - id: msv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maslam
 - id: msw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mansoanka
 - id: msx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moresada
 - id: msy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aruamu
 - id: msz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Momare
 - id: mta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cotabato Manobo
 - id: mtb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anyin Morofo
 - id: mtc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Munit
 - id: mtd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mualang
 - id: mte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mono (Solomon Islands)
 - id: mtf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murik (Papua New Guinea)
 - id: mtg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Una
 - id: mth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Munggui
 - id: mti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maiwa (Papua New Guinea)
 - id: mtj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moskona
 - id: mtk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbe'
 - id: mtl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Montol
 - id: mtm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mator
 - id: mtn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Matagalpa
 - id: mto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Totontepec Mixe
 - id: mtp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Wich\xED Lhamt\xE9s Nocten"
 - id: mtq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muong
 - id: mtr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mewari
 - id: mts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yora
 - id: mtt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mota
 - id: mtu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tututepec Mixtec
 - id: mtv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asaro'o
 - id: mtw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Binukidnon
 - id: mtx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tida\xE1 Mixtec"
 - id: mty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nabi
 - id: mua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mundang
 - id: mub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mubi
 - id: muc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ajumbu
 - id: mud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mednyj Aleut
 - id: mue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Media Lengua
 - id: mug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musgu
 - id: muh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xFCnd\xFC"
 - id: mui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musi
 - id: muj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mabire
 - id: muk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mugom
 - id: mul
+  props:
+    alpha_2: ''
   tags:
   - special-scope
   - special-type
   title:
     en: Multiple languages
 - id: mum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maiwala
 - id: muo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyong
 - id: mup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malvi
 - id: muq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Xiangxi Miao
 - id: mur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murle
 - id: mus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Creek
 - id: mut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Muria
 - id: muu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaaku
 - id: muv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muthuvan
 - id: mux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bo-Ung
 - id: muy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muyang
 - id: muz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mursi
 - id: mva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manam
 - id: mvb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mattole
 - id: mvd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamboru
 - id: mve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marwari (Pakistan)
 - id: mvf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Peripheral Mongolian
 - id: mvg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yucua\xF1e Mixtec"
 - id: mvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mulgi
 - id: mvi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miyako
 - id: mvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mekmek
 - id: mvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mbara (Australia)
 - id: mvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muya
 - id: mvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minaveha
 - id: mvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marovo
 - id: mvp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duri
 - id: mvq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moere
 - id: mvr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marau
 - id: mvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Massep
 - id: mvt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpotovoro
 - id: mvu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marfa
 - id: mvv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagal Murut
 - id: mvw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Machinga
 - id: mvx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meoswar
 - id: mvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Indus Kohistani
 - id: mvz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mesqan
 - id: mwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwatebu
 - id: mwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Juwal
 - id: mwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Are
 - id: mwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwera (Chimwera)
 - id: mwf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murrinh-Patha
 - id: mwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aiklep
 - id: mwh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mouk-Aria
 - id: mwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Labo
 - id: mwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kita Maninkakan
 - id: mwl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mirandese
 - id: mwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sar
 - id: mwn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyamwanga
 - id: mwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Maewo
 - id: mwp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kala Lagaw Ya
 - id: mwq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xFCn Chin"
 - id: mwr
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Marwari
 - id: mws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwimbi-Muthambi
 - id: mwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moken
 - id: mwu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mittu
 - id: mwv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mentawai
 - id: mww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hmong Daw
 - id: mwx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mediak
 - id: mwy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mosiro
 - id: mwz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moingi
 - id: mxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwest Oaxaca Mixtec
 - id: mxb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tezoatl\xE1n Mixtec"
 - id: mxc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manyika
 - id: mxd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Modang
 - id: mxe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mele-Fila
 - id: mxf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malgbe
 - id: mxg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbangala
 - id: mxh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mvuba
 - id: mxi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mozarabic
 - id: mxj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miju-Mishmi
 - id: mxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Monumbo
 - id: mxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maxi Gbe
 - id: mxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meramera
 - id: mxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moi (Indonesia)
 - id: mxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbowe
 - id: mxp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlahuitoltepec Mixe
 - id: mxq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Juquila Mixe
 - id: mxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murik (Malaysia)
 - id: mxs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huitepec Mixtec
 - id: mxt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jamiltepec Mixtec
 - id: mxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mada (Cameroon)
 - id: mxv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Metlat\xF3noc Mixtec"
 - id: mxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namo
 - id: mxx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mahou
 - id: mxy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Southeastern Nochixtl\xE1n Mixtec"
 - id: mxz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Masela
 - id: mya
+  props:
+    alpha_2: my
   tags:
   - individual
   - living
   title:
     en: Burmese
 - id: myb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbay
 - id: myc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayeka
 - id: myd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maramba
 - id: mye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Myene
 - id: myf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bambassi
 - id: myg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manta
 - id: myh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makah
 - id: myi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mina (India)
 - id: myj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangayat
 - id: myk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mamara Senoufo
 - id: myl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moma
 - id: mym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Me'en
 - id: myo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anfillo
 - id: myp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pirah\xE3"
 - id: myr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muniche
 - id: mys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mesmes
 - id: myu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Munduruk\xFA"
 - id: myv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Erzya
 - id: myw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muyuw
 - id: myx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masaaba
 - id: myy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Macuna
 - id: myz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Mandaic
 - id: mza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa Mar\xEDa Zacatepec Mixtec"
 - id: mzb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumzabt
 - id: mzc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Madagascar Sign Language
 - id: mzd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malimba
 - id: mze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morawa
 - id: mzg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Monastic Sign Language
 - id: mzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Wich\xED Lhamt\xE9s G\xFCisnay"
 - id: mzi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ixcatl\xE1n Mazatec"
 - id: mzj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manya
 - id: mzk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nigeria Mambila
 - id: mzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mazatl\xE1n Mixe"
 - id: mzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mumuye
 - id: mzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mazanderani
 - id: mzo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Matipuhy
 - id: mzp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Movima
 - id: mzq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mori Atas
 - id: mzr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mar\xFAbo"
 - id: mzs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Macanese
 - id: mzt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mintil
 - id: mzu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inapang
 - id: mzv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manza
 - id: mzw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Deg
 - id: mzx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mawayana
 - id: mzy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mozambican Sign Language
 - id: mzz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maiadomu
 - id: naa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namla
 - id: nab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Southern Nambiku\xE1ra"
 - id: nac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Narak
 - id: nae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naka'ela
 - id: naf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nabak
 - id: nag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naga Pidgin
 - id: naj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nalu
 - id: nak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nakanai
 - id: nal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nalik
 - id: nam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngan'gityemerri
 - id: nan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Min Nan Chinese
 - id: nao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naaba
 - id: nap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Neapolitan
 - id: naq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khoekhoe
 - id: nar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iguta
 - id: nas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naasioi
 - id: nat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ca\u0331hungwa\u0331rya\u0331"
 - id: nau
+  props:
+    alpha_2: na
   tags:
   - individual
   - living
   title:
     en: Nauru
 - id: nav
+  props:
+    alpha_2: nv
   tags:
   - individual
   - living
   title:
     en: Navajo
 - id: naw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nawuri
 - id: nax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nakwi
 - id: nay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Narrinyeri
 - id: naz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coatepec Nahuatl
 - id: nba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyemba
 - id: nbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndoe
 - id: nbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chang Naga
 - id: nbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngbinda
 - id: nbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konyak Naga
 - id: nbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nagarchal
 - id: nbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngamo
 - id: nbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mao Naga
 - id: nbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngarinman
 - id: nbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nake
 - id: nbl
+  props:
+    alpha_2: nr
   tags:
   - individual
   - living
   title:
     en: South Ndebele
 - id: nbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngbaka Ma'bo
 - id: nbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuri
 - id: nbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkukoli
 - id: nbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nnam
 - id: nbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nggem
 - id: nbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Numana-Nunku-Gbantu-Numbu
 - id: nbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namibian Sign Language
 - id: nbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Na
 - id: nbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rongmei Naga
 - id: nbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngamambo
 - id: nbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Ngbandi
 - id: nby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ningera
 - id: nca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iyo
 - id: ncb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Nicobarese
 - id: ncc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ponam
 - id: ncd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nachering
 - id: nce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yale
 - id: ncf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Notsi
 - id: ncg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nisga'a
 - id: nch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Huasteca Nahuatl
 - id: nci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Nahuatl
 - id: ncj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Puebla Nahuatl
 - id: nck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nakara
 - id: ncl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Michoac\xE1n Nahuatl"
 - id: ncm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nambo
 - id: ncn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nauna
 - id: nco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sibe
 - id: ncp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndaktup
 - id: ncr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ncane
 - id: ncs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nicaraguan Sign Language
 - id: nct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chothe Naga
 - id: ncu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chumburung
 - id: ncx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Puebla Nahuatl
 - id: ncz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Natchez
 - id: nda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndasa
 - id: ndb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenswei Nsei
 - id: ndc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndau
 - id: ndd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nde-Nsele-Nta
 - id: nde
+  props:
+    alpha_2: nd
   tags:
   - individual
   - living
   title:
     en: North Ndebele
 - id: ndf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nadruvian
 - id: ndg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndengereko
 - id: ndh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndali
 - id: ndi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samba Leko
 - id: ndj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndamba
 - id: ndk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndaka
 - id: ndl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndolo
 - id: ndm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndam
 - id: ndn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngundi
 - id: ndo
+  props:
+    alpha_2: ng
   tags:
   - individual
   - living
   title:
     en: Ndonga
 - id: ndp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndo
 - id: ndq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndombe
 - id: ndr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndoola
 - id: nds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Low German
 - id: ndt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndunga
 - id: ndu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dugun
 - id: ndv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndut
 - id: ndw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndobo
 - id: ndx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nduga
 - id: ndy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lutos
 - id: ndz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndogo
 - id: nea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Ngad'a
 - id: neb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Toura (C\xF4te d'Ivoire)"
 - id: nec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nedebang
 - id: ned
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nde-Gbite
 - id: nee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "N\xEAl\xEAmwa-Nixumwak"
 - id: nef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nefamese
 - id: neg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Negidal
 - id: neh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyenkha
 - id: nei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Neo-Hittite
 - id: nej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Neko
 - id: nek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Neku
 - id: nem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nemi
 - id: nen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nengone
 - id: neo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "N\xE1-Meo"
 - id: nep
+  props:
+    alpha_2: ne
   tags:
   - macrolanguage
   - living
   title:
     en: Nepali (macrolanguage)
 - id: neq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Central Mixe
 - id: ner
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yahadian
 - id: nes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bhoti Kinnauri
 - id: net
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nete
 - id: neu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Neo
 - id: nev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyaheun
 - id: new
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Newari
 - id: nex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Neme
 - id: ney
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Neyo
 - id: nez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nez Perce
 - id: nfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dhao
 - id: nfd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ahwai
 - id: nfl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayiwo
 - id: nfr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nafaanra
 - id: nfu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mfumte
 - id: nga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngbaka
 - id: ngb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Ngbandi
 - id: ngc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngombe (Democratic Republic of Congo)
 - id: ngd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngando (Central African Republic)
 - id: nge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngemba
 - id: ngg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngbaka Manza
 - id: ngh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: N/u
 - id: ngi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngizim
 - id: ngj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngie
 - id: ngk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dalabon
 - id: ngl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lomwe
 - id: ngm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngatik Men's Creole
 - id: ngn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngwo
 - id: ngo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngoni
 - id: ngp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngulu
 - id: ngq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngurimi
 - id: ngr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Engdewu
 - id: ngs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gvoko
 - id: ngt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngeq
 - id: ngu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guerrero Nahuatl
 - id: ngv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nagumi
 - id: ngw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngwaba
 - id: ngx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nggwahyi
 - id: ngy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tibea
 - id: ngz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngungwel
 - id: nha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nhanda
 - id: nhb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Beng
 - id: nhc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tabasco Nahuatl
 - id: nhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Chirip\xE1"
 - id: nhe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Huasteca Nahuatl
 - id: nhf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nhuwala
 - id: nhg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tetelcingo Nahuatl
 - id: nhh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nahari
 - id: nhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Zacatl\xE1n-Ahuacatl\xE1n-Tepetzintla Nahuatl"
 - id: nhk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isthmus-Cosoleacaque Nahuatl
 - id: nhm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morelos Nahuatl
 - id: nhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Nahuatl
 - id: nho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Takuu
 - id: nhp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isthmus-Pajapan Nahuatl
 - id: nhq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huaxcaleca Nahuatl
 - id: nhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naro
 - id: nht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ometepec Nahuatl
 - id: nhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Noone
 - id: nhv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temascaltepec Nahuatl
 - id: nhw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Huasteca Nahuatl
 - id: nhx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isthmus-Mecayapan Nahuatl
 - id: nhy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Oaxaca Nahuatl
 - id: nhz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa Mar\xEDa La Alta Nahuatl"
 - id: nia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nias
 - id: nib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nakame
 - id: nid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngandi
 - id: nie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Niellim
 - id: nif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nek
 - id: nig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngalakan
 - id: nih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyiha (Tanzania)
 - id: nii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nii
 - id: nij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngaju
 - id: nik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Nicobarese
 - id: nil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nila
 - id: nim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nilamba
 - id: nin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ninzo
 - id: nio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nganasan
 - id: niq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nandi
 - id: nir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nimboran
 - id: nis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nimi
 - id: nit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Kolami
 - id: niu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Niuean
 - id: niv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gilyak
 - id: niw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nimo
 - id: nix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hema
 - id: niy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngiti
 - id: niz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ningil
 - id: nja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nzanyi
 - id: njb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nocte Naga
 - id: njd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndonde Hamba
 - id: njh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lotha Naga
 - id: nji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gudanji
 - id: njj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Njen
 - id: njl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Njalgulgule
 - id: njm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angami Naga
 - id: njn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liangmai Naga
 - id: njo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ao Naga
 - id: njr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Njerep
 - id: njs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nisa
 - id: njt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndyuka-Trio Pidgin
 - id: nju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngadjunmaya
 - id: njx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunyi
 - id: njy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Njyem
 - id: njz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyishi
 - id: nka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkoya
 - id: nkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khoibu Naga
 - id: nkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkongho
 - id: nkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koireng
 - id: nke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duke
 - id: nkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inpui Naga
 - id: nkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nekgini
 - id: nkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khezha Naga
 - id: nki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thangal Naga
 - id: nkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nakai
 - id: nkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nokuku
 - id: nkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namat
 - id: nkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkangala
 - id: nko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkonya
 - id: nkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Niuatoputapu
 - id: nkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkami
 - id: nkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nukuoro
 - id: nks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Asmat
 - id: nkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyika (Tanzania)
 - id: nku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bouna Kulango
 - id: nkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyika (Malawi and Zambia)
 - id: nkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkutu
 - id: nkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkoroo
 - id: nkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nkari
 - id: nla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngombale
 - id: nlc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nalca
 - id: nld
+  props:
+    alpha_2: nl
   tags:
   - individual
   - living
   title:
     en: Dutch
 - id: nle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Nyala
 - id: nlg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gela
 - id: nli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Grangali
 - id: nlj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyali
 - id: nlk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ninia Yali
 - id: nll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nihali
 - id: nlo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngul
 - id: nlq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lao Naga
 - id: nlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nchumbulu
 - id: nlv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orizaba Nahuatl
 - id: nlw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Walangama
 - id: nlx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nahali
 - id: nly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyamal
 - id: nlz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nal\xF6go"
 - id: nma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maram Naga
 - id: nmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Big Nambas
 - id: nmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngam
 - id: nmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndumu
 - id: nme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mzieme Naga
 - id: nmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangkhul Naga (India)
 - id: nmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwasio
 - id: nmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Monsang Naga
 - id: nmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyam
 - id: nmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngombe (Central African Republic)
 - id: nmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namakura
 - id: nml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndemli
 - id: nmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manangba
 - id: nmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "!X\xF3\xF5"
 - id: nmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moyon Naga
 - id: nmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nimanbur
 - id: nmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nambya
 - id: nmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nimbari
 - id: nms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Letemboi
 - id: nmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namonuito
 - id: nmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northeast Maidu
 - id: nmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngamini
 - id: nmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nimoa
 - id: nmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nama (Papua New Guinea)
 - id: nmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namuyi
 - id: nmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nawdm
 - id: nna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyangumarta
 - id: nnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nande
 - id: nnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nancere
 - id: nnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Ambae
 - id: nne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngandyera
 - id: nnf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngaing
 - id: nng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maring Naga
 - id: nnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngiemboon
 - id: nni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Nuaulu
 - id: nnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyangatom
 - id: nnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nankina
 - id: nnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Rengma Naga
 - id: nnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namia
 - id: nnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngete
 - id: nno
+  props:
+    alpha_2: nn
   tags:
   - individual
   - living
   title:
     en: Norwegian Nynorsk
 - id: nnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wancho Naga
 - id: nnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngindo
 - id: nnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Narungga
 - id: nns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ningye
 - id: nnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nanticoke
 - id: nnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dwang
 - id: nnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nugunu (Australia)
 - id: nnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Nuni
 - id: nny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nyangga
 - id: nnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nda'nda'
 - id: noa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Woun Meu
 - id: nob
+  props:
+    alpha_2: nb
   tags:
   - individual
   - living
   title:
     en: "Norwegian Bokm\xE5l"
 - id: noc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nuk
 - id: nod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Thai
 - id: noe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nimadi
 - id: nof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nomane
 - id: nog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nogai
 - id: noh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nomu
 - id: noi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Noiri
 - id: noj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nonuya
 - id: nok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nooksack
 - id: nol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nomlaki
 - id: nom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Nocam\xE1n"
 - id: non
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Norse
 - id: nop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Numanggang
 - id: noq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngongo
 - id: nor
+  props:
+    alpha_2: 'no'
   tags:
   - macrolanguage
   - living
   title:
     en: Norwegian
 - id: nos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Nisu
 - id: not
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nomatsiguenga
 - id: nou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ewage-Notu
 - id: nov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Novial
 - id: now
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyambo
 - id: noy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Noy
 - id: noz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nayi
 - id: npa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nar Phu
 - id: npb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nupbikha
 - id: npg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ponyo-Gongwang Naga
 - id: nph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phom Naga
 - id: npi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nepali (individual language)
 - id: npl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Puebla Nahuatl
 - id: npn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mondropolon
 - id: npo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pochuri Naga
 - id: nps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nipsan
 - id: npu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puimei Naga
 - id: npy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Napu
 - id: nqg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Nago
 - id: nqk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kura Ede Nago
 - id: nqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndom
 - id: nqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nen
 - id: nqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: N'Ko
 - id: nqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyan-Karyaw Naga
 - id: nqy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akyaung Ari Naga
 - id: nra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngom
 - id: nrb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nara
 - id: nrc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Noric
 - id: nre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Rengma Naga
 - id: nrf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "J\xE8rriais"
 - id: nrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Narango
 - id: nri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chokri Naga
 - id: nrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngarla
 - id: nrl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngarluma
 - id: nrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Narom
 - id: nrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Norn
 - id: nrp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: North Picene
 - id: nrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Norra
 - id: nrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Northern Kalapuya
 - id: nru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Narua
 - id: nrx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngurmbur
 - id: nrz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lala
 - id: nsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangtam Naga
 - id: nsc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nshi
 - id: nsd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Nisu
 - id: nse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nsenga
 - id: nsf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Nisu
 - id: nsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngasa
 - id: nsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngoshie
 - id: nsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nigerian Sign Language
 - id: nsk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naskapi
 - id: nsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Norwegian Sign Language
 - id: nsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumi Naga
 - id: nsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nehan
 - id: nso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pedi
 - id: nsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nepalese Sign Language
 - id: nsq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Sierra Miwok
 - id: nsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maritime Sign Language
 - id: nss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nali
 - id: nst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tase Naga
 - id: nsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sierra Negra Nahuatl
 - id: nsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Nisu
 - id: nsw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Navut
 - id: nsx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nsongo
 - id: nsy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nasal
 - id: nsz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nisenan
 - id: ntd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tidung
 - id: nte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nathembo
 - id: ntg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngantangarra
 - id: nti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Natioro
 - id: ntj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngaanyatjarra
 - id: ntk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikoma-Nata-Isenye
 - id: ntm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nateni
 - id: nto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ntomba
 - id: ntp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tepehuan
 - id: ntr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Delo
 - id: ntu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nat\xFCgu"
 - id: ntw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nottoway
 - id: ntx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangkhul Naga (Myanmar)
 - id: nty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mantsi
 - id: ntz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Natanzi
 - id: nua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuanga
 - id: nuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nukuini
 - id: nud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngala
 - id: nue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngundu
 - id: nuf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nusu
 - id: nug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nungali
 - id: nuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndunda
 - id: nui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngumbi
 - id: nuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyole
 - id: nuk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nuu-chah-nulth
 - id: nul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nusa Laut
 - id: num
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Niuafo'ou
 - id: nun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anong
 - id: nuo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ngu\xF4n"
 - id: nup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nupe-Nupe-Tako
 - id: nuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nukumanu
 - id: nur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nukuria
 - id: nus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nuer
 - id: nut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nung (Viet Nam)
 - id: nuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngbundu
 - id: nuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Nuni
 - id: nuw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nguluwan
 - id: nux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mehek
 - id: nuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nunggubuyu
 - id: nuz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlamacazapa Nahuatl
 - id: nvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nasarian
 - id: nvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Namiae
 - id: nvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyokon
 - id: nwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nawathinehena
 - id: nwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyabwa
 - id: nwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Newari
 - id: nwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngwe
 - id: nwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngayawung
 - id: nwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwest Tanna
 - id: nwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyamusa-Molo
 - id: nwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nauo
 - id: nwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nawaru
 - id: nwx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Newar
 - id: nwy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nottoway-Meherrin
 - id: nxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nauete
 - id: nxd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngando (Democratic Republic of Congo)
 - id: nxe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nage
 - id: nxg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngad'a
 - id: nxi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nindi
 - id: nxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koki Naga
 - id: nxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Nuaulu
 - id: nxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Numidian
 - id: nxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngawun
 - id: nxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndambomo
 - id: nxq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naxi
 - id: nxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ninggerum
 - id: nxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Narau
 - id: nxx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nafri
 - id: nya
+  props:
+    alpha_2: ny
   tags:
   - individual
   - living
   title:
     en: Nyanja
 - id: nyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyangbo
 - id: nyc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyanga-li
 - id: nyd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyore
 - id: nye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyengo
 - id: nyf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Giryama
 - id: nyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyindu
 - id: nyh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyigina
 - id: nyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ama (Sudan)
 - id: nyj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyanga
 - id: nyk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyaneka
 - id: nyl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyeu
 - id: nym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyamwezi
 - id: nyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyankole
 - id: nyo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyoro
 - id: nyp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nyang'i
 - id: nyq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nayini
 - id: nyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyiha (Malawi)
 - id: nys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyunga
 - id: nyt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nyawaygi
 - id: nyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyungwe
 - id: nyv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nyulnyul
 - id: nyw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyaw
 - id: nyx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nganyaywana
 - id: nyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyakyusa-Ngonde
 - id: nza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tigon Mbembe
 - id: nzb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Njebi
 - id: nzi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nzima
 - id: nzk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nzakara
 - id: nzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zeme Naga
 - id: nzs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: New Zealand Sign Language
 - id: nzu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Nzikou
 - id: nzy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nzakambay
 - id: nzz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nanga Dama Dogon
 - id: oaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orok
 - id: oac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oroch
 - id: oar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Old Aramaic (up to 700 BCE)
 - id: oav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Avar
 - id: obi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Obispe\xF1o"
 - id: obk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Bontok
 - id: obl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oblo
 - id: obm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Moabite
 - id: obo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Obo Manobo
 - id: obr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Burmese
 - id: obt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Breton
 - id: obu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Obulom
 - id: oca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ocaina
 - id: och
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Old Chinese
 - id: oci
+  props:
+    alpha_2: oc
   tags:
   - individual
   - living
   title:
     en: Occitan (post 1500)
 - id: oco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Cornish
 - id: ocu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atzingo Matlatzinca
 - id: oda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Odut
 - id: odk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Od
 - id: odt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Dutch
 - id: odu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Odual
 - id: ofo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ofo
 - id: ofs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Frisian
 - id: ofu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Efutop
 - id: ogb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ogbia
 - id: ogc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ogbah
 - id: oge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Georgian
 - id: ogg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ogbogolo
 - id: ogo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khana
 - id: ogu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ogbronuagum
 - id: oht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Old Hittite
 - id: ohu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Hungarian
 - id: oia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oirata
 - id: oin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inebu One
 - id: ojb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Ojibwa
 - id: ojc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Ojibwa
 - id: ojg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Ojibwa
 - id: oji
+  props:
+    alpha_2: oj
   tags:
   - macrolanguage
   - living
   title:
     en: Ojibwa
 - id: ojp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Japanese
 - id: ojs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Severn Ojibwa
 - id: ojv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ontong Java
 - id: ojw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Ojibwa
 - id: oka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okanagan
 - id: okb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okobo
 - id: okd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okodia
 - id: oke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okpe (Southwestern Edo)
 - id: okg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Koko Babangk
 - id: okh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koresh-e Rostam
 - id: oki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okiek
 - id: okj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Oko-Juwoi
 - id: okk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwamtim One
 - id: okl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Old Kentish Sign Language
 - id: okm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Korean (10th-16th cent.)
 - id: okn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oki-No-Erabu
 - id: oko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Korean (3rd-9th cent.)
 - id: okr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kirike
 - id: oks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oko-Eni-Osayen
 - id: oku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oku
 - id: okv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orokaiva
 - id: okx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okpe (Northwestern Edo)
 - id: ola
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walungge
 - id: old
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mochi
 - id: ole
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Olekha
 - id: olk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Olkol
 - id: olm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oloma
 - id: olo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Livvi
 - id: olr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Olrat
 - id: olt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Lithuanian
 - id: olu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuvale
 - id: oma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Omaha-Ponca
 - id: omb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Ambae
 - id: omc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mochica
 - id: omg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Omagua
 - id: omi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Omi
 - id: omk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Omok
 - id: oml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ombo
 - id: omn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Minoan
 - id: omo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Utarmbung
 - id: omp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Manipuri
 - id: omr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Marathi
 - id: omt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Omotik
 - id: omu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Omurano
 - id: omw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Tairora
 - id: omx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Mon
 - id: ona
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ona
 - id: onb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lingao
 - id: one
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oneida
 - id: ong
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Olo
 - id: oni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Onin
 - id: onj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Onjob
 - id: onk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabore One
 - id: onn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Onobasulu
 - id: ono
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Onondaga
 - id: onp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sartang
 - id: onr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern One
 - id: ons
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ono
 - id: ont
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ontenu
 - id: onu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Unua
 - id: onw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Nubian
 - id: onx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Onin Based Pidgin
 - id: ood
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tohono O'odham
 - id: oog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ong
 - id: oon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "\xD6nge"
 - id: oor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oorlams
 - id: oos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Old Ossetic
 - id: opa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Okpamheri
 - id: opk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kopkaka
 - id: opm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oksapmin
 - id: opo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Opao
 - id: opt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Opata
 - id: opy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ofay\xE9"
 - id: ora
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oroha
 - id: orc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orma
 - id: ore
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Orej\xF3n"
 - id: org
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oring
 - id: orh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oroqen
 - id: ori
+  props:
+    alpha_2: or
   tags:
   - macrolanguage
   - living
   title:
     en: Oriya (macrolanguage)
 - id: orm
+  props:
+    alpha_2: om
   tags:
   - macrolanguage
   - living
   title:
     en: Oromo
 - id: orn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orang Kanaq
 - id: oro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orokolo
 - id: orr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oruma
 - id: ors
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orang Seletar
 - id: ort
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adivasi Oriya
 - id: oru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ormuri
 - id: orv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Russian
 - id: orw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oro Win
 - id: orx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oro
 - id: ory
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Odia
 - id: orz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ormu
 - id: osa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Osage
 - id: osc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Oscan
 - id: osi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Osing
 - id: oso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ososo
 - id: osp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Spanish
 - id: oss
+  props:
+    alpha_2: os
   tags:
   - individual
   - living
   title:
     en: Ossetian
 - id: ost
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Osatu
 - id: osu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern One
 - id: osx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Saxon
 - id: ota
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Ottoman Turkish (1500-1928)
 - id: otb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Tibetan
 - id: otd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ot Danum
 - id: ote
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mezquital Otomi
 - id: oti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Oti
 - id: otk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Turkish
 - id: otl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tilapa Otomi
 - id: otm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Highland Otomi
 - id: otn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tenango Otomi
 - id: otq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Quer\xE9taro Otomi"
 - id: otr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Otoro
 - id: ots
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Estado de M\xE9xico Otomi"
 - id: ott
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temoaya Otomi
 - id: otu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Otuke
 - id: otw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ottawa
 - id: otx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Texcatepec Otomi
 - id: oty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Old Tamil
 - id: otz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ixtenco Otomi
 - id: oua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagargrent
 - id: oub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Glio-Oubi
 - id: oue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oune
 - id: oui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Uighur
 - id: oum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ouma
 - id: owi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Owiniga
 - id: owl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Welsh
 - id: oyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oy
 - id: oyd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oyda
 - id: oym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wayampi
 - id: oyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oya'oya
 - id: ozm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koonzime
 - id: pab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Parec\xEDs"
 - id: pac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pacoh
 - id: pad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Paumar\xED"
 - id: pae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pagibete
 - id: paf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Paranaw\xE1t"
 - id: pag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pangasinan
 - id: pah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tenharim
 - id: pai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pe
 - id: pak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Parakan\xE3"
 - id: pal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Pahlavi
 - id: pam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pampanga
 - id: pan
+  props:
+    alpha_2: pa
   tags:
   - individual
   - living
   title:
     en: Panjabi
 - id: pao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Paiute
 - id: pap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papiamento
 - id: paq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parya
 - id: par
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panamint
 - id: pas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papasena
 - id: pat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papitalai
 - id: pau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palauan
 - id: pav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Paka\xE1snovos"
 - id: paw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pawnee
 - id: pax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Pankarar\xE9"
 - id: pay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pech
 - id: paz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Pankarar\xFA"
 - id: pbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xE1ez"
 - id: pbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Patamona
 - id: pbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mezontla Popoloca
 - id: pbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coyotepec Popoloca
 - id: pbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Paraujano
 - id: pbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "E'\xF1apa Woromaipu"
 - id: pbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parkwa
 - id: pbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mak (Nigeria)
 - id: pbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kpasam
 - id: pbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papel
 - id: pbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Badyara
 - id: pbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pangwa
 - id: pbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Pame
 - id: pbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Pashto
 - id: pbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Pashto
 - id: pbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pnar
 - id: pby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pyu (Papua New Guinea)
 - id: pca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa In\xE9s Ahuatempan Popoloca"
 - id: pcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pear
 - id: pcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bouyei
 - id: pcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Picard
 - id: pce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ruching Palaung
 - id: pcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paliyan
 - id: pcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paniya
 - id: pch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pardhan
 - id: pci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Duruwa
 - id: pcj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parenga
 - id: pck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paite Chin
 - id: pcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pardhi
 - id: pcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nigerian Pidgin
 - id: pcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piti
 - id: pcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pacahuara
 - id: pcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pyapun
 - id: pda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Anam
 - id: pdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pennsylvania German
 - id: pdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pa Di
 - id: pdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Podena
 - id: pdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Padoe
 - id: pdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plautdietsch
 - id: pdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayan
 - id: pea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Peranakan Indonesian
 - id: peb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Eastern Pomo
 - id: ped
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mala (Papua New Guinea)
 - id: pee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taje
 - id: pef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Northeastern Pomo
 - id: peg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pengo
 - id: peh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bonan
 - id: pei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chichimeca-Jonaz
 - id: pej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Northern Pomo
 - id: pek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Penchal
 - id: pel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pekal
 - id: pem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phende
 - id: peo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Persian (ca. 600-400 B.C.)
 - id: pep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunja
 - id: peq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Pomo
 - id: pes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iranian Persian
 - id: pev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xE9mono"
 - id: pex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Petats
 - id: pey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Petjo
 - id: pez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Penan
 - id: pfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xE1\xE1fang"
 - id: pfe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Peere
 - id: pfl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pfaelzisch
 - id: pga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sudanese Creole Arabic
 - id: pgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: "G\u0101ndh\u0101r\u012B"
 - id: pgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pangwali
 - id: pgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pagi
 - id: pgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rerep
 - id: pgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Primitive Irish
 - id: pgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Paelignian
 - id: pgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pangseng
 - id: pgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pagu
 - id: pgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papua New Guinean Sign Language
 - id: pha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pa-Hng
 - id: phd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phudagi
 - id: phg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phuong
 - id: phh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phukha
 - id: phk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phake
 - id: phl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phalura
 - id: phm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phimbi
 - id: phn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Phoenician
 - id: pho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phunoi
 - id: phq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phana'
 - id: phr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pahari-Potwari
 - id: pht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phu Thai
 - id: phu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phuan
 - id: phv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pahlavani
 - id: phw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phangduwali
 - id: pia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pima Bajo
 - id: pib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yine
 - id: pic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pinji
 - id: pid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piaroa
 - id: pie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Piro
 - id: pif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pingelapese
 - id: pig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pisabo
 - id: pih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pitcairn-Norfolk
 - id: pii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pini
 - id: pij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pijao
 - id: pil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yom
 - id: pim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Powhatan
 - id: pin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piame
 - id: pio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piapoco
 - id: pip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pero
 - id: pir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piratapuyo
 - id: pis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pijin
 - id: pit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pitta Pitta
 - id: piu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pintupi-Luritja
 - id: piv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pileni
 - id: piw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pimbwe
 - id: pix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piu
 - id: piy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piya-Kwonci
 - id: piz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pije
 - id: pjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pitjantjatjara
 - id: pka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: "Ardham\u0101gadh\u012B Pr\u0101krit"
 - id: pkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pokomo
 - id: pkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Paekche
 - id: pkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pak-Tong
 - id: pkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pankhu
 - id: pkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pakanha
 - id: pko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "P\xF6koot"
 - id: pkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pukapuka
 - id: pkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Attapady Kurumba
 - id: pks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pakistan Sign Language
 - id: pkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maleng
 - id: pku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paku
 - id: pla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miani
 - id: plb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Polonombauk
 - id: plc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Palawano
 - id: pld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Polari
 - id: ple
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palu'e
 - id: plg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pilag\xE1"
 - id: plh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paulohi
 - id: pli
+  props:
+    alpha_2: pi
   tags:
   - individual
   - ancient
   title:
     en: Pali
 - id: plj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Polci
 - id: plk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kohistani Shina
 - id: pll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shwe Palaung
 - id: pln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palenquero
 - id: plo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oluta Popoluca
 - id: plp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palpa
 - id: plq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Palaic
 - id: plr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Palaka Senoufo
 - id: pls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Marcos Tlacoyalco Popoloca
 - id: plt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plateau Malagasy
 - id: plu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Palik\xFAr"
 - id: plv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwest Palawano
 - id: plw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brooke's Point Palawano
 - id: ply
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolyu
 - id: plz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paluan
 - id: pma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paama
 - id: pmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pambia
 - id: pmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pallanganmiddang
 - id: pme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pwaamei
 - id: pmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pamona
 - id: pmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: "M\u0101h\u0101r\u0101\u1E63\u1E6Dri Pr\u0101krit"
 - id: pmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Pumi
 - id: pmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Pumi
 - id: pmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pamlico
 - id: pml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lingua Franca
 - id: pmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pomo
 - id: pmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pam
 - id: pmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pom
 - id: pmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Pame
 - id: pmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paynamar
 - id: pms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piemontese
 - id: pmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuamotuan
 - id: pmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plains Miwok
 - id: pmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Poumei Naga
 - id: pmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papuan Malay
 - id: pmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Southern Pame
 - id: pna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Bah-Biau
 - id: pnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Panjabi
 - id: pnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pannei
 - id: pne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Penan
 - id: png
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pongu
 - id: pnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Penrhyn
 - id: pni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aoheng
 - id: pnj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pinjarup
 - id: pnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paunaka
 - id: pnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paleni
 - id: pnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Batu 1
 - id: pnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pinai-Hagahai
 - id: pno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Panobo
 - id: pnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pancana
 - id: pnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pana (Burkina Faso)
 - id: pnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panim
 - id: pns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ponosakan
 - id: pnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pontic
 - id: pnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jiongnai Bunu
 - id: pnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pinigura
 - id: pnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panytyima
 - id: pnx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phong-Kniang
 - id: pny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pinyin
 - id: pnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pana (Central African Republic)
 - id: poc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Poqomam
 - id: poe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Juan Atzingo Popoloca
 - id: pof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Poke
 - id: pog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Potigu\xE1ra"
 - id: poh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Poqomchi'
 - id: poi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Highland Popoluca
 - id: pok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pokang\xE1"
 - id: pol
+  props:
+    alpha_2: pl
   tags:
   - individual
   - living
   title:
     en: Polish
 - id: pom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Pomo
 - id: pon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pohnpeian
 - id: poo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Pomo
 - id: pop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pwapw\xE2"
 - id: poq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Texistepec Popoluca
 - id: por
+  props:
+    alpha_2: pt
   tags:
   - individual
   - living
   title:
     en: Portuguese
 - id: pos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sayula Popoluca
 - id: pot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Potawatomi
 - id: pov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Guinea Crioulo
 - id: pow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Felipe Otlaltepec Popoloca
 - id: pox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Polabian
 - id: poy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pogolo
 - id: ppe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papi
 - id: ppi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paipai
 - id: ppk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uma
 - id: ppl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pipil
 - id: ppm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papuma
 - id: ppn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papapana
 - id: ppo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Folopa
 - id: ppp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pelende
 - id: ppq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pei
 - id: pps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Lu\xEDs Temalacayuca Popoloca"
 - id: ppt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pare
 - id: ppu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Papora
 - id: pqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pa'a
 - id: pqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malecite-Passamaquoddy
 - id: prb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lua'
 - id: prc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parachi
 - id: prd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parsi-Dari
 - id: pre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Principense
 - id: prf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paranan
 - id: prg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Prussian
 - id: prh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Porohanon
 - id: pri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Paic\xEE"
 - id: prk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parauk
 - id: prl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Peruvian Sign Language
 - id: prm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kibiri
 - id: prn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Prasuni
 - id: pro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: "Old Proven\xE7al (to 1500)"
 - id: prp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parsi
 - id: prq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ash\xE9ninka Peren\xE9"
 - id: prr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Puri
 - id: prs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dari
 - id: prt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phai
 - id: pru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puragi
 - id: prw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Parawen
 - id: prx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Purik
 - id: prz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Providencia Sign Language
 - id: psa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Asue Awyu
 - id: psc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Persian Sign Language
 - id: psd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Plains Indian Sign Language
 - id: pse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Malay
 - id: psg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Penang Sign Language
 - id: psh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwest Pashai
 - id: psi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeast Pashai
 - id: psl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puerto Rican Sign Language
 - id: psm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pauserna
 - id: psn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panasuan
 - id: pso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Polish Sign Language
 - id: psp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Philippine Sign Language
 - id: psq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pasi
 - id: psr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Portuguese Sign Language
 - id: pss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaulong
 - id: pst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Pashto
 - id: psu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: "Sauraseni Pr\u0101krit"
 - id: psw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Port Sandwich
 - id: psy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Piscataway
 - id: pta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pai Tavytera
 - id: pth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Patax\xF3 H\xE3-Ha-H\xE3e"
 - id: pti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pintiini
 - id: ptn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Patani
 - id: pto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Zo'\xE9"
 - id: ptp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Patep
 - id: ptq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pattapu
 - id: ptr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Piamatsina
 - id: ptt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Enrekang
 - id: ptu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bambam
 - id: ptv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Port Vato
 - id: ptw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pentlatch
 - id: pty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pathiya
 - id: pua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Highland Purepecha
 - id: pub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Purum
 - id: puc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Merap
 - id: pud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Aput
 - id: pue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Puelche
 - id: puf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Merah
 - id: pug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phuie
 - id: pui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puinave
 - id: puj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punan Tubu
 - id: puk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pu Ko
 - id: pum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puma
 - id: puo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puoc
 - id: pup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pulabu
 - id: puq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Puquina
 - id: pur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Purubor\xE1"
 - id: pus
+  props:
+    alpha_2: ps
   tags:
   - macrolanguage
   - living
   title:
     en: Pushto
 - id: put
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Putoh
 - id: puu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Punu
 - id: puw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puluwatese
 - id: pux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puare
 - id: puy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Purisime\xF1o"
 - id: pwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pawaia
 - id: pwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panawa
 - id: pwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gapapaiwa
 - id: pwi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Patwin
 - id: pwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molbog
 - id: pwn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paiwan
 - id: pwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pwo Western Karen
 - id: pwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Powari
 - id: pww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pwo Northern Karen
 - id: pxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quetzaltepec Mixe
 - id: pye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pye Krumen
 - id: pym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fyam
 - id: pyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Poyan\xE1wa"
 - id: pys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paraguayan Sign Language
 - id: pyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puyuma
 - id: pyx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Pyu (Myanmar)
 - id: pyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pyen
 - id: pzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Para Naga
 - id: qua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quapaw
 - id: qub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Huallaga Hu\xE1nuco Quechua"
 - id: quc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: K'iche'
 - id: qud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Calder\xF3n Highland Quichua"
 - id: que
+  props:
+    alpha_2: qu
   tags:
   - macrolanguage
   - living
   title:
     en: Quechua
 - id: quf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lambayeque Quechua
 - id: qug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chimborazo Highland Quichua
 - id: quh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Bolivian Quechua
 - id: qui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quileute
 - id: quk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chachapoyas Quechua
 - id: qul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Bolivian Quechua
 - id: qum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sipacapense
 - id: qun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Quinault
 - id: qup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Pastaza Quechua
 - id: quq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quinqui
 - id: qur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yanahuanca Pasco Quechua
 - id: qus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santiago del Estero Quichua
 - id: quv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sacapulteco
 - id: quw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tena Lowland Quichua
 - id: qux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yauyos Quechua
 - id: quy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayacucho Quechua
 - id: quz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cusco Quechua
 - id: qva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ambo-Pasco Quechua
 - id: qvc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cajamarca Quechua
 - id: qve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Eastern Apur\xEDmac Quechua"
 - id: qvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Huamal\xEDes-Dos de Mayo Hu\xE1nuco Quechua"
 - id: qvi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Imbabura Highland Quichua
 - id: qvj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loja Highland Quichua
 - id: qvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cajatambo North Lima Quechua
 - id: qvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Margos-Yarowilca-Lauricocha Quechua
 - id: qvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "North Jun\xEDn Quechua"
 - id: qvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Napo Lowland Quechua
 - id: qvp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pacaraos Quechua
 - id: qvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Mart\xEDn Quechua"
 - id: qvw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huaylla Wanca Quechua
 - id: qvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Queyu
 - id: qvz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Pastaza Quichua
 - id: qwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Corongo Ancash Quechua
 - id: qwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Quechua
 - id: qwh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huaylas Ancash Quechua
 - id: qwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuman (Russia)
 - id: qws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sihuas Ancash Quechua
 - id: qwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kwalhioqua-Tlatskanai
 - id: qxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Chiqui\xE1n Ancash Quechua"
 - id: qxc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chincha Quechua
 - id: qxh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Panao Hu\xE1nuco Quechua"
 - id: qxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salasaca Highland Quichua
 - id: qxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Conchucos Ancash Quechua
 - id: qxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Conchucos Ancash Quechua
 - id: qxp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puno Quechua
 - id: qxq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qashqa'i
 - id: qxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ca\xF1ar Highland Quichua"
 - id: qxs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Qiang
 - id: qxt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santa Ana de Tusi Pasco Quechua
 - id: qxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Arequipa-La Uni\xF3n Quechua"
 - id: qxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jauja Wanca Quechua
 - id: qya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Quenya
 - id: qyp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Quiripi
 - id: raa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dungmali
 - id: rab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Camling
 - id: rac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rasawa
 - id: rad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rade
 - id: raf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Meohang
 - id: rag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logooli
 - id: rah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rabha
 - id: rai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ramoaaina
 - id: raj
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Rajasthani
 - id: rak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tulu-Bohuai
 - id: ral
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ralte
 - id: ram
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Canela
 - id: ran
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Riantana
 - id: rao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rao
 - id: rap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rapanui
 - id: raq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saam
 - id: rar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rarotongan
 - id: ras
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tegali
 - id: rat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Razajerdi
 - id: rau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Raute
 - id: rav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sampang
 - id: raw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rawang
 - id: rax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rang
 - id: ray
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rapa
 - id: raz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rahambuu
 - id: rbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rumai Palaung
 - id: rbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Bontok
 - id: rbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miraya Bikol
 - id: rbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Barababaraba
 - id: rcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "R\xE9union Creole French"
 - id: rdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rudbari
 - id: rea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rerau
 - id: reb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rembong
 - id: ree
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rejang Kayan
 - id: reg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kara (Tanzania)
 - id: rei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Reli
 - id: rej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rejang
 - id: rel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rendille
 - id: rem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Remo
 - id: ren
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rengao
 - id: rer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Rer Bare
 - id: res
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Reshe
 - id: ret
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Retta
 - id: rey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Reyesano
 - id: rga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Roria
 - id: rge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romano-Greek
 - id: rgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Rangkas
 - id: rgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romagnol
 - id: rgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Res\xEDgaro"
 - id: rgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Roglai
 - id: rgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ringgou
 - id: rhg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rohingya
 - id: rhp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yahang
 - id: ria
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Riang (India)
 - id: rie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rien
 - id: rif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tarifit
 - id: ril
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Riang (Myanmar)
 - id: rim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyaturu
 - id: rin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nungu
 - id: rir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ribun
 - id: rit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ritarungo
 - id: riu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Riung
 - id: rjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rajong
 - id: rji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Raji
 - id: rjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rajbanshi
 - id: rka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kraol
 - id: rkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rikbaktsa
 - id: rkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rakahanga-Manihiki
 - id: rki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rakhine
 - id: rkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marka
 - id: rkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rangpuri
 - id: rkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arakwal
 - id: rma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rama
 - id: rmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rembarunga
 - id: rmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Carpathian Romani
 - id: rmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Traveller Danish
 - id: rme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angloromani
 - id: rmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalo Finnish Romani
 - id: rmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Traveller Norwegian
 - id: rmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Murkim
 - id: rmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lomavren
 - id: rmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romkun
 - id: rml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baltic Romani
 - id: rmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Roma
 - id: rmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balkan Romani
 - id: rmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinte Romani
 - id: rmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rempi
 - id: rmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Cal\xF3"
 - id: rms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romanian Sign Language
 - id: rmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Domari
 - id: rmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tavringer Romani
 - id: rmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Romanova
 - id: rmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Welsh Romani
 - id: rmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romam
 - id: rmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vlax Romani
 - id: rmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marma
 - id: rnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ruund
 - id: rng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ronga
 - id: rnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ranglong
 - id: rnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Roon
 - id: rnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rongpo
 - id: rnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nari Nari
 - id: rnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rungwa
 - id: rob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tae'
 - id: roc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cacgia Roglai
 - id: rod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rogo
 - id: roe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ronji
 - id: rof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rombo
 - id: rog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Roglai
 - id: roh
+  props:
+    alpha_2: rm
   tags:
   - individual
   - living
   title:
     en: Romansh
 - id: rol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romblomanon
 - id: rom
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Romany
 - id: ron
+  props:
+    alpha_2: ro
   tags:
   - individual
   - living
   title:
     en: Romanian
 - id: roo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rotokas
 - id: rop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kriol
 - id: ror
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rongga
 - id: rou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Runga
 - id: row
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dela-Oenale
 - id: rpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Repanbitip
 - id: rpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rapting
 - id: rri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ririo
 - id: rro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waima
 - id: rrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arritinngithigh
 - id: rsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Romano-Serbian
 - id: rsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rennellese Sign Language
 - id: rsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Russian Sign Language
 - id: rsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miriwoong Sign Language
 - id: rtc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rungtu Chin
 - id: rth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ratahan
 - id: rtm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rotuman
 - id: rts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yurats
 - id: rtw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rathawi
 - id: rub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gungu
 - id: ruc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ruuli
 - id: rue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rusyn
 - id: ruf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Luguru
 - id: rug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Roviana
 - id: ruh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ruga
 - id: rui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rufiji
 - id: ruk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Che
 - id: run
+  props:
+    alpha_2: rn
   tags:
   - individual
   - living
   title:
     en: Rundi
 - id: ruo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Istro Romanian
 - id: rup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Macedo-Romanian
 - id: ruq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Megleno Romanian
 - id: rus
+  props:
+    alpha_2: ru
   tags:
   - individual
   - living
   title:
     en: Russian
 - id: rut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rutul
 - id: ruu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lanas Lobu
 - id: ruy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mala (Nigeria)
 - id: ruz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ruma
 - id: rwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rawo
 - id: rwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rwa
 - id: rwm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amba (Uganda)
 - id: rwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rawa
 - id: rwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marwari (India)
 - id: rxd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngardi
 - id: rxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karuwali
 - id: ryn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Amami-Oshima
 - id: rys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaeyama
 - id: ryu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Okinawan
 - id: rzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "R\u0101zi\u1E25\u012B"
 - id: saa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saba
 - id: sab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buglere
 - id: sac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meskwaki
 - id: sad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sandawe
 - id: sae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Saban\xEA"
 - id: saf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Safaliba
 - id: sag
+  props:
+    alpha_2: sg
   tags:
   - individual
   - living
   title:
     en: Sango
 - id: sah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakut
 - id: saj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sahu
 - id: sak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sake
 - id: sam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Samaritan Aramaic
 - id: san
+  props:
+    alpha_2: sa
   tags:
   - individual
   - ancient
   title:
     en: Sanskrit
 - id: sao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sause
 - id: saq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samburu
 - id: sar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Saraveca
 - id: sas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sasak
 - id: sat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santali
 - id: sau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saleman
 - id: sav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saafi-Saafi
 - id: saw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sawi
 - id: sax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sa
 - id: say
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saya
 - id: saz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saurashtra
 - id: sba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngambay
 - id: sbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simbo
 - id: sbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kele (Papua New Guinea)
 - id: sbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Samo
 - id: sbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saliba
 - id: sbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chabu
 - id: sbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seget
 - id: sbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sori-Harengan
 - id: sbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seti
 - id: sbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Surbakhal
 - id: sbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Safwa
 - id: sbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Botolan Sambal
 - id: sbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sagala
 - id: sbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sindhi Bhil
 - id: sbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sab\xFCm"
 - id: sbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangu (Tanzania)
 - id: sbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sileibi
 - id: sbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sembakung Murut
 - id: sbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Subiya
 - id: sbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kimki
 - id: sbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Stod Bhoti
 - id: sbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sabine
 - id: sbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simba
 - id: sbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seberuang
 - id: sby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soli
 - id: sbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sara Kaba
 - id: scb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chut
 - id: sce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dongxiang
 - id: scf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Miguel Creole French
 - id: scg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanggau
 - id: sch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sakachep
 - id: sci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sri Lankan Creole Malay
 - id: sck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sadri
 - id: scl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shina
 - id: scn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sicilian
 - id: sco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Scots
 - id: scp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Helambu Sherpa
 - id: scq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sa'och
 - id: scs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Slavey
 - id: scu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shumcho
 - id: scv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sheni
 - id: scw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sha
 - id: scx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sicel
 - id: sda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toraja-Sa'dan
 - id: sdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shabak
 - id: sdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sassarese Sardinian
 - id: sde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Surubu
 - id: sdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarli
 - id: sdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Savi
 - id: sdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Kurdish
 - id: sdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suundi
 - id: sdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sos Kundi
 - id: sdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saudi Arabian Sign Language
 - id: sdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semandang
 - id: sdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gallurese Sardinian
 - id: sdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bukar-Sadung Bidayuh
 - id: sdp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sherdukpen
 - id: sdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Oraon Sadri
 - id: sds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Sened
 - id: sdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Shuadit
 - id: sdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarudu
 - id: sdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sibu Melanau
 - id: sdz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sallands
 - id: sea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semai
 - id: seb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shempire Senoufo
 - id: sec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sechelt
 - id: sed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sedang
 - id: see
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seneca
 - id: sef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cebaara Senoufo
 - id: seg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Segeju
 - id: seh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sena
 - id: sei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seri
 - id: sej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sene
 - id: sek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sekani
 - id: sel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selkup
 - id: sen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Nanerig\xE9 S\xE9noufo"
 - id: seo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suarmin
 - id: sep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "S\xECc\xECt\xE9 S\xE9noufo"
 - id: seq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Senara S\xE9noufo"
 - id: ser
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serrano
 - id: ses
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koyraboro Senni Songhai
 - id: set
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sentani
 - id: seu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serui-Laut
 - id: sev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyarafolo Senoufo
 - id: sew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sewa Bay
 - id: sey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Secoya
 - id: sez
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Senthang Chin
 - id: sfb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Langue des signes de Belgique Francophone
 - id: sfe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Subanen
 - id: sfm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Small Flowery Miao
 - id: sfs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South African Sign Language
 - id: sfw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sehwi
 - id: sga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Old Irish (to 900)
 - id: sgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mag-antsi Ayta
 - id: sgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kipsigis
 - id: sgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Surigaonon
 - id: sge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Segai
 - id: sgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swiss-German Sign Language
 - id: sgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shughni
 - id: sgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suga
 - id: sgj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Surgujia
 - id: sgk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangkong
 - id: sgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Singa
 - id: sgp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Singpho
 - id: sgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangisari
 - id: sgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samogitian
 - id: sgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Brokpake
 - id: sgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salas
 - id: sgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sebat Bet Gurage
 - id: sgx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sierra Leone Sign Language
 - id: sgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanglechi
 - id: sgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sursurunga
 - id: sha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shall-Zwall
 - id: shb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ninam
 - id: shc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sonde
 - id: shd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kundal Shahi
 - id: she
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sheko
 - id: shg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shua
 - id: shh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shoshoni
 - id: shi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tachelhit
 - id: shj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shatt
 - id: shk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shilluk
 - id: shl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shendu
 - id: shm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shahrudi
 - id: shn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shan
 - id: sho
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shanga
 - id: shp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shipibo-Conibo
 - id: shq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sala
 - id: shr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shi
 - id: shs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shuswap
 - id: sht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Shasta
 - id: shu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chadian Arabic
 - id: shv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shehri
 - id: shw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shwai
 - id: shx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: She
 - id: shy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tachawit
 - id: shz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Syenara Senoufo
 - id: sia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Akkala Sami
 - id: sib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sebop
 - id: sid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sidamo
 - id: sie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simaa
 - id: sif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siamou
 - id: sig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Paasaal
 - id: sih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zire
 - id: sii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shom Peng
 - id: sij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Numbami
 - id: sik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sikiana
 - id: sil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumulung Sisaala
 - id: sim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mende (Papua New Guinea)
 - id: sin
+  props:
+    alpha_2: si
   tags:
   - individual
   - living
   title:
     en: Sinhala
 - id: sip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sikkimese
 - id: siq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sonia
 - id: sir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siri
 - id: sis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Siuslaw
 - id: siu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinagen
 - id: siv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumariup
 - id: siw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siwai
 - id: six
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumau
 - id: siy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sivandi
 - id: siz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siwi
 - id: sja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Epena
 - id: sjb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sajau Basap
 - id: sjd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kildin Sami
 - id: sje
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pite Sami
 - id: sjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Assangori
 - id: sjk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kemi Sami
 - id: sjl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sajalong
 - id: sjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mapun
 - id: sjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Sindarin
 - id: sjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xibe
 - id: sjp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Surjapuri
 - id: sjr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siar-Lak
 - id: sjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Senhaja De Srair
 - id: sjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ter Sami
 - id: sju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ume Sami
 - id: sjw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shawnee
 - id: ska
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Skagit
 - id: skb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saek
 - id: skc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma Manda
 - id: skd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Sierra Miwok
 - id: ske
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seke (Vanuatu)
 - id: skf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sakirabi\xE1"
 - id: skg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sakalava Malagasy
 - id: skh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sikule
 - id: ski
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sika
 - id: skj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seke (Nepal)
 - id: skk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sok
 - id: skm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kutong
 - id: skn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kolibugan Subanon
 - id: sko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seko Tengah
 - id: skp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sekapan
 - id: skq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sininkere
 - id: skr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saraiki
 - id: sks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maia
 - id: skt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sakata
 - id: sku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sakao
 - id: skv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Skou
 - id: skw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Skepi Creole Dutch
 - id: skx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seko Padang
 - id: sky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sikaiana
 - id: skz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sekar
 - id: slc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "S\xE1liba"
 - id: sld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sissala
 - id: sle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sholaga
 - id: slf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swiss-Italian Sign Language
 - id: slg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selungai Murut
 - id: slh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Puget Sound Salish
 - id: sli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lower Silesian
 - id: slj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Salum\xE1"
 - id: slk
+  props:
+    alpha_2: sk
   tags:
   - individual
   - living
   title:
     en: Slovak
 - id: sll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salt-Yui
 - id: slm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pangutaran Sama
 - id: sln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Salinan
 - id: slp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lamaholot
 - id: slq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salchuq
 - id: slr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salar
 - id: sls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Singapore Sign Language
 - id: slt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sila
 - id: slu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selaru
 - id: slv
+  props:
+    alpha_2: sl
   tags:
   - individual
   - living
   title:
     en: Slovenian
 - id: slw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sialum
 - id: slx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Salampasu
 - id: sly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selayar
 - id: slz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ma'ya
 - id: sma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Sami
 - id: smb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simbari
 - id: smc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Som
 - id: smd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sama
 - id: sme
+  props:
+    alpha_2: se
   tags:
   - individual
   - living
   title:
     en: Northern Sami
 - id: smf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Auwe
 - id: smg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simbali
 - id: smh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samei
 - id: smj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lule Sami
 - id: smk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bolinao
 - id: sml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Sama
 - id: smm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Musasa
 - id: smn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Inari Sami
 - id: smo
+  props:
+    alpha_2: sm
   tags:
   - individual
   - living
   title:
     en: Samoan
 - id: smp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Samaritan
 - id: smq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samo
 - id: smr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simeulue
 - id: sms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Skolt Sami
 - id: smt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simte
 - id: smu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Somray
 - id: smv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samvedi
 - id: smw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumbawa
 - id: smx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samba
 - id: smy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semnani
 - id: smz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Simeku
 - id: sna
+  props:
+    alpha_2: sn
   tags:
   - individual
   - living
   title:
     en: Shona
 - id: snb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sebuyau
 - id: snc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinaugoro
 - id: snd
+  props:
+    alpha_2: sd
   tags:
   - individual
   - living
   title:
     en: Sindhi
 - id: sne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bau Bidayuh
 - id: snf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Noon
 - id: sng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanga (Democratic Republic of Congo)
 - id: snh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Shinabo
 - id: sni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Sensi
 - id: snj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Riverain Sango
 - id: snk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soninke
 - id: snl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangil
 - id: snm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Ma'di
 - id: snn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siona
 - id: sno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Snohomish
 - id: snp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siane
 - id: snq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangu (Gabon)
 - id: snr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sihan
 - id: sns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South West Bay
 - id: snu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Senggi
 - id: snv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sa'ban
 - id: snw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selee
 - id: snx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sam
 - id: sny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saniyo-Hiyewe
 - id: snz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinsauru
 - id: soa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thai Song
 - id: sob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sobei
 - id: soc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: So (Democratic Republic of Congo)
 - id: sod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Songoora
 - id: soe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Songomeno
 - id: sog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sogdian
 - id: soh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aka
 - id: soi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sonha
 - id: soj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soi
 - id: sok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sokoro
 - id: sol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Solos
 - id: som
+  props:
+    alpha_2: so
   tags:
   - individual
   - living
   title:
     en: Somali
 - id: soo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Songo
 - id: sop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Songe
 - id: soq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanasi
 - id: sor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Somrai
 - id: sos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seeku
 - id: sot
+  props:
+    alpha_2: st
   tags:
   - individual
   - living
   title:
     en: Southern Sotho
 - id: sou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Thai
 - id: sov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sonsorol
 - id: sow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sowanda
 - id: sox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swo
 - id: soy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miyobe
 - id: soz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temi
 - id: spa
+  props:
+    alpha_2: es
   tags:
   - individual
   - living
   title:
     en: Spanish
 - id: spb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sepa (Indonesia)
 - id: spc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sap\xE9"
 - id: spd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saep
 - id: spe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sepa (Papua New Guinea)
 - id: spg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sian
 - id: spi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saponi
 - id: spk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sengo
 - id: spl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Selepet
 - id: spm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akukem
 - id: spn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sanapan\xE1"
 - id: spo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Spokane
 - id: spp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Supyire Senoufo
 - id: spq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loreto-Ucayali Spanish
 - id: spr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saparua
 - id: sps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saposa
 - id: spt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Spiti Bhoti
 - id: spu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sapuan
 - id: spv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sambalpuri
 - id: spx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: South Picene
 - id: spy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sabaot
 - id: sqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shama-Sambuga
 - id: sqh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shau
 - id: sqi
+  props:
+    alpha_2: sq
   tags:
   - macrolanguage
   - living
   title:
     en: Albanian
 - id: sqk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Albanian Sign Language
 - id: sqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suma
 - id: sqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Susquehannock
 - id: sqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sorkhei
 - id: sqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sou
 - id: sqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Siculo Arabic
 - id: sqs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sri Lankan Sign Language
 - id: sqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soqotri
 - id: squ
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Squamish
 - id: sra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saruga
 - id: srb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sora
 - id: src
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Logudorese Sardinian
 - id: srd
+  props:
+    alpha_2: sc
   tags:
   - macrolanguage
   - living
   title:
     en: Sardinian
 - id: sre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sara
 - id: srf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nafi
 - id: srg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sulod
 - id: srh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarikoli
 - id: sri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siriano
 - id: srk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serudung Murut
 - id: srl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isirawa
 - id: srm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saramaccan
 - id: srn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sranan Tongo
 - id: sro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Campidanese Sardinian
 - id: srp
+  props:
+    alpha_2: sr
   tags:
   - individual
   - living
   title:
     en: Serbian
 - id: srq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sirion\xF3"
 - id: srr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serer
 - id: srs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarsi
 - id: srt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sauri
 - id: sru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Suru\xED"
 - id: srv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Sorsoganon
 - id: srw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serua
 - id: srx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sirmauri
 - id: sry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sera
 - id: srz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shahmirzadi
 - id: ssb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Sama
 - id: ssc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suba-Simbiti
 - id: ssd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siroi
 - id: sse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Balangingi
 - id: ssf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thao
 - id: ssg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seimat
 - id: ssh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shihhi Arabic
 - id: ssi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sansi
 - id: ssj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sausi
 - id: ssk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sunam
 - id: ssl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Sisaala
 - id: ssm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semnam
 - id: ssn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waata
 - id: sso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sissano
 - id: ssp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Spanish Sign Language
 - id: ssq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: So'a
 - id: ssr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swiss-French Sign Language
 - id: sss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "S\xF4"
 - id: sst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinasina
 - id: ssu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Susuami
 - id: ssv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shark Bay
 - id: ssw
+  props:
+    alpha_2: ss
   tags:
   - individual
   - living
   title:
     en: Swati
 - id: ssx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samberigi
 - id: ssy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saho
 - id: ssz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sengseng
 - id: sta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Settla
 - id: stb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Subanen
 - id: std
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sentinel
 - id: ste
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liana-Seti
 - id: stf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seta
 - id: stg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trieng
 - id: sth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shelta
 - id: sti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bulo Stieng
 - id: stj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matya Samo
 - id: stk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Arammba
 - id: stl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Stellingwerfs
 - id: stm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Setaman
 - id: stn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Owa
 - id: sto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Stoney
 - id: stp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Tepehuan
 - id: stq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saterfriesisch
 - id: str
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Straits Salish
 - id: sts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shumashti
 - id: stt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Budeh Stieng
 - id: stu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samtao
 - id: stv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Silt'e
 - id: stw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Satawalese
 - id: sty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siberian Tatar
 - id: sua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sulka
 - id: sub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suku
 - id: suc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Subanon
 - id: sue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suena
 - id: sug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suganga
 - id: sui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suki
 - id: suj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shubi
 - id: suk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sukuma
 - id: sun
+  props:
+    alpha_2: su
   tags:
   - individual
   - living
   title:
     en: Sundanese
 - id: suq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suri
 - id: sur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwaghavul
 - id: sus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Susu
 - id: sut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Subtiaba
 - id: suv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Puroik
 - id: suw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sumbwa
 - id: sux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sumerian
 - id: suy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Suy\xE1"
 - id: suz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sunwar
 - id: sva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Svan
 - id: svb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulau-Suain
 - id: svc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vincentian Creole English
 - id: sve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Serili
 - id: svk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Slovakian Sign Language
 - id: svm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Slavomolisano
 - id: svs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Savosavo
 - id: svx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Skalvian
 - id: swa
+  props:
+    alpha_2: sw
   tags:
   - macrolanguage
   - living
   title:
     en: Swahili (macrolanguage)
 - id: swb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maore Comorian
 - id: swc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Congo Swahili
 - id: swe
+  props:
+    alpha_2: sv
   tags:
   - individual
   - living
   title:
     en: Swedish
 - id: swf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sere
 - id: swg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swabian
 - id: swh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swahili (individual language)
 - id: swi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sui
 - id: swj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sira
 - id: swk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malawi Sena
 - id: swl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Swedish Sign Language
 - id: swm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samosa
 - id: swn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sawknah
 - id: swo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shanenawa
 - id: swp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suau
 - id: swq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sharwa
 - id: swr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saweru
 - id: sws
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seluwasan
 - id: swt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sawila
 - id: swu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suwawa
 - id: swv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shekhawati
 - id: sww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Sowa
 - id: swx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Suruah\xE1"
 - id: swy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarua
 - id: sxb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suba
 - id: sxc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sicanian
 - id: sxe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sighu
 - id: sxg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shixing
 - id: sxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Southern Kalapuya
 - id: sxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Selian
 - id: sxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samre
 - id: sxn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sangir
 - id: sxo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sorothaptic
 - id: sxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saaroa
 - id: sxs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sasaru
 - id: sxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Saxon
 - id: sxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saxwe Gbe
 - id: sya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Siang
 - id: syb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Subanen
 - id: syc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Syriac
 - id: syi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seki
 - id: syk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sukur
 - id: syl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sylheti
 - id: sym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maya Samo
 - id: syn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Senaya
 - id: syo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suoy
 - id: syr
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Syriac
 - id: sys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinyar
 - id: syw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagate
 - id: syx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samay
 - id: syy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Al-Sayyid Bedouin Sign Language
 - id: sza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semelai
 - id: szb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngalum
 - id: szc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Semaq Beri
 - id: szd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Seru
 - id: sze
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Seze
 - id: szg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sengele
 - id: szl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Silesian
 - id: szn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sula
 - id: szp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Suabo
 - id: szv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isu (Fako Division)
 - id: szw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sawai
 - id: taa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lower Tanana
 - id: tab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabassaran
 - id: tac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lowland Tarahumara
 - id: tad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tause
 - id: tae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tariana
 - id: taf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tapirap\xE9"
 - id: tag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagoi
 - id: tah
+  props:
+    alpha_2: ty
   tags:
   - individual
   - living
   title:
     en: Tahitian
 - id: taj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Tamang
 - id: tak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tala
 - id: tal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tal
 - id: tam
+  props:
+    alpha_2: ta
   tags:
   - individual
   - living
   title:
     en: Tamil
 - id: tan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangale
 - id: tao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yami
 - id: tap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taabwa
 - id: taq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tamasheq
 - id: tar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Tarahumara
 - id: tas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tay Boi
 - id: tat
+  props:
+    alpha_2: tt
   tags:
   - individual
   - living
   title:
     en: Tatar
 - id: tau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Tanana
 - id: tav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tatuyo
 - id: taw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai
 - id: tax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tamki
 - id: tay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Atayal
 - id: taz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tocho
 - id: tba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Aikan\xE3"
 - id: tbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tapeba
 - id: tbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Takia
 - id: tbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaki Ae
 - id: tbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanimbili
 - id: tbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mandara
 - id: tbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Tairora
 - id: tbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Thurawal
 - id: tbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaam
 - id: tbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiang
 - id: tbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Calamian Tagbanwa
 - id: tbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tboli
 - id: tbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagbu
 - id: tbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Barro Negro Tunebo
 - id: tbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawala
 - id: tbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taworta
 - id: tbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumtum
 - id: tbs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanguat
 - id: tbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tembo (Kitembo)
 - id: tbu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tubar
 - id: tbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobo
 - id: tbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagbanwa
 - id: tbx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kapin
 - id: tby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabaru
 - id: tbz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ditammari
 - id: tca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ticuna
 - id: tcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanacross
 - id: tcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Datooga
 - id: tcd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tafi
 - id: tce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Tutchone
 - id: tcf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malinaltepec Me'phaa
 - id: tcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tamagario
 - id: tch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turks And Caicos Creole English
 - id: tci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "W\xE1ra"
 - id: tck
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tchitchege
 - id: tcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Taman (Myanmar)
 - id: tcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanahmerah
 - id: tcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tichurong
 - id: tco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taungyo
 - id: tcp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawr Chin
 - id: tcq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaiy
 - id: tcs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Torres Strait Creole
 - id: tct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: T'en
 - id: tcu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeastern Tarahumara
 - id: tcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tecpatl\xE1n Totonac"
 - id: tcx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toda
 - id: tcy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tulu
 - id: tcz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thado Chin
 - id: tda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagdal
 - id: tdb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Panchpargania
 - id: tdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ember\xE1-Tad\xF3"
 - id: tdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tai N\xFCa"
 - id: tde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiranige Diga Dogon
 - id: tdf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talieng
 - id: tdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Tamang
 - id: tdh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thulung
 - id: tdi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tomadino
 - id: tdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tajio
 - id: tdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tambas
 - id: tdl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sur
 - id: tdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taruma
 - id: tdn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tondano
 - id: tdo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teme
 - id: tdq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tita
 - id: tdr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Todrah
 - id: tds
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doutai
 - id: tdt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tetun Dili
 - id: tdv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toro
 - id: tdx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tandroy-Mahafaly Malagasy
 - id: tdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tadyawan
 - id: tea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temiar
 - id: teb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tetete
 - id: tec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Terik
 - id: ted
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tepo Krumen
 - id: tee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huehuetla Tepehua
 - id: tef
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teressa
 - id: teg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Tege
 - id: teh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tehuelche
 - id: tei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Torricelli
 - id: tek
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ibali Teke
 - id: tel
+  props:
+    alpha_2: te
   tags:
   - individual
   - living
   title:
     en: Telugu
 - id: tem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Timne
 - id: ten
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tama (Colombia)
 - id: teo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teso
 - id: tep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tepecano
 - id: teq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temein
 - id: ter
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tereno
 - id: tes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tengger
 - id: tet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tetum
 - id: teu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soo
 - id: tev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teor
 - id: tew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tewa (USA)
 - id: tex
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tennet
 - id: tey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tulishi
 - id: tfi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tofin Gbe
 - id: tfn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanaina
 - id: tfo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tefaro
 - id: tfr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teribe
 - id: tft
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ternate
 - id: tga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sagalla
 - id: tgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobilung
 - id: tgc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tigak
 - id: tgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ciwogai
 - id: tge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Gorkha Tamang
 - id: tgf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chalikha
 - id: tgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobagonian Creole English
 - id: tgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lawunuia
 - id: tgj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagin
 - id: tgk
+  props:
+    alpha_2: tg
   tags:
   - individual
   - living
   title:
     en: Tajik
 - id: tgl
+  props:
+    alpha_2: tl
   tags:
   - individual
   - living
   title:
     en: Tagalog
 - id: tgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tandaganon
 - id: tgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sudest
 - id: tgp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangoa
 - id: tgq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tring
 - id: tgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tareng
 - id: tgs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nume
 - id: tgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Tagbanwa
 - id: tgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanggu
 - id: tgv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tingui-Boto
 - id: tgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagwana Senoufo
 - id: tgx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tagish
 - id: tgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Togoyo
 - id: tgz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tagalaka
 - id: tha
+  props:
+    alpha_2: th
   tags:
   - individual
   - living
   title:
     en: Thai
 - id: thd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thayore
 - id: the
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chitwania Tharu
 - id: thf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thangmi
 - id: thh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tarahumara
 - id: thi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Long
 - id: thk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tharaka
 - id: thl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dangaura Tharu
 - id: thm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aheu
 - id: thn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thachanadan
 - id: thp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thompson
 - id: thq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kochila Tharu
 - id: thr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rana Tharu
 - id: ths
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thakali
 - id: tht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tahltan
 - id: thu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thuri
 - id: thv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tahaggart Tamahaq
 - id: thw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thudam
 - id: thy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tha
 - id: thz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tayart Tamajeq
 - id: tia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tidikelt Tamazight
 - id: tic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tira
 - id: tif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tifal
 - id: tig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tigre
 - id: tih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Timugon Murut
 - id: tii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiene
 - id: tij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tilung
 - id: tik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tikar
 - id: til
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tillamook
 - id: tim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Timbe
 - id: tin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tindi
 - id: tio
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teop
 - id: tip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trimuris
 - id: tiq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ti\xE9fo"
 - id: tir
+  props:
+    alpha_2: ti
   tags:
   - individual
   - living
   title:
     en: Tigrinya
 - id: tis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Masadiit Itneg
 - id: tit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tinigua
 - id: tiu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adasen
 - id: tiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiv
 - id: tiw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiwi
 - id: tix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Tiwa
 - id: tiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tiruray
 - id: tiz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Hongjin
 - id: tja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tajuasohn
 - id: tjg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunjung
 - id: tji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tujia
 - id: tjl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Laing
 - id: tjm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Timucua
 - id: tjn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tonjon
 - id: tjo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temacine Tamazight
 - id: tjs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Tujia
 - id: tju
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tjurruru
 - id: tjw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Djabwurrung
 - id: tka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Truk\xE1"
 - id: tkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buksa
 - id: tkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tukudede
 - id: tke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Takwane
 - id: tkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tukumanf\xE9d"
 - id: tkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tesaka Malagasy
 - id: tkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tokelau
 - id: tkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Takelma
 - id: tkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toku-No-Shima
 - id: tkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tikopia
 - id: tkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tee
 - id: tkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsakhur
 - id: tks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Takestani
 - id: tkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kathoriya Tharu
 - id: tku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Necaxa Totonac
 - id: tkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mur Pano
 - id: tkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teanu
 - id: tkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangko
 - id: tkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Takua
 - id: tla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Tepehuan
 - id: tlb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobelo
 - id: tlc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yecuatla Totonac
 - id: tld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talaud
 - id: tlf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Telefol
 - id: tlg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tofanma
 - id: tlh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Klingon
 - id: tli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlingit
 - id: tlj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talinga-Bwisi
 - id: tlk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taloki
 - id: tll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tetela
 - id: tlm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tolomako
 - id: tln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talondo'
 - id: tlo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talodi
 - id: tlp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Filomena Mata-Coahuitl\xE1n Totonac"
 - id: tlq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Loi
 - id: tlr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talise
 - id: tls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tambotalo
 - id: tlt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sou Nama
 - id: tlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tulehu
 - id: tlv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taliabu
 - id: tlx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khehek
 - id: tly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talysh
 - id: tma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tama (Chad)
 - id: tmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katbol
 - id: tmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumak
 - id: tmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Haruai
 - id: tme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Trememb\xE9"
 - id: tmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toba-Maskoy
 - id: tmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Ternate\xF1o"
 - id: tmh
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Tamashek
 - id: tmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tutuba
 - id: tmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samarokena
 - id: tmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northwestern Tamang
 - id: tml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tamnim Citak
 - id: tmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Thanh
 - id: tmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taman (Indonesia)
 - id: tmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temoq
 - id: tmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumleo
 - id: tmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Jewish Babylonian Aramaic (ca. 200-1200 CE)
 - id: tms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tima
 - id: tmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tasmate
 - id: tmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iau
 - id: tmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tembo (Motembo)
 - id: tmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Temuan
 - id: tmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tami
 - id: tmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tamanaku
 - id: tna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tacana
 - id: tnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Tunebo
 - id: tnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tanimuca-Retuar\xE3"
 - id: tnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angosturas Tunebo
 - id: tne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tinoc Kallahan
 - id: tng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobanga
 - id: tnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maiani
 - id: tni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tandia
 - id: tnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwamera
 - id: tnl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lenakel
 - id: tnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabla
 - id: tnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Tanna
 - id: tno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toromono
 - id: tnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Whitesands
 - id: tnq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Taino
 - id: tnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "M\xE9nik"
 - id: tns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tenis
 - id: tnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tontemboan
 - id: tnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tay Khang
 - id: tnv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tangchangya
 - id: tnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tonsawang
 - id: tnx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanema
 - id: tny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tongwe
 - id: tnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ten'edn
 - id: tob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toba
 - id: toc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coyutla Totonac
 - id: tod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toma
 - id: tof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gizrra
 - id: tog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tonga (Nyasa)
 - id: toh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gitonga
 - id: toi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tonga (Zambia)
 - id: toj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tojolabal
 - id: tol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tolowa
 - id: tom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tombulu
 - id: ton
+  props:
+    alpha_2: to
   tags:
   - individual
   - living
   title:
     en: Tonga (Tonga Islands)
 - id: too
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xicotepec De Ju\xE1rez Totonac"
 - id: top
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Papantla Totonac
 - id: toq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toposa
 - id: tor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Togbo-Vara Banda
 - id: tos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Highland Totonac
 - id: tou
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tho
 - id: tov
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Taromi
 - id: tow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jemez
 - id: tox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobian
 - id: toy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Topoiyo
 - id: toz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: To
 - id: tpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taupota
 - id: tpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Azoy\xFA Me'phaa"
 - id: tpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tippera
 - id: tpf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tarpia
 - id: tpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kula
 - id: tpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tok Pisin
 - id: tpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tapiet\xE9"
 - id: tpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tupinikin
 - id: tpl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlacoapa Me'phaa
 - id: tpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tampulma
 - id: tpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tupinamb\xE1"
 - id: tpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Pao
 - id: tpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pisaflores Tepehua
 - id: tpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tukpa
 - id: tpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tupar\xED"
 - id: tpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlachichilco Tepehua
 - id: tpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tampuan
 - id: tpv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanapag
 - id: tpw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tup\xED"
 - id: tpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Acatepec Me'phaa
 - id: tpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trumai
 - id: tpz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tinputz
 - id: tqb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Temb\xE9"
 - id: tql
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lehali
 - id: tqm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turumsa
 - id: tqn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tenino
 - id: tqo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toaripi
 - id: tqp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tomoip
 - id: tqq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunni
 - id: tqr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Torona
 - id: tqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Totonac
 - id: tqu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Touo
 - id: tqw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tonkawa
 - id: tra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tirahi
 - id: trb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Terebu
 - id: trc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Copala Triqui
 - id: trd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turi
 - id: tre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Tarangan
 - id: trf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trinidadian Creole English
 - id: trg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Lish\xE1n Did\xE1n"
 - id: trh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turaka
 - id: tri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tri\xF3"
 - id: trj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toram
 - id: trl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Traveller Scottish
 - id: trm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tregami
 - id: trn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Trinitario
 - id: tro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tarao Naga
 - id: trp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kok Borok
 - id: trq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Mart\xEDn Itunyoso Triqui"
 - id: trr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taushiro
 - id: trs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chicahuaxtla Triqui
 - id: trt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunggare
 - id: tru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turoyo
 - id: trv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taroko
 - id: trw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Torwali
 - id: trx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tringgus-Sembaan Bidayuh
 - id: try
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Turung
 - id: trz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tor\xE1"
 - id: tsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsaangi
 - id: tsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsamai
 - id: tsc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tswa
 - id: tsd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsakonian
 - id: tse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunisian Sign Language
 - id: tsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tausug
 - id: tsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsuvan
 - id: tsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsimshian
 - id: tsj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tshangla
 - id: tsk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tseku
 - id: tsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ts'\xFCn-Lao"
 - id: tsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turkish Sign Language
 - id: tsn
+  props:
+    alpha_2: tn
   tags:
   - individual
   - living
   title:
     en: Tswana
 - id: tso
+  props:
+    alpha_2: ts
   tags:
   - individual
   - living
   title:
     en: Tsonga
 - id: tsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Toussian
 - id: tsq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thai Sign Language
 - id: tsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Akei
 - id: tss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taiwan Sign Language
 - id: tst
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tondi Songway Kiini
 - id: tsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsou
 - id: tsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsogo
 - id: tsw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsishingini
 - id: tsx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mubami
 - id: tsy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tebul Sign Language
 - id: tsz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Purepecha
 - id: tta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tutelo
 - id: ttb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gaa
 - id: ttc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tektiteko
 - id: ttd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tauade
 - id: tte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bwanabwana
 - id: ttf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuotomb
 - id: ttg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tutong
 - id: tth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Upper Ta'oih
 - id: tti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tobati
 - id: ttj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tooro
 - id: ttk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Totoro
 - id: ttl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Totela
 - id: ttm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tutchone
 - id: ttn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Towei
 - id: tto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lower Ta'oih
 - id: ttp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tombelala
 - id: ttq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawallammat Tamajaq
 - id: ttr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tera
 - id: tts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northeastern Thai
 - id: ttt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muslim Tat
 - id: ttu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Torau
 - id: ttv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Titan
 - id: ttw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Long Wat
 - id: tty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sikaritai
 - id: ttz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsum
 - id: tua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wiarumus
 - id: tub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "T\xFCbatulabal"
 - id: tuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mutu
 - id: tud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tux\xE1"
 - id: tue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuyuca
 - id: tuf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Tunebo
 - id: tug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunia
 - id: tuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taulil
 - id: tui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tupuri
 - id: tuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tugutil
 - id: tuk
+  props:
+    alpha_2: tk
   tags:
   - individual
   - living
   title:
     en: Turkmen
 - id: tul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tula
 - id: tum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tumbuka
 - id: tun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tunica
 - id: tuo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tucano
 - id: tuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tedaga
 - id: tur
+  props:
+    alpha_2: tr
   tags:
   - individual
   - living
   title:
     en: Turkish
 - id: tus
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuscarora
 - id: tuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tututni
 - id: tuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turkana
 - id: tux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Tuxin\xE1wa"
 - id: tuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tugen
 - id: tuz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Turka
 - id: tva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vaghua
 - id: tvd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsuvadi
 - id: tve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Te'un
 - id: tvk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeast Ambrym
 - id: tvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuvalu
 - id: tvm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tela-Masbuar
 - id: tvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tavoyan
 - id: tvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tidore
 - id: tvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Taveta
 - id: tvt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tutsa Naga
 - id: tvu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tunen
 - id: tvw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sedoa
 - id: tvy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Timor Pidgin
 - id: twa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Twana
 - id: twb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Tawbuid
 - id: twc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Teshenawa
 - id: twd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Twents
 - id: twe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tewa (Indonesia)
 - id: twf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tiwa
 - id: twg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tereweng
 - id: twh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tai D\xF3n"
 - id: twi
+  props:
+    alpha_2: tw
   tags:
   - individual
   - living
   title:
     en: Twi
 - id: twl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawara
 - id: twm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawang Monpa
 - id: twn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Twendi
 - id: two
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tswapong
 - id: twp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ere
 - id: twq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tasawaq
 - id: twr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Tarahumara
 - id: twt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Turiw\xE1ra"
 - id: twu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Termanu
 - id: tww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuwari
 - id: twx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tewe
 - id: twy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tawoyan
 - id: txa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tombonuo
 - id: txb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Tokharian B
 - id: txc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tsetsaut
 - id: txe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Totoli
 - id: txg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Tangut
 - id: txh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Thracian
 - id: txi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ikpeng
 - id: txj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tarjumo
 - id: txm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tomini
 - id: txn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Tarangan
 - id: txo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Toto
 - id: txq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tii
 - id: txr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Tartessian
 - id: txs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tonsea
 - id: txt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Citak
 - id: txu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Kayap\xF3"
 - id: txx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tatana
 - id: txy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanosy Malagasy
 - id: tya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tauya
 - id: tye
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kyanga
 - id: tyh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: O'du
 - id: tyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Tsaayi
 - id: tyj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Do
 - id: tyl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thu Lao
 - id: tyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kombai
 - id: typ
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Thaypan
 - id: tyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tai Daeng
 - id: tys
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "T\xE0y Sa Pa"
 - id: tyt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "T\xE0y Tac"
 - id: tyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kua
 - id: tyv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tuvinian
 - id: tyx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Teke-Tyee
 - id: tyz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "T\xE0y"
 - id: tza
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanzanian Sign Language
 - id: tzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tzeltal
 - id: tzj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tz'utujil
 - id: tzl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Talossan
 - id: tzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Atlas Tamazight
 - id: tzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tugun
 - id: tzo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tzotzil
 - id: tzx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabriak
 - id: uam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Uamu\xE9"
 - id: uan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuan
 - id: uar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tairuma
 - id: uba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ubang
 - id: ubi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ubi
 - id: ubl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Buhi'non Bikol
 - id: ubr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ubir
 - id: ubu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umbu-Ungu
 - id: uby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ubykh
 - id: uda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uda
 - id: ude
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Udihe
 - id: udg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muduga
 - id: udi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Udi
 - id: udj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ujir
 - id: udl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wuzlam
 - id: udm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Udmurt
 - id: udu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uduk
 - id: ues
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kioko
 - id: ufi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ufim
 - id: uga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Ugaritic
 - id: ugb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuku-Ugbanh
 - id: uge
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ughele
 - id: ugn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ugandan Sign Language
 - id: ugo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ugong
 - id: ugy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uruguayan Sign Language
 - id: uha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uhami
 - id: uhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Damal
 - id: uig
+  props:
+    alpha_2: ug
   tags:
   - individual
   - living
   title:
     en: Uighur
 - id: uis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uisai
 - id: uiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iyive
 - id: uji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanjijili
 - id: uka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaburi
 - id: ukg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukuriguma
 - id: ukh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukhwejo
 - id: ukl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukrainian Sign Language
 - id: ukp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukpe-Bayobiri
 - id: ukq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukwa
 - id: ukr
+  props:
+    alpha_2: uk
   tags:
   - individual
   - living
   title:
     en: Ukrainian
 - id: uks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Urub\xFA-Kaapor Sign Language"
 - id: uku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukue
 - id: ukw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukwuani-Aboh-Ndoni
 - id: uky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuuk-Yak
 - id: ula
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Fungwa
 - id: ulb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulukwumi
 - id: ulc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulch
 - id: ule
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lule
 - id: ulf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usku
 - id: uli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulithian
 - id: ulk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Meriam
 - id: ull
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ullatan
 - id: ulm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulumanda'
 - id: uln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Unserdeutsch
 - id: ulu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uma' Lung
 - id: ulw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ulwa
 - id: uma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umatilla
 - id: umb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umbundu
 - id: umc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Marrucinian
 - id: umd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Umbindhamu
 - id: umg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Umbuygamu
 - id: umi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ukit
 - id: umm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umon
 - id: umn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makyan Naga
 - id: umo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Umot\xEDna"
 - id: ump
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umpila
 - id: umr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Umbugarla
 - id: ums
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pendau
 - id: umu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Munsee
 - id: una
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Watut
 - id: und
+  props:
+    alpha_2: ''
   tags:
   - special-scope
   - special-type
   title:
     en: Undetermined
 - id: une
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uneme
 - id: ung
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngarinyin
 - id: unk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Enawen\xE9-Naw\xE9"
 - id: unm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Unami
 - id: unn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurnai
 - id: unr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mundari
 - id: unu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Unubahe
 - id: unx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Munda
 - id: unz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Unde Kaili
 - id: upi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Umeda
 - id: upv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uripiv-Wala-Rano-Atchin
 - id: ura
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urarina
 - id: urb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Urub\xFA-Kaapor"
 - id: urc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Urningangg
 - id: urd
+  props:
+    alpha_2: ur
   tags:
   - individual
   - living
   title:
     en: Urdu
 - id: ure
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uru
 - id: urf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Uradhi
 - id: urg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urigina
 - id: urh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urhobo
 - id: uri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urim
 - id: urk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urak Lawoi'
 - id: url
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urali
 - id: urm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urapmin
 - id: urn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uruangnirin
 - id: uro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ura (Papua New Guinea)
 - id: urp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uru-Pa-In
 - id: urr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lehalurup
 - id: urt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urat
 - id: uru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Urumi
 - id: urv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Uruava
 - id: urw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sop
 - id: urx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urimo
 - id: ury
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Orya
 - id: urz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uru-Eu-Wau-Wau
 - id: usa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usarufa
 - id: ush
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ushojo
 - id: usi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usui
 - id: usk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usaghade
 - id: usp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uspanteco
 - id: usu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uya
 - id: uta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Otank
 - id: ute
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ute-Southern Paiute
 - id: utp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Amba (Solomon Islands)
 - id: utr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Etulo
 - id: utu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Utu
 - id: uum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Urum
 - id: uun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulon-Pazeh
 - id: uur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ura (Vanuatu)
 - id: uuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: U
 - id: uve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Uvean
 - id: uvh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uri
 - id: uvl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lote
 - id: uwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuku-Uwanh
 - id: uya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Doko-Uyanga
 - id: uzb
+  props:
+    alpha_2: uz
   tags:
   - macrolanguage
   - living
   title:
     en: Uzbek
 - id: uzn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Uzbek
 - id: uzs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Uzbek
 - id: vaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vaagri Booli
 - id: vae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vale
 - id: vaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vafsi
 - id: vag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vagla
 - id: vah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Varhadi-Nagpuri
 - id: vai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vai
 - id: vaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sekele
 - id: val
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vehes
 - id: vam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vanimo
 - id: van
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Valman
 - id: vao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vao
 - id: vap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vaiphei
 - id: var
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Huarijio
 - id: vas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vasavi
 - id: vau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vanuma
 - id: vav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Varli
 - id: vay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wayu
 - id: vbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southeast Babar
 - id: vbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southwestern Bontok
 - id: vec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Venetian
 - id: ved
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Veddah
 - id: vel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Veluws
 - id: vem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vemgo-Mabas
 - id: ven
+  props:
+    alpha_2: ve
   tags:
   - individual
   - living
   title:
     en: Venda
 - id: veo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Venture\xF1o"
 - id: vep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Veps
 - id: ver
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mom Jango
 - id: vgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vaghri
 - id: vgt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vlaamse Gebarentaal
 - id: vic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Virgin Islands Creole English
 - id: vid
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vidunda
 - id: vie
+  props:
+    alpha_2: vi
   tags:
   - individual
   - living
   title:
     en: Vietnamese
 - id: vif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vili
 - id: vig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Viemo
 - id: vil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vilela
 - id: vin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vinza
 - id: vis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vishavan
 - id: vit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Viti
 - id: viv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iduna
 - id: vka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kariyarra
 - id: vki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ija-Zuba
 - id: vkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kujarge
 - id: vkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaur
 - id: vkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulisusu
 - id: vkm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kamakan
 - id: vko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kodeoha
 - id: vkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korlai Creole Portuguese
 - id: vkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tenggarong Kutai Malay
 - id: vku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurrama
 - id: vlp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Valpei
 - id: vls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vlaams
 - id: vma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Martuyhunira
 - id: vmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Barbaram
 - id: vmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Juxtlahuaca Mixtec
 - id: vmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mudu Koraga
 - id: vme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Masela
 - id: vmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mainfr\xE4nkisch"
 - id: vmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lungalunga
 - id: vmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maraghei
 - id: vmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Miwa
 - id: vmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ixtayutla Mixtec
 - id: vmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa-Shirima
 - id: vml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Malgana
 - id: vmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mitlatongo Mixtec
 - id: vmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soyaltepec Mazatec
 - id: vmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soyaltepec Mixtec
 - id: vmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marenje
 - id: vms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Moksela
 - id: vmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Muluridyi
 - id: vmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Valley Maidu
 - id: vmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa
 - id: vmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tamazola Mixtec
 - id: vmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayautla Mazatec
 - id: vmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mazatl\xE1n Mazatec"
 - id: vnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vano
 - id: vnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vinmavis
 - id: vnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vunapu
 - id: vol
+  props:
+    alpha_2: vo
   tags:
   - individual
   - constructed
   title:
     en: "Volap\xFCk"
 - id: vor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Voro
 - id: vot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Votic
 - id: vra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vera'a
 - id: vro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "V\xF5ro"
 - id: vrs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Varisi
 - id: vrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Burmbar
 - id: vsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moldova Sign Language
 - id: vsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Venezuelan Sign Language
 - id: vsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Valencian Sign Language
 - id: vto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vitou
 - id: vum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vumbu
 - id: vun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vunjo
 - id: vut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vute
 - id: vwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awa (China)
 - id: waa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walla Walla
 - id: wab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wab
 - id: wac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wasco-Wishram
 - id: wad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wandamen
 - id: wae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walser
 - id: waf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Wakon\xE1"
 - id: wag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wa'ema
 - id: wah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Watubela
 - id: wai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wares
 - id: waj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waffa
 - id: wal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wolaytta
 - id: wam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wampanoag
 - id: wan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wan
 - id: wao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wappo
 - id: wap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wapishana
 - id: waq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wageman
 - id: war
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waray (Philippines)
 - id: was
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Washo
 - id: wat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaninuwa
 - id: wau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Waur\xE1"
 - id: wav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waka
 - id: waw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waiwai
 - id: wax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Watam
 - id: way
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wayana
 - id: waz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wampur
 - id: wba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warao
 - id: wbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wabo
 - id: wbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waritai
 - id: wbf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wara
 - id: wbh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanda
 - id: wbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vwanji
 - id: wbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alagwa
 - id: wbk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waigali
 - id: wbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wakhi
 - id: wbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wa
 - id: wbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warlpiri
 - id: wbq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waddar
 - id: wbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wagdi
 - id: wbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanman
 - id: wbv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wajarri
 - id: wbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Woi
 - id: wca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yanom\xE1mi"
 - id: wci
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waci Gbe
 - id: wdd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wandji
 - id: wdg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wadaginam
 - id: wdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wadjiginy
 - id: wdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wadikali
 - id: wdu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wadjigu
 - id: wdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wadjabangayi
 - id: wea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wewaw
 - id: wec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "W\xE8 Western"
 - id: wed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wedau
 - id: weg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wergaia
 - id: weh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Weh
 - id: wei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiunum
 - id: wem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Weme Gbe
 - id: weo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wemale
 - id: wep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Westphalien
 - id: wer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Weri
 - id: wes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cameroon Pidgin
 - id: wet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Perai
 - id: weu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Rawngtu Chin
 - id: wew
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wejewa
 - id: wfg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yafi
 - id: wga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wagaya
 - id: wgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wagawaga
 - id: wgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wangganguru
 - id: wgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wahgi
 - id: wgo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waigeo
 - id: wgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wirangu
 - id: wgy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warrgamay
 - id: wha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sou Upaa
 - id: whg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Wahgi
 - id: whk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wahau Kenyah
 - id: whu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wahau Kayan
 - id: wib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Toussian
 - id: wic
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wichita
 - id: wie
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wik-Epa
 - id: wif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wik-Keyangan
 - id: wig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wik-Ngathana
 - id: wih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wik-Me'anha
 - id: wii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minidien
 - id: wij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wik-Iiyanh
 - id: wik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wikalkan
 - id: wil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wilawila
 - id: wim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wik-Mungkan
 - id: win
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ho-Chunk
 - id: wir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Wiraf\xE9d"
 - id: wiu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wiru
 - id: wiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Vitu
 - id: wiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wiyot
 - id: wja
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waja
 - id: wji
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warji
 - id: wka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kw'adza
 - id: wkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumbaran
 - id: wkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wakde
 - id: wkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalanadi
 - id: wku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunduvadi
 - id: wkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wakawaka
 - id: wky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wangkayutyuru
 - id: wla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walio
 - id: wlc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwali Comorian
 - id: wle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wolane
 - id: wlg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunbarlang
 - id: wli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waioli
 - id: wlk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wailaki
 - id: wll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wali (Sudan)
 - id: wlm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Welsh
 - id: wln
+  props:
+    alpha_2: wa
   tags:
   - individual
   - living
   title:
     en: Walloon
 - id: wlo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wolio
 - id: wlr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wailapa
 - id: wls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wallisian
 - id: wlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wuliwuli
 - id: wlv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Wich\xED Lhamt\xE9s Vejoz"
 - id: wlw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walak
 - id: wlx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wali (Ghana)
 - id: wly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Waling
 - id: wma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mawa (Nigeria)
 - id: wmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wambaya
 - id: wmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wamas
 - id: wmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Mamaind\xE9"
 - id: wme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wambule
 - id: wmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waima'a
 - id: wmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wamin
 - id: wmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maiwa (Indonesia)
 - id: wmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Waamwang
 - id: wmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wom (Papua New Guinea)
 - id: wms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wambon
 - id: wmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Walmajarri
 - id: wmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mwani
 - id: wmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Womo
 - id: wnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanambre
 - id: wnc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wantoat
 - id: wnd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wandarang
 - id: wne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waneci
 - id: wng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanggom
 - id: wni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ndzwani Comorian
 - id: wnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanukaka
 - id: wnm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wanggamala
 - id: wnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wunumara
 - id: wno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wano
 - id: wnp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanap
 - id: wnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Usan
 - id: wnw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wintu
 - id: wny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wanyi
 - id: woa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tyaraity
 - id: wob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "W\xE8 Northern"
 - id: woc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wogeo
 - id: wod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wolani
 - id: woe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Woleaian
 - id: wof
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gambian Wolof
 - id: wog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wogamusin
 - id: woi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamang
 - id: wok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Longto
 - id: wol
+  props:
+    alpha_2: wo
   tags:
   - individual
   - living
   title:
     en: Wolof
 - id: wom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wom (Nigeria)
 - id: won
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wongo
 - id: woo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manombai
 - id: wor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Woria
 - id: wos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hanga Hundi
 - id: wow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wawonii
 - id: woy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Weyto
 - id: wpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maco
 - id: wra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warapu
 - id: wrb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Warluwara
 - id: wrd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warduji
 - id: wrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Warungu
 - id: wrh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wiradhuri
 - id: wri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wariyangga
 - id: wrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Garrwa
 - id: wrl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warlmanpa
 - id: wrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warumungu
 - id: wrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warnang
 - id: wro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Worrorra
 - id: wrp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waropen
 - id: wrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wardaman
 - id: wrs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waris
 - id: wru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waru
 - id: wrv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waruna
 - id: wrw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gugu Warra
 - id: wrx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wae Rana
 - id: wry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Merwari
 - id: wrz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Waray (Australia)
 - id: wsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Warembori
 - id: wsg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Adilabad Gondi
 - id: wsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wusi
 - id: wsk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waskia
 - id: wsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Owenia
 - id: wss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wasa
 - id: wsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wasu
 - id: wsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wotapuri-Katarqalai
 - id: wtf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Watiwa
 - id: wth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wathawurrung
 - id: wti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Berta
 - id: wtk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Watakataui
 - id: wtm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mewati
 - id: wtw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wotu
 - id: wua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wikngenchera
 - id: wub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wunambal
 - id: wud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wudu
 - id: wuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wutunhua
 - id: wul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Silimo
 - id: wum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wumbvu
 - id: wun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bungu
 - id: wur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wurrugu
 - id: wut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wutung
 - id: wuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wu Chinese
 - id: wuv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wuvulu-Aua
 - id: wux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wulna
 - id: wuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wauyai
 - id: wwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waama
 - id: wwb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wakabunga
 - id: wwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wetamut
 - id: wwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Warrwa
 - id: www
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wawa
 - id: wxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Waxianghua
 - id: wxw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wardandi
 - id: wya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wyandot
 - id: wyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wangaaybuwan-Ngiyambaa
 - id: wyi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Woiwurrung
 - id: wym
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wymysorys
 - id: wyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Wayor\xF3"
 - id: wyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Fijian
 - id: xaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Andalusian Arabic
 - id: xab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sambe
 - id: xac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kachari
 - id: xad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Adai
 - id: xae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Aequian
 - id: xag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aghwan
 - id: xai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kaimb\xE9"
 - id: xaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Ararandew\xE1ra"
 - id: xak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "M\xE1ku"
 - id: xal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalmyk
 - id: xam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: /Xam
 - id: xan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xamtanga
 - id: xao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khao
 - id: xap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Apalachee
 - id: xaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Aquitanian
 - id: xar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karami
 - id: xas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kamas
 - id: xat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katawixi
 - id: xau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kauwera
 - id: xav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xav\xE1nte"
 - id: xaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kawaiisu
 - id: xay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayan Mahakam
 - id: xbb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Lower Burdekin
 - id: xbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Bactrian
 - id: xbd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bindal
 - id: xbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bigambal
 - id: xbg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bunganditj
 - id: xbi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kombio
 - id: xbj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Birrpayi
 - id: xbm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Breton
 - id: xbn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kenaboi
 - id: xbo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bolgarian
 - id: xbp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Bibbulman
 - id: xbr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kambera
 - id: xbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kambiw\xE1"
 - id: xby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batyala
 - id: xcb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cumbric
 - id: xcc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Camunic
 - id: xce
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Celtiberian
 - id: xcg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Cisalpine Gaulish
 - id: xch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chemakum
 - id: xcl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Armenian
 - id: xcm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Comecrudo
 - id: xcn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cotoname
 - id: xco
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Chorasmian
 - id: xcr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Carian
 - id: xct
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Classical Tibetan
 - id: xcu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Curonian
 - id: xcv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Chuvantsy
 - id: xcw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Coahuilteco
 - id: xcy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Cayuse
 - id: xda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Darkinyung
 - id: xdc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Dacian
 - id: xdk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dharuk
 - id: xdm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Edomite
 - id: xdy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malayic Dayak
 - id: xeb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Eblan
 - id: xed
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hdi
 - id: xeg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: //Xegwi
 - id: xel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kelo
 - id: xem
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kembayan
 - id: xep
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Epi-Olmec
 - id: xer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xer\xE9nte"
 - id: xes
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kesawai
 - id: xet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xet\xE1"
 - id: xeu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Keoru-Ahia
 - id: xfa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Faliscan
 - id: xga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Galatian
 - id: xgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gbin
 - id: xgd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gudang
 - id: xgf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Gabrielino-Fernande\xF1o"
 - id: xgg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Goreng
 - id: xgi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Garingbal
 - id: xgl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Galindan
 - id: xgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Dharumbal
 - id: xgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Garza
 - id: xgu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Unggumi
 - id: xgw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Guwa
 - id: xha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Harami
 - id: xhc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Hunnic
 - id: xhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hadrami
 - id: xhe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khetrani
 - id: xho
+  props:
+    alpha_2: xh
   tags:
   - individual
   - living
   title:
     en: Xhosa
 - id: xhr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hernican
 - id: xht
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hattic
 - id: xhu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Hurrian
 - id: xhv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khua
 - id: xib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Iberian
 - id: xii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xiri
 - id: xil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Illyrian
 - id: xin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Xinca
 - id: xir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Xiri\xE2na"
 - id: xis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kisan
 - id: xiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Indus Valley Language
 - id: xiy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xipaya
 - id: xjb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Minjungbal
 - id: xjt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Jaitmatang
 - id: xka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalkoti
 - id: xkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Nago
 - id: xkc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kho'ini
 - id: xkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mendalam Kayan
 - id: xke
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kereho
 - id: xkf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khengkha
 - id: xkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kagoro
 - id: xki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenyan Sign Language
 - id: xkj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kajali
 - id: xkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaco'
 - id: xkl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mainstream Kenyah
 - id: xkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kayan River Kayan
 - id: xko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kiorr
 - id: xkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kabatei
 - id: xkq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Koroni
 - id: xkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Xakriab\xE1"
 - id: xks
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumbewaha
 - id: xkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kantosi
 - id: xku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaamba
 - id: xkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kgalagadi
 - id: xkw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kembra
 - id: xkx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karore
 - id: xky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Uma' Lasan
 - id: xkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kurtokha
 - id: xla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamula
 - id: xlb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Loup B
 - id: xlc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Lycian
 - id: xld
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Lydian
 - id: xle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Lemnian
 - id: xlg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Ligurian (Ancient)
 - id: xli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Liburnian
 - id: xln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Alanic
 - id: xlo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Loup A
 - id: xlp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Lepontic
 - id: xls
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Lusitanian
 - id: xlu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Cuneiform Luwian
 - id: xly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Elymian
 - id: xma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mushungulu
 - id: xmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbonga
 - id: xmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa-Marrevone
 - id: xmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbudum
 - id: xme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Median
 - id: xmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mingrelian
 - id: xmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mengaka
 - id: xmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuku-Muminh
 - id: xmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Majera
 - id: xmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Ancient Macedonian
 - id: xml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malaysian Sign Language
 - id: xmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manado Malay
 - id: xmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Manichaean Middle Persian
 - id: xmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Morerebi
 - id: xmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuku-Mu'inh
 - id: xmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuku-Mangk
 - id: xmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Meroitic
 - id: xms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moroccan Sign Language
 - id: xmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Matbat
 - id: xmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kamu
 - id: xmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Antankarana Malagasy
 - id: xmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tsimihety Malagasy
 - id: xmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maden
 - id: xmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayaguduna
 - id: xmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mori Bawah
 - id: xna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Ancient North Arabian
 - id: xnb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanakanabu
 - id: xng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Middle Mongolian
 - id: xnh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuanhua
 - id: xni
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngarigu
 - id: xnk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nganakarti
 - id: xnn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Kankanay
 - id: xno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Anglo-Norman
 - id: xnr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kangri
 - id: xns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanashi
 - id: xnt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Narragansett
 - id: xnu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Nukunul
 - id: xny
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyiyaparli
 - id: xnz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kenzi
 - id: xoc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: O'chi'chi'
 - id: xod
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kokoda
 - id: xog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Soga
 - id: xoi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kominimung
 - id: xok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xokleng
 - id: xom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Komo (Sudan)
 - id: xon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Konkomba
 - id: xoo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Xukur\xFA"
 - id: xop
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kopar
 - id: xor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Korubo
 - id: xow
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kowaki
 - id: xpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pirriya
 - id: xpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pecheneg
 - id: xpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liberia Kpelle
 - id: xpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Phrygian
 - id: xpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pictish
 - id: xpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mpalitjanh
 - id: xpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kulina Pano
 - id: xpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pumpokol
 - id: xpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Kapinaw\xE1"
 - id: xpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pochutec
 - id: xpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Puyo-Paekche
 - id: xpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mohegan-Pequot
 - id: xpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Parthian
 - id: xps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Pisidian
 - id: xpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Punthamara
 - id: xpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Punic
 - id: xpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Puyo
 - id: xqa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Karakhanid
 - id: xqt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Qatabanian
 - id: xra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Krah\xF4"
 - id: xrb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Karaboro
 - id: xrd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Gundungurra
 - id: xre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kreye
 - id: xrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Minang
 - id: xri
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Krikati-Timbira
 - id: xrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Armazic
 - id: xrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Arin
 - id: xrq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karranga
 - id: xrr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Raetic
 - id: xrt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Aranama-Tamique
 - id: xru
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marriammu
 - id: xrw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karawa
 - id: xsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sabaean
 - id: xsb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sambal
 - id: xsc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Scythian
 - id: xsd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Sidetic
 - id: xse
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sempan
 - id: xsh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Shamang
 - id: xsi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sio
 - id: xsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: South Slavey
 - id: xsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kasem
 - id: xsn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanga (Nigeria)
 - id: xso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Solano
 - id: xsp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Silopi
 - id: xsq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makhuwa-Saka
 - id: xsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sherpa
 - id: xss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Assan
 - id: xsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sanum\xE1"
 - id: xsv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Sudovian
 - id: xsy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Saisiyat
 - id: xta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alcozauca Mixtec
 - id: xtb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chazumba Mixtec
 - id: xtc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Katcha-Kadugli-Miri
 - id: xtd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Diuxi-Tilantongo Mixtec
 - id: xte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ketengban
 - id: xtg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Transalpine Gaulish
 - id: xth
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yitha Yitha
 - id: xti
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sinicahua Mixtec
 - id: xtj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Juan Teita Mixtec
 - id: xtl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tijaltepec Mixtec
 - id: xtm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Magdalena Pe\xF1asco Mixtec"
 - id: xtn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Tlaxiaco Mixtec
 - id: xto
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Tokharian A
 - id: xtp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Miguel Piedras Mixtec
 - id: xtq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Tumshuqese
 - id: xtr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Early Tripuri
 - id: xts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sindihui Mixtec
 - id: xtt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tacahua Mixtec
 - id: xtu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cuyamecalco Mixtec
 - id: xtv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Thawa
 - id: xtw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Tawand\xEA"
 - id: xty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yoloxochitl Mixtec
 - id: xtz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tasmanian
 - id: xua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alu Kurumba
 - id: xub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Betta Kurumba
 - id: xud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Umiida
 - id: xug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kunigami
 - id: xuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Jennu Kurumba
 - id: xul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ngunawal
 - id: xum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Umbrian
 - id: xun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Unggaranggu
 - id: xuo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuo
 - id: xup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Upper Umpqua
 - id: xur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Urartian
 - id: xut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kuthant
 - id: xuu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kxoe
 - id: xve
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Venetic
 - id: xvi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kamviri
 - id: xvn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Vandalic
 - id: xvo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Volscian
 - id: xvs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Vestinian
 - id: xwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwaza
 - id: xwc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Woccon
 - id: xwd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wadi Wadi
 - id: xwe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xwela Gbe
 - id: xwg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwegu
 - id: xwj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wajuk
 - id: xwk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wangkumara
 - id: xwl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Xwla Gbe
 - id: xwo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Written Oirat
 - id: xwr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kwerba Mamberamo
 - id: xwt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wotjobaluk
 - id: xww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Wemba Wemba
 - id: xxb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Boro (Ghana)
 - id: xxk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ke'o
 - id: xxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Minkin
 - id: xxr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Korop\xF3"
 - id: xxt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Tambora
 - id: xya
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yaygir
 - id: xyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yandjibara
 - id: xyj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mayi-Yapi
 - id: xyk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mayi-Kulan
 - id: xyl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yalakalore
 - id: xyt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mayi-Thakurti
 - id: xyy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yorta Yorta
 - id: xzh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Zhang-Zhung
 - id: xzm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Zemgalian
 - id: xzp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - historical
   title:
     en: Ancient Zapotec
 - id: yaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaminahua
 - id: yab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuhup
 - id: yac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pass Valley Yali
 - id: yad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yagua
 - id: yae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Pum\xE9"
 - id: yaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaka (Democratic Republic of Congo)
 - id: yag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Y\xE1mana"
 - id: yah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yazgulyam
 - id: yai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yagnobi
 - id: yaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Banda-Yangere
 - id: yak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakama
 - id: yal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yalunka
 - id: yam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamba
 - id: yan
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mayangna
 - id: yao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yao
 - id: yap
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yapese
 - id: yaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaqui
 - id: yar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yabarana
 - id: yas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nugunu (Cameroon)
 - id: yat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yambeta
 - id: yau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuwana
 - id: yav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangben
 - id: yaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yawalapit\xED"
 - id: yax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yauma
 - id: yay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Agwagwune
 - id: yaz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lokaa
 - id: yba
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yala
 - id: ybb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yemba
 - id: ybe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Yugur
 - id: ybh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakha
 - id: ybi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamphu
 - id: ybj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hasha
 - id: ybk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bokha
 - id: ybl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yukuben
 - id: ybm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaben
 - id: ybn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "Yaba\xE2na"
 - id: ybo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yabong
 - id: ybx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yawiyo
 - id: yby
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaweyuha
 - id: ych
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chesu
 - id: ycl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lolopo
 - id: ycn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yucuna
 - id: ycp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chepya
 - id: yda
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yanda
 - id: ydd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Yiddish
 - id: yde
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangum Dey
 - id: ydg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yidgha
 - id: ydk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yoidik
 - id: yea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ravula
 - id: yec
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yeniche
 - id: yee
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yimas
 - id: yei
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yeni
 - id: yej
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yevanic
 - id: yel
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yela
 - id: yer
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tarok
 - id: 'yes'
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nyankpa
 - id: yet
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yetfa
 - id: yeu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yerukula
 - id: yev
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yapunda
 - id: yey
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yeyi
 - id: yga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Malyangapa
 - id: ygi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yiningayi
 - id: ygl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangum Gel
 - id: ygm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yagomi
 - id: ygp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Gepo
 - id: ygr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yagaria
 - id: ygs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yol\u014Bu Sign Language"
 - id: ygu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yugul
 - id: ygw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yagwoia
 - id: yha
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Baha Buyang
 - id: yhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Iraqi Arabic
 - id: yhl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Hlepho Phowa
 - id: yhs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yan-nha\u014Bu Sign Language"
 - id: yia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yinggarda
 - id: yid
+  props:
+    alpha_2: yi
   tags:
   - macrolanguage
   - living
   title:
     en: Yiddish
 - id: yif
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ache
 - id: yig
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wusa Nasu
 - id: yih
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Yiddish
 - id: yii
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yidiny
 - id: yij
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yindjibarndi
 - id: yik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dongshanba Lalo
 - id: yil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yindjilandji
 - id: yim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yimchungru Naga
 - id: yin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yinchia
 - id: yip
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Pholo
 - id: yiq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Miqie
 - id: yir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: North Awyu
 - id: yis
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yis
 - id: yit
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Lalu
 - id: yiu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Awu
 - id: yiv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Nisu
 - id: yix
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Axi Yi
 - id: yiz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Azhe
 - id: yka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakan
 - id: ykg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Yukaghir
 - id: yki
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yoke
 - id: ykk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakaikeke
 - id: ykl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Khlula
 - id: ykm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kap
 - id: ykn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kua-nsi
 - id: yko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yasa
 - id: ykr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yekora
 - id: ykt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kathu
 - id: yku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kuamasi
 - id: yky
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yakoma
 - id: yla
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaul
 - id: ylb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yaleba
 - id: yle
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yele
 - id: ylg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yelogu
 - id: yli
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Angguruk Yali
 - id: yll
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yil
 - id: ylm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Limi
 - id: yln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Langnian Buyang
 - id: ylo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naluo Yi
 - id: ylr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yalarnnga
 - id: ylu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aribwaung
 - id: yly
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ny\xE2layu"
 - id: ymb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yambes
 - id: ymc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Muji
 - id: ymd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muda
 - id: yme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yameo
 - id: ymg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamongeri
 - id: ymh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mili
 - id: ymi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Moji
 - id: ymk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Makwe
 - id: yml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Iamalele
 - id: ymm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maay
 - id: ymn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamna
 - id: ymo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangum Mon
 - id: ymp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yamap
 - id: ymq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qila Muji
 - id: ymr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malasar
 - id: yms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Mysian
 - id: ymx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Northern Muji
 - id: ymz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Muzi
 - id: yna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Aluo
 - id: ynd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yandruwandha
 - id: yne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lang'e
 - id: yng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yango
 - id: ynk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Naukan Yupik
 - id: ynl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yangulam
 - id: ynn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yana
 - id: yno
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yong
 - id: ynq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yendang
 - id: yns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yansi
 - id: ynu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yahuna
 - id: yob
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yoba
 - id: yog
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yogad
 - id: yoi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yonaguni
 - id: yok
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yokuts
 - id: yol
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yola
 - id: yom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yombe
 - id: yon
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yongkom
 - id: yor
+  props:
+    alpha_2: yo
   tags:
   - individual
   - living
   title:
     en: Yoruba
 - id: yot
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yotti
 - id: yox
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yoron
 - id: yoy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yoy
 - id: ypa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phala
 - id: ypb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Labo Phowa
 - id: ypg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phola
 - id: yph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phupha
 - id: ypm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phuma
 - id: ypn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ani Phowa
 - id: ypo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Alo Phola
 - id: ypp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phupa
 - id: ypz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Phuza
 - id: yra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yerakai
 - id: yrb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yareba
 - id: yre
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yaour\xE9"
 - id: yrk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nenets
 - id: yrl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nhengatu
 - id: yrm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yirrk-Mel
 - id: yrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yerong
 - id: yro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yaroam\xEB"
 - id: yrs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yarsun
 - id: yrw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yarawata
 - id: yry
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yarluyandi
 - id: ysc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yassic
 - id: ysd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Samatao
 - id: ysg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sonaga
 - id: ysl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yugoslavian Sign Language
 - id: ysn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sani
 - id: yso
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nisi (China)
 - id: ysp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Lolopo
 - id: ysr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Sirenik Yupik
 - id: yss
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yessan-Mayo
 - id: ysy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sanie
 - id: yta
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Talu
 - id: ytl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tanglang
 - id: ytp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Thopho
 - id: ytw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yout Wam
 - id: yty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yatay
 - id: yua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yucateco
 - id: yub
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yugambal
 - id: yuc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuchi
 - id: yud
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Judeo-Tripolitanian Arabic
 - id: yue
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yue Chinese
 - id: yuf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Havasupai-Walapai-Yavapai
 - id: yug
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yug
 - id: yui
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yurut\xED"
 - id: yuj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Karkar-Yuri
 - id: yuk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yuki
 - id: yul
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yulu
 - id: yum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quechan
 - id: yun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bena (Nigeria)
 - id: yup
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yukpa
 - id: yuq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuqui
 - id: yur
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yurok
 - id: yut
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yopno
 - id: yuw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yau (Morobe Province)
 - id: yux
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Yukaghir
 - id: yuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Yugur
 - id: yuz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yuracare
 - id: yva
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yawa
 - id: yvt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yavitero
 - id: ywa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kalou
 - id: ywg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yinhawangka
 - id: ywl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Lalu
 - id: ywn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yawanawa
 - id: ywq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wuding-Luquan Yi
 - id: ywr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yawuru
 - id: ywt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xishanba Lalo
 - id: ywu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Wumeng Nasu
 - id: yww
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yawarawarga
 - id: yxa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mayawali
 - id: yxg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yagara
 - id: yxl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yardliyawarra
 - id: yxm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yinwum
 - id: yxu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yuyu
 - id: yxy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yabula Yabula
 - id: yyr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Yir Yoront
 - id: yyu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yau (Sandaun Province)
 - id: yyz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayizi
 - id: yzg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: E'ma Buyang
 - id: yzk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zokhuo
 - id: zaa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Sierra de Ju\xE1rez Zapotec"
 - id: zab
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Western Tlacolula Valley Zapotec
 - id: zac
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ocotl\xE1n Zapotec"
 - id: zad
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Cajonos Zapotec
 - id: zae
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yareni Zapotec
 - id: zaf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ayoquesco Zapotec
 - id: zag
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zaghawa
 - id: zah
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zangwal
 - id: zai
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Isthmus Zapotec
 - id: zaj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zaramo
 - id: zak
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zanaki
 - id: zal
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zauzou
 - id: zam
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Miahuatl\xE1n Zapotec"
 - id: zao
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ozolotepec Zapotec
 - id: zap
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Zapotec
 - id: zaq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Alo\xE1pam Zapotec"
 - id: zar
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Rinc\xF3n Zapotec"
 - id: zas
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santo Domingo Albarradas Zapotec
 - id: zat
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabaa Zapotec
 - id: zau
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zangskari
 - id: zav
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yatzachi Zapotec
 - id: zaw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mitla Zapotec
 - id: zax
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Xadani Zapotec
 - id: zay
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zayse-Zergulla
 - id: zaz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zari
 - id: zbc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Berawan
 - id: zbe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: East Berawan
 - id: zbl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - constructed
   title:
     en: Blissymbols
 - id: zbt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Batui
 - id: zbw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: West Berawan
 - id: zca
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Coatecas Altas Zapotec
 - id: zch
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Central Hongshuihe Zhuang
 - id: zdj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Ngazidja Comorian
 - id: zea
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zeeuws
 - id: zeg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zenag
 - id: zeh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Eastern Hongshuihe Zhuang
 - id: zen
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zenaga
 - id: zga
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kinga
 - id: zgb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guibei Zhuang
 - id: zgh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Standard Moroccan Tamazight
 - id: zgm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Minz Zhuang
 - id: zgn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guibian Zhuang
 - id: zgr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Magori
 - id: zha
+  props:
+    alpha_2: za
   tags:
   - macrolanguage
   - living
   title:
     en: Zhuang
 - id: zhb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zhaba
 - id: zhd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Dai Zhuang
 - id: zhi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zhire
 - id: zhn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Nong Zhuang
 - id: zho
+  props:
+    alpha_2: zh
   tags:
   - macrolanguage
   - living
   title:
     en: Chinese
 - id: zhw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zhoa
 - id: zia
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zia
 - id: zib
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zimbabwe Sign Language
 - id: zik
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zimakani
 - id: zil
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zialo
 - id: zim
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mesme
 - id: zin
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zinza
 - id: zir
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Ziriya
 - id: ziw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zigula
 - id: ziz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zizilivakan
 - id: zka
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kaimbulawa
 - id: zkb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Koibal
 - id: zkd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kadu
 - id: zkg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Koguryo
 - id: zkh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Khorezmian
 - id: zkk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Karankawa
 - id: zkn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kanan
 - id: zko
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kott
 - id: zkp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: "S\xE3o Paulo Kaing\xE1ng"
 - id: zkr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zakhring
 - id: zkt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kitan
 - id: zku
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kaurna
 - id: zkv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Krevinian
 - id: zkz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Khazar
 - id: zlj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liujiang Zhuang
 - id: zlm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Malay (individual language)
 - id: zln
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lianshan Zhuang
 - id: zlq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Liuqian Zhuang
 - id: zma
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Manda (Australia)
 - id: zmb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zimba
 - id: zmc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Margany
 - id: zmd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maridan
 - id: zme
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mangerr
 - id: zmf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mfinu
 - id: zmg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marti Ke
 - id: zmh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Makolkol
 - id: zmi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Negeri Sembilan Malay
 - id: zmj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maridjabin
 - id: zmk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mandandanyi
 - id: zml
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Madngele
 - id: zmm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Marimanindji
 - id: zmn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbangwe
 - id: zmo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Molo
 - id: zmp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mpuono
 - id: zmq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mituku
 - id: zmr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maranunggu
 - id: zms
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbesa
 - id: zmt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Maringarr
 - id: zmu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Muruwari
 - id: zmv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Mbariman-Gudhinma
 - id: zmw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbo (Democratic Republic of Congo)
 - id: zmx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Bomitaba
 - id: zmy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mariyedi
 - id: zmz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mbandja
 - id: zna
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zan Gula
 - id: zne
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zande (individual language)
 - id: zng
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mang
 - id: znk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Manangkari
 - id: zns
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mangas
 - id: zoc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Copainal\xE1 Zoque"
 - id: zoh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chimalapa Zoque
 - id: zom
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zou
 - id: zoo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Asunci\xF3n Mixtepec Zapotec"
 - id: zoq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tabasco Zoque
 - id: zor
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Ray\xF3n Zoque"
 - id: zos
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Francisco Le\xF3n Zoque"
 - id: zpa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Lachiguiri Zapotec
 - id: zpb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yautepec Zapotec
 - id: zpc
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Choapan Zapotec
 - id: zpd
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Southeastern Ixtl\xE1n Zapotec"
 - id: zpe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Petapa Zapotec
 - id: zpf
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Pedro Quiatoni Zapotec
 - id: zpg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Guevea De Humboldt Zapotec
 - id: zph
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Totomachapan Zapotec
 - id: zpi
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa Mar\xEDa Quiegolani Zapotec"
 - id: zpj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Quiavicuzas Zapotec
 - id: zpk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tlacolulita Zapotec
 - id: zpl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Lachix\xEDo Zapotec"
 - id: zpm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mixtepec Zapotec
 - id: zpn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Santa In\xE9s Yatzechi Zapotec"
 - id: zpo
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Amatl\xE1n Zapotec"
 - id: zpp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: El Alto Zapotec
 - id: zpq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zoogocho Zapotec
 - id: zpr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santiago Xanica Zapotec
 - id: zps
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Coatl\xE1n Zapotec"
 - id: zpt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Vicente Coatl\xE1n Zapotec"
 - id: zpu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Yal\xE1lag Zapotec"
 - id: zpv
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Chichicapan Zapotec
 - id: zpw
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zaniza Zapotec
 - id: zpx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: San Baltazar Loxicha Zapotec
 - id: zpy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mazaltepec Zapotec
 - id: zpz
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Texmelucan Zapotec
 - id: zqe
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Qiubei Zhuang
 - id: zra
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Kara (Korea)
 - id: zrg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mirgan
 - id: zrn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zerenkel
 - id: zro
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Z\xE1paro"
 - id: zrp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - extinct
   title:
     en: Zarphatic
 - id: zrs
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Mairasi
 - id: zsa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sarasira
 - id: zsk
+  props:
+    alpha_2: ''
   tags:
   - individual
   - ancient
   title:
     en: Kaskean
 - id: zsl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zambian Sign Language
 - id: zsm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Standard Malay
 - id: zsr
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Southern Rincon Zapotec
 - id: zsu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Sukurum
 - id: zte
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Elotepec Zapotec
 - id: ztg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Xanagu\xEDa Zapotec"
 - id: ztl
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Lapagu\xEDa-Guivini Zapotec"
 - id: ztm
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "San Agust\xEDn Mixtepec Zapotec"
 - id: ztn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Santa Catarina Albarradas Zapotec
 - id: ztp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Loxicha Zapotec
 - id: ztq
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "Quioquitani-Quier\xED Zapotec"
 - id: zts
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tilquiapan Zapotec
 - id: ztt
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tejalapan Zapotec
 - id: ztu
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: "G\xFCil\xE1 Zapotec"
 - id: ztx
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zaachila Zapotec
 - id: zty
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yatee Zapotec
 - id: zua
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zeem
 - id: zuh
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Tokano
 - id: zul
+  props:
+    alpha_2: zu
   tags:
   - individual
   - living
   title:
     en: Zulu
 - id: zum
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Kumzari
 - id: zun
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zuni
 - id: zuy
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zumaya
 - id: zwa
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zay
 - id: zxx
+  props:
+    alpha_2: ''
   tags:
   - special-scope
   - special-type
   title:
     en: No linguistic content
 - id: zyb
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yongbei Zhuang
 - id: zyg
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yang Zhuang
 - id: zyj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Youjiang Zhuang
 - id: zyn
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Yongnan Zhuang
 - id: zyp
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living
   title:
     en: Zyphe Chin
 - id: zza
+  props:
+    alpha_2: ''
   tags:
   - macrolanguage
   - living
   title:
     en: Zaza
 - id: zzj
+  props:
+    alpha_2: ''
   tags:
   - individual
   - living

--- a/invenio_rdm_records/resources/serializers/datacite/__init__.py
+++ b/invenio_rdm_records/resources/serializers/datacite/__init__.py
@@ -18,7 +18,3 @@ class DataCite43JSONSerializer(MarshmallowJSONSerializer):
     def __init__(self, **options):
         """Constructor."""
         super().__init__(schema_cls=DataCite43Schema, **options)
-
-    def dump_one(self, obj):
-        """Dump the object with extra information."""
-        return self._schema_cls().dump(obj)

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -184,6 +184,17 @@ class DataCite43Schema(Schema):
             system_identity
         )._record
 
+    def _read_language(self, id_):
+        """Retrieve resource type record using service."""
+        lang = vocabulary_service.read(
+            ('languages', id_),
+            system_identity
+        )._record
+
+        alpha_2 = lang["props"].get("alpha_2", None)
+
+        return alpha_2 or missing
+
     def get_type(self, obj):
         """Get resource type."""
         resource_type = obj["metadata"]["resource_type"]
@@ -208,7 +219,7 @@ class DataCite43Schema(Schema):
                 title["titleType"] = type_.capitalize()
             lang_id = add_title.get("lang", {}).get("id")
             if lang_id:
-                title["lang"] = lang_id
+                title["lang"] = self._read_language(lang_id)
 
             titles.append(title)
 
@@ -252,7 +263,7 @@ class DataCite43Schema(Schema):
 
         if languages:
             # PIDS-FIXME: How to choose? the first?
-            return languages[0]["id"]
+            return self._read_language(languages[0]["id"])
 
         return missing
 
@@ -321,11 +332,9 @@ class DataCite43Schema(Schema):
                 "descriptionType": add_desc["type"].capitalize()
             }
 
-            lang = add_desc.get("lang")
-            if lang:
-                id = lang.get("id")
-                if id:
-                    description["lang"] = id
+            lang_id = add_desc.get("lang", {}).get("id")
+            if lang_id:
+                description["lang"] = self._read_language(lang_id)
 
             descriptions.append(description)
 

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -67,6 +67,38 @@ def headers():
     }
 
 
+@pytest.fixture(scope="module")
+def laguanges_vocabulary(app, lang_type):
+    """Language vocabulary records."""
+    lang = []
+
+    lang.append(vocabulary_service.create(system_identity, {
+        "id": "eng",
+        "title": {
+            "en": "English",
+            "da": "Engelsk",
+        },
+        "props": {"alpha_2": "en"},
+        "tags": ["individual", "living"],
+        "type": "languages"
+    }))
+
+    lang.append(vocabulary_service.create(system_identity, {
+        "id": "dan",
+        "title": {
+            "en": "Danish",
+            "da": "Dansk",
+        },
+        "props": {"alpha_2": "da"},
+        "tags": ["individual", "living"],
+        "type": "languages"
+    }))
+
+    Vocabulary.index.refresh()
+
+    return lang
+
+
 @pytest.fixture(scope="function")
 def resource_type_type(app):
     """Resource type vocabulary type."""

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -43,7 +43,9 @@ def resource_type_dataset(resource_type_type):
 
 
 def test_datacite43_serializer(
-        running_app, full_record, resource_type_dataset, vocabulary_clear):
+    running_app, full_record, resource_type_dataset, laguanges_vocabulary,
+    vocabulary_clear
+):
     """Test serializer to DayaCide 4.3 JSON"""
     expected_data = {
         "types": {
@@ -75,7 +77,7 @@ def test_datacite43_serializer(
             {
                 "title": "a research data management platform",
                 "titleType": "Subtitle",
-                "lang": "eng",
+                "lang": "en",
             },
         ],
         "publisher": "InvenioRDM",
@@ -114,7 +116,7 @@ def test_datacite43_serializer(
                 "dateInformation": "A date"
             },
         ],
-        "language": "dan",
+        "language": "da",
         "identifiers": [
             {
                 "identifier": "1924MNRAS..84..308E",
@@ -149,7 +151,7 @@ def test_datacite43_serializer(
             {
                 "description": "Bla bla bla",
                 "descriptionType": "Methods",
-                "lang": "eng"
+                "lang": "en"
             },
         ],
         "geoLocations": [


### PR DESCRIPTION
closes #629 

~~How do we deal with those that have no alpha_2? There are many...~~ --> `missing` since it's not a mandatory field in datacite