### PR TITLE
schemas: remove 'required' properties from jsonschema

### DIFF
--- a/invenio_rdm_records/records/jsonschemas/records/definitions-v1.1.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/definitions-v1.1.0.json
@@ -31,8 +31,7 @@
       "id": {
         "type": "string"
       }
-    },
-    "required": ["id"]
+    }
   },
   "longitude": {
     "type": "number",
@@ -132,15 +131,11 @@
       "id": {
         "type": "string"
       }
-    },
-    "required": ["id"]
+    }
   },
   "person_or_org": {
     "type": "object",
     "additionalProperties": false,
-    "required": [
-      "type"
-    ],
     "properties": {
       "name": {
         "type": "string"
@@ -180,10 +175,7 @@
           },
           "uniqueItems": true
         }
-      },
-      "required": [
-        "name"
-      ]
+      }
     }
   },
   "file": {

--- a/invenio_rdm_records/records/jsonschemas/records/record-v3.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v3.0.0.json
@@ -39,7 +39,6 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["person_or_org"],
             "properties": {
                 "person_or_org": {"$ref": "local://records/definitions-v1.1.0.json#/person_or_org"},
                 "role": {"type": "string"},
@@ -88,8 +87,7 @@
                   "subject": {"type": "string"},
                   "identifier": {"$ref": "local://records/definitions-v1.1.0.json#/identifier"},
                   "scheme": {"$ref": "local://records/definitions-v1.1.0.json#/scheme"}
-              },
-              "required": ["subject"]
+              }
           }
         },
 
@@ -99,7 +97,6 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["person_or_org", "role"],
             "properties": {
               "person_or_org": {"$ref": "local://records/definitions-v1.1.0.json#/person_or_org"},
               "role": {"$ref": "local://records/definitions-v1.1.0.json#/contributorType"},
@@ -226,7 +223,6 @@
           "$comment": "This part of the schema is modelled on GeoJSON, but without the scope to embed arbitrary metadata.\n\nWe nest `features` within `locations` to give scope later to say something about the locations as a whole.",
           "type": "object",
           "additionalProperties": false,
-          "required": ["features"],
           "properties": {
             "features": {
               "type": "array",
@@ -264,13 +260,6 @@
                     "minLength": 1
                   }
                 }
-                }, {
-                  "anyOf": [
-                    {"required": ["geometry"]},
-                    {"required": ["identifiers"]},
-                    {"required": ["place"]},
-                    {"required": ["description"]}
-                  ]
                 }]
               }
             }

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -125,7 +125,7 @@ class CreatorSchema(Schema):
 class ContributorSchema(Schema):
     """Contributor schema."""
 
-    person_or_org = fields.Nested(PersonOrOrganizationSchema)
+    person_or_org = fields.Nested(PersonOrOrganizationSchema, required=True)
     role = SanitizedUnicode(required=True)
     affiliations = fields.List(fields.Nested(AffiliationSchema))
 

--- a/tests/records/test_jsonschema.py
+++ b/tests/records/test_jsonschema.py
@@ -161,7 +161,6 @@ def test_metadata(appctx):
 
 def test_resource_type(appctx):
     """Test resource type."""
-    assert fails_meta({"resource_type": {}})
     assert validates_meta({"resource_type": {"id": "publication"}})
     assert fails_meta({"resource_type": {"id": 123}})
 
@@ -431,9 +430,7 @@ def test_locations_valid(appctx, features):
 
 @pytest.mark.parametrize("locations", [
     None,  # locations must be an object
-    {},  # Missing features
     {'features': []},  # Empty features
-    {'features': [{}]},  # Empty feature
     {
         'features': [{
             "properties": None,   # Additional props

--- a/tests/records/test_relations_languages.py
+++ b/tests/records/test_relations_languages.py
@@ -77,10 +77,6 @@ def test_languages_invalid(running_app, minimal_record, lang):
     minimal_record["metadata"]["languages"] = [{"test": "eng"}]
     pytest.raises(ValidationError, RDMDraft.create, minimal_record)
 
-    # id key is required
-    minimal_record["metadata"]["languages"] = [{}]
-    pytest.raises(ValidationError, RDMDraft.create, minimal_record)
-
     # non-string types are not allowed as id values
     minimal_record["metadata"]["languages"] = [{"id": 1}]
     pytest.raises(ValidationError, RDMDraft.create, minimal_record)


### PR DESCRIPTION
* previously, missing required properties would lead to generic 500
  errors during the upload of metadata for drafts without useful
  information
* also, the draft would not be saved
* this was because during draft creation, marshmallow validation
  errors wouldn't lead to an abort, but jsonschema validation errors
  would
* as per discussion, the role of jsonschema is primarily for basic
  structural validation nowadays