### PR TITLE
schemas: add missing 'features' property in 'metadata.locations'

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -343,7 +343,8 @@ class DataCite43Schema(Schema):
         """Get locations."""
         locations = []
 
-        for location in obj["metadata"].get("locations", []):
+        loc_list = obj["metadata"].get("locations", {}).get("features", [])
+        for location in loc_list:
             place = location.get("place")
             serialized_location = {}
             if place:

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -403,6 +403,12 @@ class LocationSchema(Schema):
             })
 
 
+class FeatureSchema(Schema):
+    """Location feature schema."""
+
+    features = fields.List(fields.Nested(LocationSchema))
+
+
 class MetadataSchema(Schema):
     """Schema for the record metadata."""
 
@@ -444,6 +450,6 @@ class MetadataSchema(Schema):
     rights = fields.List(fields.Nested(RightsSchema))
     description = SanitizedHTML(validate=validate.Length(min=3))
     additional_descriptions = fields.List(fields.Nested(DescriptionSchema))
-    locations = fields.List(fields.Nested(LocationSchema))
+    locations = fields.Nested(FeatureSchema)
     funding = fields.List(fields.Nested(FundingSchema))
     references = fields.List(fields.Nested(ReferenceSchema))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,23 +186,25 @@ def full_record(users):
                     "id": "eng"
                 }
             }],
-            "locations": [{
-                "geometry": {
-                    "type": "Point",
-                    "coordinates": [-32.94682, -60.63932]
-                },
-                "place": "test location place",
-                "description": "test location description",
-                "identifiers": [
-                    {
-                        "identifier": "12345abcde",
-                        "scheme": "wikidata"
-                    }, {
-                        "identifier": "12345abcde",
-                        "scheme": "geonames"
-                    }
-                ],
-            }],
+            "locations": {
+                "features": [{
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [-32.94682, -60.63932]
+                    },
+                    "place": "test location place",
+                    "description": "test location description",
+                    "identifiers": [
+                        {
+                            "identifier": "12345abcde",
+                            "scheme": "wikidata"
+                        }, {
+                            "identifier": "12345abcde",
+                            "scheme": "geonames"
+                        }
+                    ],
+                }]
+            },
             "funding": [{
                 "funder": {
                     "name": "European Commission",

--- a/tests/services/schemas/test_location.py
+++ b/tests/services/schemas/test_location.py
@@ -75,7 +75,7 @@ def test_valid_single_location(app, minimal_record, valid_full_location):
     metadata = minimal_record['metadata']
     # NOTE: this is done to get possible load transformations out of the way
     metadata = MetadataSchema().load(metadata)
-    metadata['locations'] = [valid_full_location]
+    metadata['locations'] = {"features": [valid_full_location]}
 
     assert metadata == MetadataSchema().load(metadata)
 
@@ -84,14 +84,18 @@ def test_valid_multiple_locations(app, minimal_record, valid_full_location):
     metadata = minimal_record['metadata']
     # NOTE: this is done to get possible load transformations out of the way
     metadata = MetadataSchema().load(metadata)
-    metadata['locations'] = [valid_full_location, valid_full_location]
+    metadata['locations'] = {
+        "features": [
+            valid_full_location, valid_full_location
+        ]
+    }
 
     assert metadata == MetadataSchema().load(metadata)
 
 
 def test_invalid_no_list_location(app, minimal_record, valid_full_location):
     metadata = minimal_record['metadata']
-    metadata['locations'] = valid_full_location
+    metadata['locations'] = {"features": valid_full_location}
 
     with pytest.raises(ValidationError):
         data = MetadataSchema().load(metadata)


### PR DESCRIPTION
in the marshmallow schema, the `features` property was missing from `metadata.locations`, causing the locations to always be dropped on ingest.
this mismatch could be fixed by simply adding the missing intermediate `features` property.

example record:
```
{
  "files": {
    "enabled": false
  },
  "metadata": {
    "resource_type": {
      "id": "other"
    },
    "title": "Awesome Information",
    "description": "Nothing really new, but now packaged as a single record!",
    "creators": [
      {
        "person_or_org": {
          "given_name": "Max",
          "family_name": "Moser",
          "type": "personal"
        },
        "affiliations": [
          {
            "name": "TU Wien",
            "identifiers": [
              {
                "scheme": "ror",
                "identifier": "04d836q62"
              }
            ]
          }
        ]
      }
    ],
    "publisher": "TU Data",
    "publication_date": "2021-04-03",
    "locations": {
      "features": [
        {
          "place": "Alpbach",
          "geometry": {
            "type": "Point",
            "coordinates": [
              11.9432,
              47.3991
            ]
          },
          "identifiers": [
            {
              "scheme": "tgn",
              "identifier": "http://vocab.getty.edu/tgn/8713338"
            }
          ],
          "description": "Where the cows are"
        },
        {
          "place": "Vienna",
          "geometry": {
            "type": "Point",
            "coordinates": [
              16.3738,
              48.2082
            ]
          },
          "description": "Where the bars are",
          "identifiers": [
            {
              "scheme": "tgn",
              "identifier": "http://vocab.getty.edu/tgn/7003030"
            }
          ]
        }
      ]
    }
  }
}
```

results in (JSON export, nicely highlighted specifically for @ppanero  ):
![image](https://user-images.githubusercontent.com/6437519/121701852-a0d19f00-cad1-11eb-8e29-14d1d933deb0.png)
