### PR TITLE
serializers: DataCite serializer fixes

### DIFF
--- a/invenio_rdm_records/fixtures/data/vocabularies.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies.yaml
@@ -25,6 +25,6 @@ datetypes:
 subjects:
   pid-type: sub
   data-file: vocabularies/subjects.yaml
-title_types:
+titletypes:
   pid-type: ttyp
   data-file: vocabularies/title_types.yaml

--- a/invenio_rdm_records/fixtures/data/vocabularies/description_types.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/description_types.yaml
@@ -1,18 +1,30 @@
 - id: abstract
+  props:
+    datacite: Abstract
   title:
     en: Abstract
 - id: methods
+  props:
+    datacite: Methods
   title:
     en: Methods
 - id: series-information
+  props:
+    datacite: Series information
   title:
-    en: Series Information
+    en: Series information
 - id: table-of-contents
+  props:
+    datacite: Table of contents
   title:
-    en: Table of Contents
+    en: Table of contents
 - id: technical-info
+  props:
+    datacite: Technical info
   title:
-    en: Technical Info
+    en: Technical info
 - id: other
+  props:
+    datacite: Other
   title:
     en: Other

--- a/invenio_rdm_records/fixtures/data/vocabularies/roles.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/roles.yaml
@@ -1,63 +1,105 @@
 - id: contactperson
+  props:
+    datacite: Contact person
   title:
-    en: Contact Person
+    en: Contact person
 - id: datacollector
+  props:
+    datacite: Data collector
   title:
-    en: Data Collector
+    en: Data collector
 - id: datacurator
+  props:
+    datacite: Data curator
   title:
-    en: Data Curator
+    en: Data curator
 - id: datamanager
+  props:
+    datacite: Data manager
   title:
-    en: Data Manager
+    en: Data manager
 - id: distributor
+  props:
+    datacite: Distributor
   title:
     en: Distributor
 - id: editor
+  props:
+    datacite: Editor
   title:
     en: Editor
 - id: hostinginstitution
+  props:
+    datacite: Hosting institution
   title:
-    en: Hosting Institution
+    en: Hosting institution
 - id: producer
+  props:
+    datacite: Producer
   title:
     en: Producer
 - id: projectleader
+  props:
+    datacite: Project leader
   title:
-    en: Project Leader
+    en: Project leader
 - id: projectmanager
+  props:
+    datacite: Project manager
   title:
-    en: Project Manager
+    en: Project manager
 - id: projectmember
+  props:
+    datacite: Project member
   title:
-    en: Project Member
+    en: Project member
 - id: registrationagency
+  props:
+    datacite: Registration agency
   title:
-    en: Registration Agency
+    en: Registration agency
 - id: registrationauthority
+  props:
+    datacite: Registration authority
   title:
-    en: Registration Authority
+    en: Registration authority
 - id: relatedperson
+  props:
+    datacite: Related person
   title:
-    en: Related Person
+    en: Related person
 - id: researcher
+  props:
+    datacite: Researcher
   title:
     en: Researcher
 - id: researchgroup
+  props:
+    datacite: Research group
   title:
-    en: Research Group
+    en: Research group
 - id: rightsholder
+  props:
+    datacite: Rights holder
   title:
-    en: Rights Holder
+    en: Rights holder
 - id: sponsor
+  props:
+    datacite: Sponsor
   title:
     en: Sponsor
 - id: supervisor
+  props:
+    datacite: Supervisor
   title:
     en: Supervisor
 - id: workpackageleader
+  props:
+    datacite: Work package leader
   title:
-    en: Work Package Leader
+    en: Work package leader
 - id: other
+  props:
+    datacite: Other
   title:
     en: Other

--- a/invenio_rdm_records/fixtures/data/vocabularies/title_types.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/title_types.yaml
@@ -2,7 +2,7 @@
   props:
     datacite: AlternativeTitle
   title:
-    en: Alternative Title
+    en: Alternative title
 - id: subtitle
   props:
     datacite: Subtitle
@@ -12,7 +12,7 @@
   props:
     datacite: TranslatedTitle
   title:
-    en: Translated Title
+    en: Translated title
 - id: other
   props:
     datacite: Other

--- a/invenio_rdm_records/fixtures/demo.py
+++ b/invenio_rdm_records/fixtures/demo.py
@@ -98,7 +98,7 @@ class CachedVocabularies:
 
             cls._title_type_ids = []
 
-            title_types = cls._read_vocabulary("title_types")
+            title_types = cls._read_vocabulary("titletypes")
 
             for tt in title_types:
                 cls._title_type_ids.append(tt["id"])

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -112,14 +112,14 @@ class CommonFieldsMixin:
             cache_key='resource_type',
             relation_field='resource_type'
         ),
-        title_type=PIDListRelation(
+        title_types=PIDListRelation(
             'metadata.additional_titles',
             attrs=['id', 'title'],
             pid_field=Vocabulary.pid.with_type_ctx('title_types'),
             cache_key='title_type',
             relation_field='type',
         ),
-        titles_languages=PIDListRelation(
+        title_languages=PIDListRelation(
             'metadata.additional_titles',
             attrs=['id', 'title'],
             pid_field=Vocabulary.pid.with_type_ctx('languages'),

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -115,7 +115,7 @@ class CommonFieldsMixin:
         title_types=PIDListRelation(
             'metadata.additional_titles',
             attrs=['id', 'title'],
-            pid_field=Vocabulary.pid.with_type_ctx('title_types'),
+            pid_field=Vocabulary.pid.with_type_ctx('titletypes'),
             cache_key='title_type',
             relation_field='type',
         ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -446,7 +446,7 @@ def resource_type_v(app, resource_type_type):
 def title_type(app):
     """title vocabulary type."""
     return vocabulary_service.create_type(system_identity,
-                                          "title_types", "ttyp")
+                                          "titletypes", "ttyp")
 
 
 @pytest.fixture(scope="module")
@@ -458,9 +458,9 @@ def title_type_v(app, title_type):
             "datacite": "AlternativeTitle"
          },
         "title": {
-            "en": "Alternative Title"
+            "en": "Alternative title"
         },
-        "type": "title_types"
+        "type": "titletypes"
     })
 
     Vocabulary.index.refresh()
@@ -483,6 +483,9 @@ def description_type_v(app, description_type):
         "title": {
             "en": "Methods"
         },
+        "props": {
+            "datacite": "Methods"
+        },
         "type": "descriptiontypes"
     })
 
@@ -503,7 +506,8 @@ def subject_v(app, subject_type):
     vocab = vocabulary_service.create(system_identity, {
         "id": "A-D000007",
         "props": {
-            "subjectScheme": "MeSH"
+            "subjectScheme": "MeSH",
+            "datacite": "Abdominal Injuries"
         },
         "tags": ["mesh"],
         "title": {
@@ -535,6 +539,33 @@ def date_type_v(app, date_type):
             "datacite": "Other"
         },
         "type": "datetypes"
+    })
+
+    Vocabulary.index.refresh()
+
+    return vocab
+
+
+@pytest.fixture(scope="module")
+def contributors_role_type(app):
+    """Contributor role vocabulary type."""
+    return vocabulary_service.create_type(
+        system_identity, "contributorsroles", "cor"
+    )
+
+
+@pytest.fixture(scope="module")
+def contributors_role_v(app, contributors_role_type):
+    """Contributor role vocabulary record."""
+    vocab = vocabulary_service.create(system_identity, {
+        "id": "other",
+        "props": {
+            "datacite": "Other"
+        },
+        "title": {
+            "en": "Other"
+        },
+        "type": "contributorsroles"
     })
 
     Vocabulary.index.refresh()
@@ -575,14 +606,15 @@ RunningApp = namedtuple("RunningApp", [
     "affiliations_v",
     "title_type_v",
     "description_type_v",
-    "date_type_v"
+    "date_type_v",
+    "contributors_role_v"
 ])
 
 
 @pytest.fixture
 def running_app(
     app, location, resource_type_v, subject_v, languages_v, affiliations_v,
-    title_type_v, description_type_v, date_type_v
+    title_type_v, description_type_v, date_type_v, contributors_role_v
 ):
     """This fixture provides an app with the typically needed db data loaded.
 
@@ -598,7 +630,8 @@ def running_app(
         affiliations_v,
         title_type_v,
         description_type_v,
-        date_type_v
+        date_type_v,
+        contributors_role_v
     )
 
 

--- a/tests/fixtures/app_data/vocabularies.yaml
+++ b/tests/fixtures/app_data/vocabularies.yaml
@@ -5,6 +5,6 @@ subjects:
   pid-type: sub
   data-file:
     A: vocabularies/subjects.yaml
-title_types:
+titletypes:
   pid-type: ttyp
   data-file: vocabularies/title_types.yaml

--- a/tests/fixtures/app_data/vocabularies/subjects.yaml
+++ b/tests/fixtures/app_data/vocabularies/subjects.yaml
@@ -1,6 +1,7 @@
 - id: A-D000007
   props:
     subjectScheme: MeSH
+    datacite: Abdominal Injuries
   tags:
     - mesh
   title:
@@ -8,6 +9,7 @@
 - id: A-D000008
   props:
     subjectScheme: MeSH
+    datacite: Abdominal Neoplasms
   tags:
     - mesh
   title:

--- a/tests/fixtures/data/vocabularies/description_types.yaml
+++ b/tests/fixtures/data/vocabularies/description_types.yaml
@@ -1,18 +1,30 @@
 - id: abstract
+  props:
+    datacite: Abstract
   title:
     en: Abstract
 - id: methods
+  props:
+    datacite: Methods
   title:
     en: Methods
 - id: series-information
+  props:
+    datacite: Series information
   title:
-    en: Series Information
+    en: Series information
 - id: table-of-contents
+  props:
+    datacite: Table of contents
   title:
-    en: Table of Contents
+    en: Table of contents
 - id: technical-info
+  props:
+    datacite: Technical info
   title:
-    en: Technical Info
+    en: Technical info
 - id: other
+  props:
+    datacite: Other
   title:
     en: Other

--- a/tests/fixtures/data/vocabularies/roles.yaml
+++ b/tests/fixtures/data/vocabularies/roles.yaml
@@ -1,9 +1,15 @@
 - id: contactperson
+  props:
+    datacite: Contact person
   title:
-    en: Contact Person
+    en: Contact person
 - id: datacollector
+  props:
+    datacite: Data collector
   title:
-    en: Data Collector
+    en: Data collector
 - id: other
+  props:
+    datacite: Other
   title:
     en: Other

--- a/tests/fixtures/data/vocabularies/title_types.yaml
+++ b/tests/fixtures/data/vocabularies/title_types.yaml
@@ -2,7 +2,7 @@
   props:
     datacite: AlternativeTitle
   title:
-    en: Alternative Title
+    en: Alternative title
 - id: subtitle
   props:
     datacite: Subtitle
@@ -12,7 +12,7 @@
   props:
     datacite: TranslatedTitle
   title:
-    en: Translated Title
+    en: Translated title
 - id: other
   props:
     datacite: Other

--- a/tests/fixtures/test_cli.py
+++ b/tests/fixtures/test_cli.py
@@ -28,7 +28,7 @@ def test_fake_demo_record_creation(app, location, db, es_clear, vocabularies):
             Path(__file__).parent / "data/vocabularies/languages.yaml"
         ),
         (
-            'title_types',
+            'titletypes',
             "ttyp",
             Path(__file__).parent / "data/vocabularies/title_types.yaml"
         ),

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -100,7 +100,7 @@ def title_type_v(app, title_type):
         "title": {
             "en": "Subtitle"
         },
-        "type": "title_types"
+        "type": "titletypes"
     })
 
     Vocabulary.index.refresh()
@@ -111,7 +111,7 @@ def title_type_v(app, title_type):
 @pytest.fixture
 def running_app(
     app, location, resource_type_v, subject_v, languages_v, title_type_v,
-    description_type_v, affiliations_v, date_type_v
+    description_type_v, affiliations_v, date_type_v, contributors_role_v
 ):
     """Return running_app but load everything for datacite serialization.
 
@@ -154,7 +154,7 @@ def test_datacite43_serializer(running_app, full_record, vocabulary_clear):
             {
                 "title": "a research data management platform",
                 "titleType": "Subtitle",
-                "lang": "en",
+                "lang": "eng",
             },
         ],
         "publisher": "InvenioRDM",
@@ -192,7 +192,7 @@ def test_datacite43_serializer(running_app, full_record, vocabulary_clear):
                 "dateInformation": "A date"
             },
         ],
-        "language": "da",
+        "language": "dan",
         "identifiers": [
             {
                 "identifier": "1924MNRAS..84..308E",
@@ -227,7 +227,7 @@ def test_datacite43_serializer(running_app, full_record, vocabulary_clear):
             {
                 "description": "Bla bla bla",
                 "descriptionType": "Methods",
-                "lang": "en"
+                "lang": "eng"
             },
         ],
         "geoLocations": [


### PR DESCRIPTION
Missing:

- [ ] Creator/contributors affiliations should be optimized to use ``read_many`` (reads from ES instead of DB, and sends a single query vs one per affiliation - think of CERN paper with 5000 people with affiliations).
- [x] Subjects should be migrated to efficient querying.