### PR TITLE
serializers: minor fixes to datacite json and add tests for xml

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/__init__.py
+++ b/invenio_rdm_records/resources/serializers/datacite/__init__.py
@@ -23,10 +23,6 @@ class DataCite43JSONSerializer(MarshmallowJSONSerializer):
 class DataCite43XMLSerializer(DataCite43JSONSerializer):
     """JSON based DataCite XML serializer for records."""
 
-    def __init__(self, **options):
-        """Constructor."""
-        super().__init__(**options)
-
     def serialize_object(self, record, **kwargs):
         """Serialize a single record."""
         data = self.dump_one(record, **kwargs)


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/703
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/727

Differences I can observe in comparison with the full example of [DataCite 4.3 XML](https://github.com/inveniosoftware/datacite/blob/master/tests/data/datacite-v4.3-full-example.xml), which are not yet implemented are:
- All languages should use the 2 letter encoding, instead of 3. This should be fixed for the JSON schema too.
- We do not have alternate identifiers, we put them in `identifiers`. This would differ from the JSON schema. We should:
    - pids --> identifiers
    - identifiers --> alternate identifiers