### PR TITLE
serializers: fix subjects capitalization in datacite export

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -407,7 +407,7 @@ class DataCite43Schema(Schema):
         for subject in subjects:
             sub_text = subject.get("subject")
             if sub_text:
-                serialized_subjects.append({"Subject": sub_text})
+                serialized_subjects.append({"subject": sub_text})
             else:
                 ids.append(subject.get("id"))
 
@@ -419,7 +419,7 @@ class DataCite43Schema(Schema):
             validator = validate.URL()
             for subject in subjects:
                 serialized_subj = {
-                    "Subject": subject.get("subject"),
+                    "subject": subject.get("subject"),
                     "subjectScheme": subject.get("scheme"),
                 }
                 id_ = subject.get("id")

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -162,9 +162,9 @@ def test_datacite43_serializer(running_app, full_record, vocabulary_clear):
         "publisher": "InvenioRDM",
         "publicationYear": "2018",
         "subjects": [{
-            "Subject": "custom"
+            "subject": "custom"
         }, {
-            "Subject": "Abdominal Injuries",
+            "subject": "Abdominal Injuries",
             "subjectScheme": "MeSH",
             "valueURI": "http://id.nlm.nih.gov/mesh/A-D000007",
         }],


### PR DESCRIPTION
- closes #727 

There was a `KeyError` masked as a 404.

The issue was due to the capitalization of the `subjects` key. The PDF of DataCite 4.3 seems to mention it as `Subject` but this might simply be due to a capitalization of the beginning of a text line (🤔)

The examples in:
- [DataCite 4.3 JSON](https://github.com/inveniosoftware/datacite/blob/master/tests/data/datacite-v4.3-full-example.json#L44)
- [DataCite 4.3 XML](https://github.com/inveniosoftware/datacite/blob/master/tests/data/datacite-v4.3-full-example.xml#L20)
- The [serialization code itself](https://github.com/inveniosoftware/datacite/blob/master/datacite/schema43.py#L205)
 
expect it lowercased.

![Screenshot 2021-07-12 at 13 26 45](https://user-images.githubusercontent.com/6756943/125279952-d0640900-e314-11eb-89e3-b4e316302631.png)

