### PR TITLE
vocabularies: fix subjects and affiliations registration

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -13,10 +13,14 @@ from flask_babelex import _
 from flask_principal import identity_loaded
 from invenio_records_resources.resources.files import FileResource
 from invenio_records_resources.services import FileService
-from invenio_vocabularies.contrib.affiliations.affiliations import \
-    record_type as affiliations_record_type
-from invenio_vocabularies.contrib.subjects.subjects import \
-    record_type as subject_record_type
+from invenio_vocabularies.contrib.affiliations.resources import \
+    AffiliationsResource, AffiliationsResourceConfig
+from invenio_vocabularies.contrib.affiliations.services import \
+    AffiliationsService, AffiliationsServiceConfig
+from invenio_vocabularies.contrib.subjects.resources import SubjectsResource, \
+    SubjectsResourceConfig
+from invenio_vocabularies.contrib.subjects.services import SubjectsService, \
+    SubjectsServiceConfig
 from itsdangerous import SignatureExpired
 
 from . import config
@@ -111,11 +115,10 @@ class InvenioRDMRecords(object):
             draft_files_service=FileService(RDMFileDraftServiceConfig),
             secret_links_service=SecretLinkService(RDMRecordServiceConfig)
         )
-        self.subjects_service = subject_record_type.service_cls(
-            config=subject_record_type.service_config_cls,
-        )
-        self.affiliations_service = affiliations_record_type.service_cls(
-            config=affiliations_record_type.service_config_cls,
+        self.subjects_service = SubjectsService(config=SubjectsServiceConfig)
+
+        self.affiliations_service = AffiliationsService(
+            config=AffiliationsServiceConfig
         )
 
     def init_resource(self, app):
@@ -144,12 +147,12 @@ class InvenioRDMRecords(object):
         )
 
         # Vocabularies
-        self.subjects_resource = subject_record_type.resource_cls(
+        self.subjects_resource = SubjectsResource(
             service=self.subjects_service,
-            config=subject_record_type.resource_config_cls,
+            config=SubjectsResourceConfig,
         )
 
-        self.affiliations_resource = affiliations_record_type.resource_cls(
+        self.affiliations_resource = AffiliationsResource(
             service=self.affiliations_service,
-            config=affiliations_record_type.resource_config_cls,
+            config=AffiliationsResourceConfig,
         )

--- a/tests/resources/vocabularies/test_subjects_vocabulary.py
+++ b/tests/resources/vocabularies/test_subjects_vocabulary.py
@@ -7,6 +7,8 @@
 
 """Subject resource tests."""
 
+from urllib.parse import quote
+
 import pytest
 from invenio_records_resources.proxies import current_service_registry
 from invenio_vocabularies.contrib.subjects.api import Subject
@@ -33,18 +35,18 @@ def example_subject(
     return aff
 
 
-@pytest.mark.skip(
-    "resolving does not work due to url econding. Tried encode/quote, fails."
-)
 def test_subjects_get(client, example_subject, headers):
     """Test the endpoint to retrieve a single item."""
     id_ = example_subject.id
     res = client.get(f"/subjects/{id_}", headers=headers)
     assert res.status_code == 200
     assert res.json["id"] == id_
+    # test encoding the URL ID too
+    res = client.get(f"/subjects/{quote(id_)}", headers=headers)
+    assert res.status_code == 200
     # Test links
     assert res.json["links"] == {
-        "self": "https://127.0.0.1:5000/api/subjects/https://id.nlm.nih.gov/mesh/D000001"  # noqa
+        "self": "https://127.0.0.1:5000/api/subjects/https%3A%2F%2Fid.nlm.nih.gov%2Fmesh%2FD000001"  # noqa
     }
 
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-vocabularies/issues/66

Both affiliations and subjects were being installed without potential changes in the config since it was being taken directly from the `record_type` and not from the corresponding class.