### PR TITLE
serializers: add error for missing vocabulary

### DIFF
--- a/invenio_rdm_records/resources/serializers/errors.py
+++ b/invenio_rdm_records/resources/serializers/errors.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Errors for serializers."""
+
+
+class SerializerError(Exception):
+    """Base class for serializer errors."""
+
+
+class VocabularyItemNotFoundError(SerializerError):
+    """Error thrown when a vocabulary is not found."""

--- a/invenio_rdm_records/resources/serializers/utils.py
+++ b/invenio_rdm_records/resources/serializers/utils.py
@@ -11,6 +11,8 @@
 from invenio_access.permissions import system_identity
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 
+from .errors import VocabularyItemNotFoundError
+
 
 def map_type(vocabulary, fields, id_):
     """Maps an internal vocabulary type to external vocabulary type."""
@@ -23,3 +25,6 @@ def map_type(vocabulary, fields, id_):
     for h in res.hits:
         if h["id"] == id_:
             return h["props"] if "props" in h else {}
+
+    raise VocabularyItemNotFoundError(
+        f"The '{vocabulary}' vocabulary item  '{id_}' was not found.")

--- a/tests/resources/serializers/test_dublincore_serializer.py
+++ b/tests/resources/serializers/test_dublincore_serializer.py
@@ -11,6 +11,8 @@ import pytest
 
 from invenio_rdm_records.resources.serializers.dublincore import \
     DublinCoreJSONSerializer, DublinCoreXMLSerializer
+from invenio_rdm_records.resources.serializers.errors import \
+    VocabularyItemNotFoundError
 
 
 @pytest.fixture(scope="function")
@@ -77,6 +79,14 @@ def test_dublincorejson_serializer_minimal(
     serialized_record = serializer.dump_one(updated_minimal_record)
 
     assert serialized_record == expected_data
+
+
+def test_vocabulary_type_error(running_app, updated_minimal_record):
+    """Test error thrown on missing resource type."""
+    updated_minimal_record['metadata']['resource_type']['id'] = 'invalid'
+
+    with pytest.raises(VocabularyItemNotFoundError):
+        DublinCoreJSONSerializer().dump_one(updated_minimal_record)
 
 
 def test_dublincorexml_serializer(running_app, updated_full_record):


### PR DESCRIPTION
* Throws a specific error if a generic vocabulary item was not found.