### PR TITLE
vocabularies: remove metadata relation types

### DIFF
--- a/invenio_rdm_records/fixtures/data/vocabularies/relation_types.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/relation_types.yaml
@@ -38,16 +38,6 @@
      datacite: Describes
   title:
      en: Describes
-- id: hasmetadata
-  props:
-     datacite: HasMetadata
-  title:
-     en: Has metadata
-- id: ismetadatafor
-  props:
-     datacite: IsMetadataFor
-  title:
-     en: Is metadata for
 - id: hasversion
   props:
      datacite: HasVersion


### PR DESCRIPTION
* Removes IsMetadataFor, HasMetadata relation type pair because they
  require use of additional fields that we do not support.