### PR TITLE
serializers: fix datacite creatibutors affiliations

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -39,7 +39,7 @@ class PersonOrOrgSchema43(Schema):
     givenName = fields.Str(attribute="person_or_org.given_name")
     familyName = fields.Str(attribute="person_or_org.family_name")
     nameIdentifiers = fields.Method('get_name_identifiers')
-    affiliations = fields.Method('get_affiliation')
+    affiliation = fields.Method('get_affiliation')
 
     def get_name_identifiers(self, obj):
         """Get name identifier list."""

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -143,7 +143,7 @@ def test_datacite43_serializer(running_app, full_record):
                     "nameIdentifierScheme": "ORCID",
                     'schemeURI': 'http://orcid.org/'
                 }],
-                "affiliations": [
+                "affiliation": [
                     {'name': 'free-text'},
                     {
                         "name": "CERN",
@@ -182,7 +182,7 @@ def test_datacite43_serializer(running_app, full_record):
                     "nameIdentifierScheme": "ORCID",
                     'schemeURI': 'http://orcid.org/'
                 }],
-                "affiliations": [
+                "affiliation": [
                     {
                         "name": "CERN",
                         "affiliationIdentifier": "https://ror.org/01ggx4157",
@@ -277,6 +277,8 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
         "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
+        "      <affiliation>free-text</affiliation>",
+        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </creator>",
         "  </creators>",
         "  <titles>",
@@ -295,6 +297,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
         "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
+        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </contributor>",
         "  </contributors>",
         "  <dates>",


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/967

The field name is `affiliation` in singular, even if the cardinality is `0-n`.

![Screenshot 2021-07-16 at 13 34 05](https://user-images.githubusercontent.com/6756943/125941660-9abebfac-6009-4039-b583-8302380bbce4.png)
