### PR TITLE
schemas: use new allowed identifiers structure

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -174,37 +174,140 @@ RDM_RECORDS_DOI_DATACITE_TEST_MODE = True
 
 # PID Schemes
 
-RDM_RECORDS_RECORD_PID_SCHEMES = ["doi"]
-RDM_RECORDS_PERSONORG_SCHEMES = ["orcid", "isni", "gnd", "ror"]
-RDM_RECORDS_IDENTIFIERS_SCHEMES = [
-    "ark",
-    "arxiv",
-    ("bibcode", idutils.is_ads),
-    "doi",
-    "ean13",
-    ("eissn", lambda x: True),  # FIXME: is this an issn
-    "handle",
-    ("igsn", lambda x: True),
-    "isbn",
-    "issn",
-    "istc",
-    ("lissn", lambda x: True),
-    "lsid",
-    "pmid",
-    "purl",
-    ("upc", lambda x: True),
-    "url",
-    "urn",
-    ("w3id", lambda x: True),
-]
-RDM_RECORDS_REFERENCES_SCHEMES = [
-    "isni",
-    ("grid", lambda x: True),
-    ("crossreffunderid", lambda x: True),
-    ("other", lambda x: True)
-]
-RDM_RECORDS_LOCATION_SCHEMES = [
-    ("wikidata", lambda x: True),
-    ("geonames", lambda x: True)
-]
+
+def always_valid(identifier):
+    """Gives every identifier as valid."""
+    return True
+
+
+RDM_RECORDS_RECORD_PID_SCHEMES = {
+    "doi": {
+        "label": _("DOI"),
+        "validator": idutils.is_doi
+    }
+}
+RDM_RECORDS_PERSONORG_SCHEMES = {
+    "orcid": {
+        "label": _("ORCID"),
+        "validator": idutils.is_orcid
+    },
+    "isni": {
+        "label": _("ISNI"),
+        "validator": idutils.is_isni
+    },
+    "gnd": {
+        "label": _("GND"),
+        "validator": idutils.is_gnd
+    },
+    "ror": {
+        "label": _("ROR"),
+        "validator": idutils.is_ror
+    },
+}
+RDM_RECORDS_IDENTIFIERS_SCHEMES = {
+    "ark": {
+        "label": _("ARK"),
+        "validator": idutils.is_ark
+    },
+    "arxiv": {
+        "label": _("arXiv"),
+        "validator": idutils.is_arxiv
+    },
+    "bibcode": {
+        "label": _("Bibcode"),
+        "validator": idutils.is_ads
+    },
+    "doi": {
+        "label": _("DOI"),
+        "validator": idutils.is_doi
+    },
+    "ean13": {
+        "label": _("EAN13"),
+        "validator": idutils.is_ean13
+    },
+    "eissn": {
+        "label": _("EISSN"),
+        "validator": idutils.is_issn
+    },
+    "handle": {
+        "label": _("Handle"),
+        "validator": idutils.is_handle
+    },
+    "igsn": {
+        "label": _("IGSN"),
+        "validator": always_valid
+    },
+    "isbn": {
+        "label": _("ISBN"),
+        "validator": idutils.is_isbn
+    },
+    "issn": {
+        "label": _("ISSN"),
+        "validator": idutils.is_issn
+    },
+    "istc": {
+        "label": _("ISTC"),
+        "validator": idutils.is_istc
+    },
+    "lissn": {
+        "label": _("LISSN"),
+        "validator": idutils.is_issn
+    },
+    "lsid": {
+        "label": _("LSID"),
+        "validator": idutils.is_lsid
+    },
+    "pmid": {
+        "label": _("PMID"),
+        "validator": idutils.is_pmid
+    },
+    "purl": {
+        "label": _("PURL"),
+        "validator": idutils.is_purl
+    },
+    "upc": {
+        "label": _("UPC"),
+        "validator": always_valid
+    },
+    "url": {
+        "label": _("URL"),
+        "validator": idutils.is_url
+    },
+    "urn": {
+        "label": _("URN"),
+        "validator": idutils.is_urn
+    },
+    "w3id": {
+        "label": _("W3ID"),
+        "validator": always_valid
+    },
+}
+RDM_RECORDS_REFERENCES_SCHEMES = {
+    "isni": {
+        "label": _("ISNI"),
+        "validator": idutils.is_isni
+    },
+    "grid": {
+        "label": _("GRID"),
+        "validator": always_valid
+    },
+    "crossreffunderid": {
+        "label": _("Crossref Funder ID"),
+        "validator": always_valid
+    },
+    "other": {
+        "label": _("Other"),
+        "validator": always_valid
+    }
+}
+RDM_RECORDS_LOCATION_SCHEMES = {
+    "wikidata": {
+        "label": _("Wikidata"),
+        "validator": always_valid
+    },
+    "geonames": {
+        "label": _("GeoNames"),
+        "validator": always_valid
+    }
+}
 RDM_RECORDS_DOI_DATACITE_FORMAT = "{prefix}/{id}"

--- a/invenio_rdm_records/version.py
+++ b/invenio_rdm_records/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_rdm_records.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '0.31.14'
+__version__ = '0.31.15'

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     'Faker>=2.0.3',
     'ftfy>=4.4.3,<5.0.0',
     'invenio-drafts-resources>=0.13.2,<0.14.0',
-    'invenio-vocabularies>=0.7.9,<0.8.0',
+    'invenio-vocabularies>=0.7.11,<0.8.0',
     'pytz>=2020.4',
     'pyyaml>=5.4.0',
 ]

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -139,15 +139,14 @@ def test_datacite43_serializer(running_app, full_record):
                 "givenName": "Lars Holm",
                 "familyName": "Nielsen",
                 "nameIdentifiers": [{
-                    "nameIdentifier": "http://orcid.org/0000-0001-8135-3489",
+                    "nameIdentifier": "0000-0001-8135-3489",
                     "nameIdentifierScheme": "ORCID",
-                    'schemeURI': 'http://orcid.org/'
                 }],
                 "affiliation": [
                     {'name': 'free-text'},
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "https://ror.org/01ggx4157",
+                        "affiliationIdentifier": "01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     }
                 ],
@@ -178,14 +177,13 @@ def test_datacite43_serializer(running_app, full_record):
                 "givenName": "Lars Holm",
                 "familyName": "Nielsen",
                 "nameIdentifiers": [{
-                    "nameIdentifier": "http://orcid.org/0000-0001-8135-3489",
+                    "nameIdentifier": "0000-0001-8135-3489",
                     "nameIdentifierScheme": "ORCID",
-                    'schemeURI': 'http://orcid.org/'
                 }],
                 "affiliation": [
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "https://ror.org/01ggx4157",
+                        "affiliationIdentifier": "01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     }
                 ],
@@ -207,7 +205,7 @@ def test_datacite43_serializer(running_app, full_record):
             },
             {
                 "identifier": "1924MNRAS..84..308E",
-                "identifierType": "bibcode"
+                "identifierType": "Bibcode"
             },
         ],
         "relatedIdentifiers": [
@@ -278,16 +276,16 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "<resource xmlns=\"http://datacite.org/schema/kernel-4\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd\">",  # noqa
         "  <identifier identifierType=\"DOI\">10.5281/inveniordm.1234</identifier>",  # noqa
         "  <alternateIdentifiers>",
-        "    <alternateIdentifier alternateIdentifierType=\"bibcode\">1924MNRAS..84..308E</alternateIdentifier>",  # noqa
+        "    <alternateIdentifier alternateIdentifierType=\"Bibcode\">1924MNRAS..84..308E</alternateIdentifier>",  # noqa
         "  </alternateIdentifiers>",
         "  <creators>",
         "    <creator>",
         "      <creatorName nameType=\"Personal\">Nielsen, Lars Holm</creatorName>",  # noqa
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
-        "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
+        "      <nameIdentifier nameIdentifierScheme=\"ORCID\">0000-0001-8135-3489</nameIdentifier>",  # noqa
         "      <affiliation>free-text</affiliation>",
-        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
+        "      <affiliation affiliationIdentifier=\"01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </creator>",
         "  </creators>",
         "  <titles>",
@@ -305,8 +303,8 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <contributorName nameType=\"Personal\">Nielsen, Lars Holm</contributorName>",  # noqa
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
-        "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
-        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
+        "      <nameIdentifier nameIdentifierScheme=\"ORCID\">0000-0001-8135-3489</nameIdentifier>",  # noqa
+        "      <affiliation affiliationIdentifier=\"01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </contributor>",
         "  </contributors>",
         "  <dates>",

--- a/tests/services/schemas/test_creator_contributor.py
+++ b/tests/services/schemas/test_creator_contributor.py
@@ -209,8 +209,8 @@ def test_creator_invalid_identifiers_scheme(app):
     assert_raises_messages(
         lambda: PersonOrOrganizationSchema().load(invalid_scheme),
         {'identifiers': {0: {
-            '_schema': [
-                'Missing or invalid scheme for identifier 0000-0002-1825-0097.'
+            'scheme': [
+                'Invalid scheme for identifier 0000-0002-1825-0097.'
             ]
         }}}
     )
@@ -230,9 +230,7 @@ def test_creator_invalid_identifiers_orcid(app):
 
     assert_raises_messages(
         lambda: PersonOrOrganizationSchema().load(invalid_orcid_identifier),
-        {'identifiers': {0: {
-            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme orcid.']
-        }}}
+        {'identifiers': {0: {'identifier': ['Invalid ORCID identifier.']}}}
     )
 
 
@@ -248,9 +246,7 @@ def test_creator_invalid_identifiers_ror(app):
 
     assert_raises_messages(
         lambda: PersonOrOrganizationSchema().load(invalid_ror_identifier),
-        {'identifiers': {0: {
-            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme ror.']
-        }}}
+        {'identifiers': {0: {'identifier': ['Invalid ROR identifier.']}}}
     )
 
 

--- a/tests/services/schemas/test_identifier.py
+++ b/tests/services/schemas/test_identifier.py
@@ -7,11 +7,19 @@
 
 """Test identifier schema."""
 
+import idutils
 import pytest
 from marshmallow import ValidationError
 
 from invenio_rdm_records.services.schemas.metadata import IdentifierSchema, \
     MetadataSchema
+
+allowed_schemes = {
+    "doi": {
+        "label": "DOI",
+        "validator": idutils.is_doi
+    }
+}
 
 
 def test_valid_identifier():
@@ -19,7 +27,7 @@ def test_valid_identifier():
         "identifier": "10.5281/rdm.9999999",
         "scheme": "doi"
     }
-    loaded = IdentifierSchema(allowed_schemes=["doi"]).load(valid)
+    loaded = IdentifierSchema(allowed_schemes=allowed_schemes).load(valid)
     assert valid == loaded
 
 
@@ -28,7 +36,9 @@ def test_valid_no_schema():
     valid_identifier = {
         "identifier": "10.5281/rdm.9999999",
     }
-    loaded = IdentifierSchema(allowed_schemes=["doi"]).load(valid_identifier)
+    loaded = IdentifierSchema(
+        allowed_schemes=allowed_schemes
+    ).load(valid_identifier)
     valid_identifier["scheme"] = "doi"
     assert valid_identifier == loaded
 
@@ -38,7 +48,9 @@ def test_invalid_no_identifier():
         "scheme": "doi"
     }
     with pytest.raises(ValidationError):
-        data = IdentifierSchema(allowed_schemes=["doi"]).load(invalid)
+        data = IdentifierSchema(
+            allowed_schemes=allowed_schemes
+        ).load(invalid)
 
 
 def test_valid_empty_list(app, minimal_record):


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-vocabularies/pull/76
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/962
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/735
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/750 (incorporated changes from #756 to make things easier)

![Screenshot 2021-07-19 at 13 30 22](https://user-images.githubusercontent.com/6756943/126153649-16a64ef2-4e4d-4d57-99e2-3df751ac1755.png)
![Screenshot 2021-07-19 at 13 30 06](https://user-images.githubusercontent.com/6756943/126153655-b7bb9b21-5f72-4d18-bec6-f955576976a8.png)