### PR TITLE
Datacite

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -174,37 +174,140 @@ RDM_RECORDS_DOI_DATACITE_TEST_MODE = True
 
 # PID Schemes
 
-RDM_RECORDS_RECORD_PID_SCHEMES = ["doi"]
-RDM_RECORDS_PERSONORG_SCHEMES = ["orcid", "isni", "gnd", "ror"]
-RDM_RECORDS_IDENTIFIERS_SCHEMES = [
-    "ark",
-    "arxiv",
-    ("bibcode", idutils.is_ads),
-    "doi",
-    "ean13",
-    ("eissn", lambda x: True),  # FIXME: is this an issn
-    "handle",
-    ("igsn", lambda x: True),
-    "isbn",
-    "issn",
-    "istc",
-    ("lissn", lambda x: True),
-    "lsid",
-    "pmid",
-    "purl",
-    ("upc", lambda x: True),
-    "url",
-    "urn",
-    ("w3id", lambda x: True),
-]
-RDM_RECORDS_REFERENCES_SCHEMES = [
-    "isni",
-    ("grid", lambda x: True),
-    ("crossreffunderid", lambda x: True),
-    ("other", lambda x: True)
-]
-RDM_RECORDS_LOCATION_SCHEMES = [
-    ("wikidata", lambda x: True),
-    ("geonames", lambda x: True)
-]
+
+def always_valid(identifier):
+    """Gives every identifier as valid."""
+    return True
+
+
+RDM_RECORDS_RECORD_PID_SCHEMES = {
+    "doi": {
+        "label": _("DOI"),
+        "validator": idutils.is_doi
+    }
+}
+RDM_RECORDS_PERSONORG_SCHEMES = {
+    "orcid": {
+        "label": _("ORCID"),
+        "validator": idutils.is_orcid
+    },
+    "isni": {
+        "label": _("ISNI"),
+        "validator": idutils.is_isni
+    },
+    "gnd": {
+        "label": _("GND"),
+        "validator": idutils.is_gnd
+    },
+    "ror": {
+        "label": _("ROR"),
+        "validator": idutils.is_ror
+    },
+}
+RDM_RECORDS_IDENTIFIERS_SCHEMES = {
+    "ark": {
+        "label": _("ARK"),
+        "validator": idutils.is_ark
+    },
+    "arxiv": {
+        "label": _("arXiv"),
+        "validator": idutils.is_arxiv
+    },
+    "bibcode": {
+        "label": _("Bibcode"),
+        "validator": idutils.is_ads
+    },
+    "doi": {
+        "label": _("DOI"),
+        "validator": idutils.is_doi
+    },
+    "ean13": {
+        "label": _("EAN13"),
+        "validator": idutils.is_ean13
+    },
+    "eissn": {
+        "label": _("EISSN"),
+        "validator": idutils.is_issn
+    },
+    "handle": {
+        "label": _("Handle"),
+        "validator": idutils.is_handle
+    },
+    "igsn": {
+        "label": _("IGSN"),
+        "validator": always_valid
+    },
+    "isbn": {
+        "label": _("ISBN"),
+        "validator": idutils.is_isbn
+    },
+    "issn": {
+        "label": _("ISSN"),
+        "validator": idutils.is_issn
+    },
+    "istc": {
+        "label": _("ISTC"),
+        "validator": idutils.is_istc
+    },
+    "lissn": {
+        "label": _("LISSN"),
+        "validator": idutils.is_issn
+    },
+    "lsid": {
+        "label": _("LSID"),
+        "validator": idutils.is_lsid
+    },
+    "pmid": {
+        "label": _("PMID"),
+        "validator": idutils.is_pmid
+    },
+    "purl": {
+        "label": _("PURL"),
+        "validator": idutils.is_purl
+    },
+    "upc": {
+        "label": _("UPC"),
+        "validator": always_valid
+    },
+    "url": {
+        "label": _("URL"),
+        "validator": idutils.is_url
+    },
+    "urn": {
+        "label": _("URN"),
+        "validator": idutils.is_urn
+    },
+    "w3id": {
+        "label": _("W3ID"),
+        "validator": always_valid
+    },
+}
+RDM_RECORDS_REFERENCES_SCHEMES = {
+    "isni": {
+        "label": _("ISNI"),
+        "validator": idutils.is_isni
+    },
+    "grid": {
+        "label": _("GRID"),
+        "validator": always_valid
+    },
+    "crossreffunderid": {
+        "label": _("Crossref Funder ID"),
+        "validator": always_valid
+    },
+    "other": {
+        "label": _("Other"),
+        "validator": always_valid
+    }
+}
+RDM_RECORDS_LOCATION_SCHEMES = {
+    "wikidata": {
+        "label": _("Wikidata"),
+        "validator": always_valid
+    },
+    "geonames": {
+        "label": _("GeoNames"),
+        "validator": always_valid
+    }
+}
 RDM_RECORDS_DOI_DATACITE_FORMAT = "{prefix}/{id}"

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -27,6 +27,11 @@ from invenio_rdm_records.resources.serializers.ui.schema import \
 from ..utils import map_type
 
 
+def get_scheme_label(scheme, labels):
+    """Returns a scheme label."""
+    return current_app.config[labels][scheme]["label"]
+
+
 class PersonOrOrgSchema43(Schema):
     """Creator/contributor common schema for v4."""
 
@@ -48,13 +53,17 @@ class PersonOrOrgSchema43(Schema):
 
             name_id = {
                 "nameIdentifier": value,
-                "nameIdentifierScheme": scheme.upper(),
+                "nameIdentifierScheme": get_scheme_label(
+                    scheme,
+                    "RDM_RECORDS_PERSONORG_SCHEMES"
+                ),
             }
 
             uri = to_url(value, scheme)
             if uri:
                 name_id["nameIdentifier"] = uri
-                name_id["schemeURI"] = LANDING_URLS.get(scheme)
+                name_id["schemeURI"] = LANDING_URLS.get(scheme).format(
+                    scheme="http", pid="")
 
             serialized_identifiers.append(name_id)
 
@@ -96,7 +105,9 @@ class PersonOrOrgSchema43(Schema):
                     scheme = identifier["scheme"]
                     id_value = identifier["identifier"]
                     aff["affiliationIdentifier"] = id_value
-                    aff["affiliationIdentifierScheme"] = scheme.upper()
+                    aff["affiliationIdentifierScheme"] = get_scheme_label(
+                        scheme, "VOCABULARIES_AFFILIATION_SCHEMES"
+                    )
                     uri = to_url(id_value, scheme)
                     if uri:
                         aff["affiliationIdentifier"] = uri
@@ -299,7 +310,9 @@ class DataCite43Schema(Schema):
         for scheme, id_ in pids.items():
             serialized_identifiers.append({
                 "identifier": id_["identifier"],
-                "identifierType": scheme.upper()
+                "identifierType": get_scheme_label(
+                    scheme, "RDM_RECORDS_IDENTIFIERS_SCHEMES"
+                )
             })
 
         # Identifiers field
@@ -307,7 +320,9 @@ class DataCite43Schema(Schema):
         for id_ in identifiers:
             serialized_identifiers.append({
                 "identifier": id_["identifier"],
-                "identifierType": id_["scheme"]
+                "identifierType": get_scheme_label(
+                    id_["scheme"], "RDM_RECORDS_IDENTIFIERS_SCHEMES"
+                )
             })
 
         return serialized_identifiers or missing
@@ -325,7 +340,9 @@ class DataCite43Schema(Schema):
                 relation_type_id
             )
             serialized_identifier = {
-                "relatedIdentifierType": rel_id["scheme"].upper(),
+                "relatedIdentifierType": get_scheme_label(
+                    rel_id["scheme"], "RDM_RECORDS_IDENTIFIERS_SCHEMES"
+                ),
                 "relationType": props.get("datacite", ""),
                 "relatedIdentifier": rel_id["identifier"],
             }

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -12,6 +12,7 @@ from edtf import parse_edtf
 from edtf.parser.grammar import ParseException
 from flask import current_app
 from flask_babelex import lazy_gettext as _
+from idutils import LANDING_URLS, to_url
 from invenio_access.permissions import system_identity
 from invenio_records_resources.proxies import current_service_registry
 from invenio_vocabularies.proxies import current_service as vocabulary_service
@@ -29,14 +30,6 @@ from ..utils import map_type
 class PersonOrOrgSchema43(Schema):
     """Creator/contributor common schema for v4."""
 
-    # PIDS-FIXME: need a more escalable solution for URIs
-    URIS = {
-        "orcid": "http://orcid.org/",
-        "gnd": "http://d-nb.info/",  # PIDS-FIXME: is this correct?
-        "ror": "https://ror.org/",
-        "isni": "https://isni.org",
-    }
-
     name = fields.Str(attribute="person_or_org.name")
     nameType = fields.Str(attribute="person_or_org.type")
     givenName = fields.Str(attribute="person_or_org.given_name")
@@ -52,16 +45,16 @@ class PersonOrOrgSchema43(Schema):
         for identifier in identifiers:
             scheme = identifier["scheme"]
             value = identifier["identifier"]
-            uri = self.URIS.get(scheme)
 
             name_id = {
                 "nameIdentifier": value,
                 "nameIdentifierScheme": scheme.upper(),
             }
 
+            uri = to_url(value, scheme)
             if uri:
-                name_id["nameIdentifier"] = uri + value
-                name_id["schemeURI"] = uri
+                name_id["nameIdentifier"] = uri
+                name_id["schemeURI"] = LANDING_URLS.get(scheme)
 
             serialized_identifiers.append(name_id)
 
@@ -104,9 +97,9 @@ class PersonOrOrgSchema43(Schema):
                     id_value = identifier["identifier"]
                     aff["affiliationIdentifier"] = id_value
                     aff["affiliationIdentifierScheme"] = scheme.upper()
-                    uri = self.URIS.get(scheme)
+                    uri = to_url(id_value, scheme)
                     if uri:
-                        aff["affiliationIdentifier"] = uri + id_value
+                        aff["affiliationIdentifier"] = uri
 
                 serialized_affiliations.append(aff)
 

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -147,7 +147,7 @@ def test_datacite43_serializer(running_app, full_record):
                     {'name': 'free-text'},
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "https://ror.org/01ggx4157",
+                        "affiliationIdentifier": "http://ror.org/01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     }
                 ],
@@ -185,7 +185,7 @@ def test_datacite43_serializer(running_app, full_record):
                 "affiliation": [
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "https://ror.org/01ggx4157",
+                        "affiliationIdentifier": "http://ror.org/01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     }
                 ],
@@ -207,7 +207,7 @@ def test_datacite43_serializer(running_app, full_record):
             },
             {
                 "identifier": "1924MNRAS..84..308E",
-                "identifierType": "bibcode"
+                "identifierType": "Bibcode"
             },
         ],
         "relatedIdentifiers": [
@@ -278,7 +278,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "<resource xmlns=\"http://datacite.org/schema/kernel-4\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.3/metadata.xsd\">",  # noqa
         "  <identifier identifierType=\"DOI\">10.5281/inveniordm.1234</identifier>",  # noqa
         "  <alternateIdentifiers>",
-        "    <alternateIdentifier alternateIdentifierType=\"bibcode\">1924MNRAS..84..308E</alternateIdentifier>",  # noqa
+        "    <alternateIdentifier alternateIdentifierType=\"Bibcode\">1924MNRAS..84..308E</alternateIdentifier>",  # noqa
         "  </alternateIdentifiers>",
         "  <creators>",
         "    <creator>",
@@ -287,7 +287,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <familyName>Nielsen</familyName>",
         "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
         "      <affiliation>free-text</affiliation>",
-        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
+        "      <affiliation affiliationIdentifier=\"http://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </creator>",
         "  </creators>",
         "  <titles>",
@@ -306,7 +306,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
         "      <nameIdentifier nameIdentifierScheme=\"ORCID\">http://orcid.org/0000-0001-8135-3489</nameIdentifier>",  # noqa
-        "      <affiliation affiliationIdentifier=\"https://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
+        "      <affiliation affiliationIdentifier=\"http://ror.org/01ggx4157\" affiliationIdentifierScheme=\"ROR\">CERN</affiliation>",  # noqa
         "    </contributor>",
         "  </contributors>",
         "  <dates>",

--- a/tests/services/schemas/test_creator_contributor.py
+++ b/tests/services/schemas/test_creator_contributor.py
@@ -231,7 +231,7 @@ def test_creator_invalid_identifiers_orcid(app):
     assert_raises_messages(
         lambda: PersonOrOrganizationSchema().load(invalid_orcid_identifier),
         {'identifiers': {0: {
-            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme orcid.']
+            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme ORCID.']
         }}}
     )
 
@@ -249,7 +249,7 @@ def test_creator_invalid_identifiers_ror(app):
     assert_raises_messages(
         lambda: PersonOrOrganizationSchema().load(invalid_ror_identifier),
         {'identifiers': {0: {
-            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme ror.']
+            '_schema': ['Invalid value 9999-9999-9999-9999 for scheme ROR.']
         }}}
     )
 

--- a/tests/services/schemas/test_identifier.py
+++ b/tests/services/schemas/test_identifier.py
@@ -7,11 +7,19 @@
 
 """Test identifier schema."""
 
+import idutils
 import pytest
 from marshmallow import ValidationError
 
 from invenio_rdm_records.services.schemas.metadata import IdentifierSchema, \
     MetadataSchema
+
+allowed_schemes = {
+    "doi": {
+        "label": "DOI",
+        "validator": idutils.is_doi
+    }
+}
 
 
 def test_valid_identifier():
@@ -19,7 +27,7 @@ def test_valid_identifier():
         "identifier": "10.5281/rdm.9999999",
         "scheme": "doi"
     }
-    loaded = IdentifierSchema(allowed_schemes=["doi"]).load(valid)
+    loaded = IdentifierSchema(allowed_schemes=allowed_schemes).load(valid)
     assert valid == loaded
 
 
@@ -28,7 +36,9 @@ def test_valid_no_schema():
     valid_identifier = {
         "identifier": "10.5281/rdm.9999999",
     }
-    loaded = IdentifierSchema(allowed_schemes=["doi"]).load(valid_identifier)
+    loaded = IdentifierSchema(
+        allowed_schemes=allowed_schemes
+    ).load(valid_identifier)
     valid_identifier["scheme"] = "doi"
     assert valid_identifier == loaded
 
@@ -38,7 +48,9 @@ def test_invalid_no_identifier():
         "scheme": "doi"
     }
     with pytest.raises(ValidationError):
-        data = IdentifierSchema(allowed_schemes=["doi"]).load(invalid)
+        data = IdentifierSchema(
+            allowed_schemes=allowed_schemes
+        ).load(invalid)
 
 
 def test_valid_empty_list(app, minimal_record):


### PR DESCRIPTION
- requires #753 
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/750

**Open questions**
- CSL fixes the labelling by using the marshmallow [data_key](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/resources/serializers/csl/schema.py#L47) which I think it is fine since it is only specific identifiers that are allowed.
- UI, is not being touched at the moment although it will be necessary for https://github.com/inveniosoftware/invenio-app-rdm/issues/980
- Dublin Core uses the `scheme` directly e.g. [here](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/resources/serializers/dublincore/schema.py#L68). I am quite sure that:
    - It should use the label
    - In cases like `arXiv` where idutils allows (optionally) the prefix, it might actually get double prefixed

```
>>> idutils.is_arxiv("1904.00007")
<re.Match object; span=(0, 10), match='1904.00007'>
>>> idutils.is_arxiv("arxiv:1904.00007")
<re.Match object; span=(0, 16), match='arxiv:1904.00007'>
```


![Screenshot 2021-07-19 at 15 03 13](https://user-images.githubusercontent.com/6756943/126163897-82b8a5f9-a42b-430d-83b2-8fbfa0fb3f9b.png)
![Screenshot 2021-07-19 at 15 03 08](https://user-images.githubusercontent.com/6756943/126163900-90c6fa3b-a1bf-4e05-bd40-a2178e7e3dcf.png)
