### PR TITLE
tests: add test for lift embargo task

### DIFF
--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -10,12 +10,8 @@
 """Service level tests for Invenio RDM Records."""
 
 from collections import namedtuple
-from datetime import datetime
-from unittest import mock
 
-import arrow
 import pytest
-from dateutil import tz
 from flask_babelex import lazy_gettext as _
 from invenio_pidstore.errors import PIDDoesNotExistError
 from marshmallow import ValidationError
@@ -359,31 +355,6 @@ def test_draft_w_languages_creation(running_app, es_clear, minimal_record):
 #
 # Embargo lift
 #
-@pytest.fixture()
-@mock.patch('arrow.utcnow')
-def embargoed_record(mock_arrow, running_app, minimal_record):
-
-    superuser_identity = running_app.superuser_identity
-    service = current_rdm_records.records_service
-
-    # Add embargo to record
-    minimal_record["access"]["files"] = 'restricted'
-    minimal_record["access"]["status"] = 'embargoed'
-    minimal_record["access"]["embargo"] = dict(
-        active=True, until='2020-06-01', reason=None
-    )
-
-    # We need to set the current date in the past to pass the validations
-    mock_arrow.return_value = arrow.get(datetime(1954, 9, 29), tz.gettz('UTC'))
-    draft = service.create(superuser_identity, minimal_record)
-    record = service.publish(id_=draft.id, identity=superuser_identity)
-
-    # Recover current date
-    mock_arrow.return_value = arrow.get(datetime.utcnow())
-
-    return record
-
-
 def test_embargo_lift_without_draft(embargoed_record, running_app, es_clear):
     record = embargoed_record
     service = current_rdm_records.records_service

--- a/tests/services/test_service_tasks.py
+++ b/tests/services/test_service_tasks.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Service tasks tests."""
+
+import pytest
+
+from invenio_rdm_records.proxies import current_rdm_records
+from invenio_rdm_records.records.api import RDMDraft
+from invenio_rdm_records.services.tasks import update_expired_embargos
+
+
+def test_embargo_lift_without_draft(embargoed_record, running_app, es_clear):
+    update_expired_embargos()
+
+    service = current_rdm_records.records_service
+    record_lifted = service.record_cls.pid.resolve(embargoed_record['id'])
+    assert record_lifted.access.embargo.active is False
+    assert record_lifted.access.protection.files == 'public'
+    assert record_lifted.access.protection.record == 'public'
+    assert record_lifted.access.status.value == 'metadata-only'
+
+
+def test_embargo_lift_with_draft(
+        embargoed_record, es_clear, superuser_identity):
+    record = embargoed_record
+    service = current_rdm_records.records_service
+
+    # Edit a draft
+    ongoing_draft = service.edit(
+        id_=record['id'], identity=superuser_identity)
+    RDMDraft.index.refresh()
+
+    update_expired_embargos()
+
+    record_lifted = service.record_cls.pid.resolve(record['id'])
+    draft_lifted = service.draft_cls.pid.resolve(ongoing_draft['id'])
+
+    assert record_lifted.access.embargo.active is False
+    assert record_lifted.access.protection.files == 'public'
+    assert record_lifted.access.protection.record == 'public'
+
+    assert draft_lifted.access.embargo.active is False
+    assert draft_lifted.access.protection.files == 'public'
+    assert draft_lifted.access.protection.record == 'public'
+
+
+def test_embargo_lift_with_updated_draft(
+        embargoed_record, superuser_identity, es_clear):
+    record = embargoed_record
+    service = current_rdm_records.records_service
+
+    # This draft simulates an existing one while lifting the record
+    draft = service.edit(id_=record['id'], identity=superuser_identity).data
+
+    # Change record's title and access field to be restricted
+    draft["metadata"]["title"] = 'Record modified by the user'
+    draft["access"]["status"] = 'restricted'
+    draft["access"]["embargo"] = dict(
+        active=False, until=None, reason=None
+    )
+    # Update the ongoing draft with the new data simulating the user's input
+    ongoing_draft = service.update_draft(
+        id_=draft['id'], identity=superuser_identity, data=draft)
+    RDMDraft.index.refresh()
+
+    update_expired_embargos()
+
+    record_lifted = service.record_cls.pid.resolve(record['id'])
+    draft_lifted = service.draft_cls.pid.resolve(ongoing_draft['id'])
+
+    assert record_lifted.access.embargo.active is False
+    assert record_lifted.access.protection.files == 'public'
+    assert record_lifted.access.protection.record == 'public'
+
+    assert draft_lifted.access.embargo.active is False
+    assert draft_lifted.access.protection.files == 'restricted'
+    assert draft_lifted.access.protection.record == 'public'


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/758

Tests are sometimes failing sometimes not. It seems something does not get timely propagated but there is a `db.session.commit` so it should not be the issue.