### PR TITLE
i18n: adds missing manifest extention

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,7 +27,7 @@ recursive-include examples *.sh
 recursive-include invenio_rdm_records *.html *.js *.less
 recursive-include invenio_rdm_records *.json *.csv
 recursive-include invenio_rdm_records *.png *.svg
-recursive-include invenio_rdm_records *.po *.pot
+recursive-include invenio_rdm_records *.po *.pot *.mo
 recursive-include invenio_rdm_records *.yaml
 recursive-include tests *.py *.csv *.json *.yaml
 

--- a/invenio_rdm_records/translations/en/LC_MESSAGES/messages.po
+++ b/invenio_rdm_records/translations/en/LC_MESSAGES/messages.po
@@ -1,30 +1,227 @@
-# English translations for invenio-rdm-records.
-# Copyright (C) 2019 CERN
+# Translations template for invenio-rdm-records.
+# Copyright (C) 2021 CERN
+# Copyright (C) 2021 Graz University of Technology
 # This file is distributed under the same license as the invenio-rdm-records
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
-#
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+# 
 msgid ""
 msgstr ""
-"Project-Id-Version: invenio-rdm-records 1.0.0a1\n"
+"Project-Id-Version: invenio-rdm-records 0.31.8\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2019-10-08 13:13+0200\n"
-"PO-Revision-Date: 2019-10-08 13:13+0200\n"
+"POT-Creation-Date: 2021-07-12 15:34+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language: en\n"
-"Language-Team: en <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.7.0\n"
+"Generated-By: Babel 2.9.1\n"
 
-#: invenio_rdm_records/views.py:30
-msgid "Invenio-RDM-Records"
-msgstr ""
+#: invenio_rdm_records/ext.py:49
+msgid "Your shared link has expired."
+msgstr "Your shared link has expired."
 
-#: invenio_rdm_records/templates/invenio_rdm_records/index.html:12
+#: invenio_rdm_records/resources/serializers/datacite/schema.py:283
+msgid "Invalid publication date value."
+msgstr "Invalid publication date value."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:35
+#: invenio_rdm_records/services/config.py:67
+msgid "Open"
+msgstr "Open"
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:36
+#: invenio_rdm_records/services/config.py:68
+msgid "Embargoed"
+msgstr "Embargoed"
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:37
+#: invenio_rdm_records/services/config.py:69
+msgid "Restricted"
+msgstr "Restricted"
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:38
+#: invenio_rdm_records/services/config.py:70
+msgid "Metadata-only"
+msgstr "Metadata-only"
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:65
+msgid "The record and files are publicly accessible."
+msgstr "The record and files are publicly accessible."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:67
+msgid "No files are available for this record."
+msgstr "No files are available for this record."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:74
 #, python-format
-msgid "Welcome to %(module_name)s"
-msgstr ""
+msgid "The record and files will be made publicly available on %(date)s."
+msgstr "The record and files will be made publicly available on %(date)s."
 
+#: invenio_rdm_records/resources/serializers/ui/fields.py:77
+msgid "The record and files are restricted to users with access."
+msgstr "The record and files are restricted to users with access."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:83
+#, python-format
+msgid "The record will be made publicly available on %(date)s."
+msgstr "The record will be made publicly available on %(date)s."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:86
+msgid "The record is restricted to users with access."
+msgstr "The record is restricted to users with access."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:91
+#, python-format
+msgid "The files will be made publicly available on %(date)s."
+msgstr "The files will be made publicly available on %(date)s."
+
+#: invenio_rdm_records/resources/serializers/ui/fields.py:94
+msgid ""
+"The record is publicly accessible, but files are restricted to users with "
+"access."
+msgstr ""
+"The record is publicly accessible, but files are restricted to users with "
+"access."
+
+#: invenio_rdm_records/services/config.py:47
+msgid "Resource types"
+msgstr "Resource types"
+
+#: invenio_rdm_records/services/config.py:53
+msgid "Languages"
+msgstr "Languages"
+
+#: invenio_rdm_records/services/config.py:59
+msgid "Subjects"
+msgstr "Subjects"
+
+#: invenio_rdm_records/services/config.py:65
+msgid "Access status"
+msgstr "Access status"
+
+#: invenio_rdm_records/services/config.py:76
+msgid "State"
+msgstr "State"
+
+#: invenio_rdm_records/services/config.py:77
+msgid "Published"
+msgstr "Published"
+
+#: invenio_rdm_records/services/config.py:77
+msgid "Unpublished"
+msgstr "Unpublished"
+
+#: invenio_rdm_records/services/services.py:77
+msgid "Unknown PID provider for {scheme}"
+msgstr "Unknown PID provider for {scheme}"
+
+#: invenio_rdm_records/services/services.py:95
+msgid "{client_name} not supported for PID {scheme}"
+msgstr "{client_name} not supported for PID {scheme}"
+
+#: invenio_rdm_records/services/services.py:182
+msgid "No registered PID found for type {pid_type}"
+msgstr "No registered PID found for type {pid_type}"
+
+#: invenio_rdm_records/services/components/pids.py:31
+msgid "Provider {provider_name} not found for PID type {scheme}"
+msgstr "Provider {provider_name} not found for PID type {scheme}"
+
+#: invenio_rdm_records/services/pids/providers/base.py:214
+msgid "{pid_type}:{identifier} is already registered to another record"
+msgstr "{pid_type}:{identifier} is already registered to another record"
+
+#: invenio_rdm_records/services/schemas/__init__.py:98
+msgid "Invalid value for scheme {scheme}"
+msgstr "Invalid value for scheme {scheme}"
+
+#: invenio_rdm_records/services/schemas/access.py:40
+msgid "Embargo end date must be set to a future date if active is True."
+msgstr "Embargo end date must be set to a future date if active is True."
+
+#: invenio_rdm_records/services/schemas/access.py:50
+msgid "Embargo end date must be unset or in the past if active is False."
+msgstr "Embargo end date must be unset or in the past if active is False."
+
+#: invenio_rdm_records/services/schemas/access.py:68
+msgid "'{field_name}' must be either 'public' or 'restricted'"
+msgstr "'{field_name}' must be either 'public' or 'restricted'"
+
+#: invenio_rdm_records/services/schemas/metadata.py:51
+msgid "An existing id or a free text name must be present"
+msgstr "An existing id or a free text name must be present"
+
+#: invenio_rdm_records/services/schemas/metadata.py:75
+msgid "An existing id or a free text subject must be present"
+msgstr "An existing id or a free text subject must be present"
+
+#: invenio_rdm_records/services/schemas/metadata.py:92
+#: invenio_rdm_records/services/schemas/metadata.py:98
+msgid "Invalid value. Choose one of {NAMES}."
+msgstr "Invalid value. Choose one of {NAMES}."
+
+#: invenio_rdm_records/services/schemas/metadata.py:120
+msgid "Family name must be filled."
+msgstr "Family name must be filled."
+
+#: invenio_rdm_records/services/schemas/metadata.py:127
+#: invenio_rdm_records/services/schemas/metadata.py:265
+#: invenio_rdm_records/services/schemas/metadata.py:279
+#: invenio_rdm_records/services/schemas/metadata.py:283
+msgid "Name cannot be blank."
+msgstr "Name cannot be blank."
+
+#: invenio_rdm_records/services/schemas/metadata.py:210
+msgid "Not a valid URL."
+msgstr "Not a valid URL."
+
+#: invenio_rdm_records/services/schemas/metadata.py:300
+msgid "At least award or funder shold be present."
+msgstr "At least award or funder shold be present."
+
+#: invenio_rdm_records/services/schemas/metadata.py:344
+msgid ""
+"At least one of ['geometry', 'place',                 'identifiers', "
+"'description'] shold be present."
+msgstr ""
+"At least one of ['geometry', 'place',                 'identifiers', "
+"'description'] shold be present."
+
+#: invenio_rdm_records/services/schemas/metadata.py:372
+msgid "Missing data for required field."
+msgstr "Missing data for required field."
+
+#: invenio_rdm_records/services/schemas/metadata.py:389
+msgid "Size cannot be a blank string."
+msgstr "Size cannot be a blank string."
+
+#: invenio_rdm_records/services/schemas/metadata.py:391
+msgid "Format cannot be a blank string."
+msgstr "Format cannot be a blank string."
+
+#: invenio_rdm_records/services/secret_links/service.py:61
+#: invenio_rdm_records/services/secret_links/service.py:93
+msgid "Expiration date must be set to the future"
+msgstr "Expiration date must be set to the future"
+
+#: invenio_rdm_records/services/secret_links/service.py:87
+msgid "Cannot postpone expiration of links"
+msgstr "Cannot postpone expiration of links"
+
+#: invenio_rdm_records/services/secret_links/service.py:121
+msgid "An access permission level is required"
+msgstr "An access permission level is required"
+
+#: invenio_rdm_records/services/secret_links/service.py:134
+msgid "Invalid access permission level."
+msgstr "Invalid access permission level."
+
+#: invenio_rdm_records/vocabularies/resource_type.py:52
+msgid "Invalid value."
+msgstr "Invalid value."
+
+#: invenio_rdm_records/vocabularies/vocabulary.py:107
+msgid "Invalid value. Choose one of {choices}."
+msgstr "Invalid value. Choose one of {choices}."


### PR DESCRIPTION
Reason of these changes - translations were not loaded after a pip install of the latest release.
* i18n: adds default english po file
* adds missing manifest extension for `.mo` files