### PR TITLE
serializers: csl should validate existance of resource_type

### DIFF
--- a/invenio_rdm_records/resources/serializers/csl/schema.py
+++ b/invenio_rdm_records/resources/serializers/csl/schema.py
@@ -67,7 +67,11 @@ class CSLJSONSchema(Schema):
 
     def get_type(self, obj):
         """Get resource type."""
-        resource_type = obj["metadata"]["resource_type"]
+        resource_type = obj["metadata"].get(
+            "resource_type",
+            {"id": "publication-article"}
+        )
+
         resource_type_record = self._read_resource_type(resource_type["id"])
         props = resource_type_record["props"]
         return props.get("csl", "article")  # article is CSL "Other"


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/729

This PR makes the REST API return a validation error for the citation, as it should since the resource type is mandatory for CiteProc to work.

It is up to app-rdm to display one message or another.