### PR TITLE
vocabularies: add tags for software and data licenses

### DIFF
--- a/invenio_rdm_records/fixtures/data/vocabularies/licenses.csv
+++ b/invenio_rdm_records/fixtures/data/vocabularies/licenses.csv
@@ -1,156 +1,156 @@
 id;title__en;description__en;icon;tags;props__url;props__scheme;props__osi_approved
-0bsd;BSD Zero Clause License;;;all;http://landley.net/toybox/license.html;spdx;y
-aal;Attribution Assurance License;;;all;https://opensource.org/licenses/attribution;spdx;y
+0bsd;BSD Zero Clause License;;;all,software;http://landley.net/toybox/license.html;spdx;y
+aal;Attribution Assurance License;;;all,software;https://opensource.org/licenses/attribution;spdx;y
 adsl;Amazon Digital Services License;;;all;https://fedoraproject.org/wiki/Licensing/AmazonDigitalServicesLicense;spdx;
-afl-1.1;Academic Free License v1.1;;;all;http://opensource.linux-mirror.org/licenses/afl-1.1.txt;spdx;y
-afl-1.2;Academic Free License v1.2;;;all;http://opensource.linux-mirror.org/licenses/afl-1.2.txt;spdx;y
-afl-2.0;Academic Free License v2.0;;;all;http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt;spdx;y
-afl-2.1;Academic Free License v2.1;;;all;http://opensource.linux-mirror.org/licenses/afl-2.1.txt;spdx;y
-afl-3.0;Academic Free License v3.0;;;all;http://www.rosenlaw.com/AFL3.0.htm;spdx;y
-agpl-1.0-only;Affero General Public License v1.0 only;;;all;http://www.affero.org/oagpl.html;spdx;
-agpl-1.0-or-later;Affero General Public License v1.0 or later;;;all;http://www.affero.org/oagpl.html;spdx;
-agpl-3.0-only;GNU Affero General Public License v3.0 only;;;all;https://www.gnu.org/licenses/agpl.txt;spdx;y
-agpl-3.0-or-later;GNU Affero General Public License v3.0 or later;;;all;https://www.gnu.org/licenses/agpl.txt;spdx;y
+afl-1.1;Academic Free License v1.1;;;all,software;http://opensource.linux-mirror.org/licenses/afl-1.1.txt;spdx;y
+afl-1.2;Academic Free License v1.2;;;all,software;http://opensource.linux-mirror.org/licenses/afl-1.2.txt;spdx;y
+afl-2.0;Academic Free License v2.0;;;all,software;http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt;spdx;y
+afl-2.1;Academic Free License v2.1;;;all,software;http://opensource.linux-mirror.org/licenses/afl-2.1.txt;spdx;y
+afl-3.0;Academic Free License v3.0;;;all,software;http://www.rosenlaw.com/AFL3.0.htm;spdx;y
+agpl-1.0-only;Affero General Public License v1.0 only;;;all,software;http://www.affero.org/oagpl.html;spdx;
+agpl-1.0-or-later;Affero General Public License v1.0 or later;;;all,software;http://www.affero.org/oagpl.html;spdx;
+agpl-3.0-only;GNU Affero General Public License v3.0 only;;;all,software;https://www.gnu.org/licenses/agpl.txt;spdx;y
+agpl-3.0-or-later;GNU Affero General Public License v3.0 or later;;;all,software;https://www.gnu.org/licenses/agpl.txt;spdx;y
 amdplpa;AMD's plpa_map.c License;;;all;https://fedoraproject.org/wiki/Licensing/AMD_plpa_map_License;spdx;
-aml;Apple MIT License;;;all;https://fedoraproject.org/wiki/Licensing/Apple_MIT_License;spdx;
+aml;Apple MIT License;;;all,software;https://fedoraproject.org/wiki/Licensing/Apple_MIT_License;spdx;
 ampas;Academy of Motion Picture Arts and Sciences BSD;;;all;https://fedoraproject.org/wiki/Licensing/BSD#AMPASBSD;spdx;
-antlr-pd;ANTLR Software Rights Notice;;;all;http://www.antlr2.org/license.html;spdx;
-antlr-pd-fallback;ANTLR Software Rights Notice with license fallback;;;all;http://www.antlr2.org/license.html;spdx;
+antlr-pd;ANTLR Software Rights Notice;;;all,software;http://www.antlr2.org/license.html;spdx;
+antlr-pd-fallback;ANTLR Software Rights Notice with license fallback;;;all,software;http://www.antlr2.org/license.html;spdx;
 apafml;Adobe Postscript AFM License;;;all;https://fedoraproject.org/wiki/Licensing/AdobePostscriptAFM;spdx;
-apl-1.0;Adaptive Public License 1.0;;;all;https://opensource.org/licenses/APL-1.0;spdx;y
-apsl-1.0;Apple Public Source License 1.0;;;all;https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0;spdx;y
-apsl-1.1;Apple Public Source License 1.1;;;all;http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE;spdx;y
-apsl-1.2;Apple Public Source License 1.2;;;all;http://www.samurajdata.se/opensource/mirror/licenses/apsl.php;spdx;y
-apsl-2.0;Apple Public Source License 2.0;;;all;http://www.opensource.apple.com/license/apsl/;spdx;y
+apl-1.0;Adaptive Public License 1.0;;;all,software;https://opensource.org/licenses/APL-1.0;spdx;y
+apsl-1.0;Apple Public Source License 1.0;;;all,software;https://fedoraproject.org/wiki/Licensing/Apple_Public_Source_License_1.0;spdx;y
+apsl-1.1;Apple Public Source License 1.1;;;all,software;http://www.opensource.apple.com/source/IOSerialFamily/IOSerialFamily-7/APPLE_LICENSE;spdx;y
+apsl-1.2;Apple Public Source License 1.2;;;all,software;http://www.samurajdata.se/opensource/mirror/licenses/apsl.php;spdx;y
+apsl-2.0;Apple Public Source License 2.0;;;all,software;http://www.opensource.apple.com/license/apsl/;spdx;y
 abstyles;Abstyles License;;;all;https://fedoraproject.org/wiki/Licensing/Abstyles;spdx;
-adobe-2006;Adobe Systems Incorporated Source Code License Agreement;;;all;https://fedoraproject.org/wiki/Licensing/AdobeLicense;spdx;
+adobe-2006;Adobe Systems Incorporated Source Code License Agreement;;;all,software;https://fedoraproject.org/wiki/Licensing/AdobeLicense;spdx;
 adobe-glyph;Adobe Glyph List License;;;all;https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph;spdx;
 afmparse;Afmparse License;;;all;https://fedoraproject.org/wiki/Licensing/Afmparse;spdx;
 aladdin;Aladdin Free Public License;;;all;http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm;spdx;
-apache-1.0;Apache License 1.0;;;all;http://www.apache.org/licenses/LICENSE-1.0;spdx;
-apache-1.1;Apache License 1.1;;;all;http://apache.org/licenses/LICENSE-1.1;spdx;y
-apache-2.0;Apache License 2.0;A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.;;recommended,all;http://www.apache.org/licenses/LICENSE-2.0;spdx;y
-artistic-1.0;Artistic License 1.0;;;all;https://opensource.org/licenses/Artistic-1.0;spdx;y
-artistic-1.0-perl;Artistic License 1.0 (Perl);;;all;http://dev.perl.org/licenses/artistic.html;spdx;y
-artistic-1.0-cl8;Artistic License 1.0 w/clause 8;;;all;https://opensource.org/licenses/Artistic-1.0;spdx;y
-artistic-2.0;Artistic License 2.0;;;all;http://www.perlfoundation.org/artistic_license_2_0;spdx;y
-bsd-1-clause;BSD 1-Clause License;;;all;https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823;spdx;y
-bsd-2-clause;"BSD 2-Clause ""Simplified"" License";;;all;https://opensource.org/licenses/BSD-2-Clause;spdx;y
-bsd-2-clause-patent;BSD-2-Clause Plus Patent License;;;all;https://opensource.org/licenses/BSDplusPatent;spdx;y
-bsd-2-clause-views;BSD 2-Clause with views sentence;;;all;http://www.freebsd.org/copyright/freebsd-license.html;spdx;
-bsd-3-clause;"BSD 3-Clause ""New"" or ""Revised"" License";;;all;https://opensource.org/licenses/BSD-3-Clause;spdx;y
-bsd-3-clause-attribution;BSD with attribution;;;all;https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution;spdx;
-bsd-3-clause-clear;BSD 3-Clause Clear License;;;all;http://labs.metacarta.com/license-explanation.html#license;spdx;
-bsd-3-clause-lbnl;Lawrence Berkeley National Labs BSD variant license;;;all;https://fedoraproject.org/wiki/Licensing/LBNLBSD;spdx;y
-bsd-3-clause-no-nuclear-license;BSD 3-Clause No Nuclear License;;;all;http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam=1467140197_43d516ce1776bd08a58235a7785be1cc;spdx;
-bsd-3-clause-no-nuclear-license-2014;BSD 3-Clause No Nuclear License 2014;;;all;https://java.net/projects/javaeetutorial/pages/BerkeleyLicense;spdx;
-bsd-3-clause-no-nuclear-warranty;BSD 3-Clause No Nuclear Warranty;;;all;"https://jogamp.org/git/?p=gluegen.git;a=blob_plain;f=LICENSE.txt";spdx;
-bsd-3-clause-open-mpi;BSD 3-Clause Open MPI variant;;;all;https://www.open-mpi.org/community/license.php;spdx;
-bsd-4-clause;"BSD 4-Clause ""Original"" or ""Old"" License";;;all;http://directory.fsf.org/wiki/License:BSD_4Clause;spdx;
-bsd-4-clause-uc;BSD-4-Clause (University of California-Specific);;;all;http://www.freebsd.org/copyright/license.html;spdx;
-bsd-protection;BSD Protection License;;;all;https://fedoraproject.org/wiki/Licensing/BSD_Protection_License;spdx;
-bsd-source-code;BSD Source Code Attribution;;;all;https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt;spdx;
-bsl-1.0;Boost Software License 1.0;;;all;http://www.boost.org/LICENSE_1_0.txt;spdx;y
+apache-1.0;Apache License 1.0;;;all,software;http://www.apache.org/licenses/LICENSE-1.0;spdx;
+apache-1.1;Apache License 1.1;;;all,software;http://apache.org/licenses/LICENSE-1.1;spdx;y
+apache-2.0;Apache License 2.0;A permissive license whose main conditions require preservation of copyright and license notices. Contributors provide an express grant of patent rights. Licensed works, modifications, and larger works may be distributed under different terms and without source code.;;recommended,all,software;http://www.apache.org/licenses/LICENSE-2.0;spdx;y
+artistic-1.0;Artistic License 1.0;;;all,software;https://opensource.org/licenses/Artistic-1.0;spdx;y
+artistic-1.0-perl;Artistic License 1.0 (Perl);;;all,software;http://dev.perl.org/licenses/artistic.html;spdx;y
+artistic-1.0-cl8;Artistic License 1.0 w/clause 8;;;all,software;https://opensource.org/licenses/Artistic-1.0;spdx;y
+artistic-2.0;Artistic License 2.0;;;all,software;http://www.perlfoundation.org/artistic_license_2_0;spdx;y
+bsd-1-clause;BSD 1-Clause License;;;all,software;https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823;spdx;y
+bsd-2-clause;"BSD 2-Clause ""Simplified"" License";;;all,software;https://opensource.org/licenses/BSD-2-Clause;spdx;y
+bsd-2-clause-patent;BSD-2-Clause Plus Patent License;;;all,software;https://opensource.org/licenses/BSDplusPatent;spdx;y
+bsd-2-clause-views;BSD 2-Clause with views sentence;;;all,software;http://www.freebsd.org/copyright/freebsd-license.html;spdx;
+bsd-3-clause;"BSD 3-Clause ""New"" or ""Revised"" License";;;all,software;https://opensource.org/licenses/BSD-3-Clause;spdx;y
+bsd-3-clause-attribution;BSD with attribution;;;all,software;https://fedoraproject.org/wiki/Licensing/BSD_with_Attribution;spdx;
+bsd-3-clause-clear;BSD 3-Clause Clear License;;;all,software;http://labs.metacarta.com/license-explanation.html#license;spdx;
+bsd-3-clause-lbnl;Lawrence Berkeley National Labs BSD variant license;;;all,software;https://fedoraproject.org/wiki/Licensing/LBNLBSD;spdx;y
+bsd-3-clause-no-nuclear-license;BSD 3-Clause No Nuclear License;;;all,software;http://download.oracle.com/otn-pub/java/licenses/bsd.txt?AuthParam=1467140197_43d516ce1776bd08a58235a7785be1cc;spdx;
+bsd-3-clause-no-nuclear-license-2014;BSD 3-Clause No Nuclear License 2014;;;all,software;https://java.net/projects/javaeetutorial/pages/BerkeleyLicense;spdx;
+bsd-3-clause-no-nuclear-warranty;BSD 3-Clause No Nuclear Warranty;;;all,software;"https://jogamp.org/git/?p=gluegen.git;a=blob_plain;f=LICENSE.txt";spdx;
+bsd-3-clause-open-mpi;BSD 3-Clause Open MPI variant;;;all,software;https://www.open-mpi.org/community/license.php;spdx;
+bsd-4-clause;"BSD 4-Clause ""Original"" or ""Old"" License";;;all,software;http://directory.fsf.org/wiki/License:BSD_4Clause;spdx;
+bsd-4-clause-uc;BSD-4-Clause (University of California-Specific);;;all,software;http://www.freebsd.org/copyright/license.html;spdx;
+bsd-protection;BSD Protection License;;;all,software;https://fedoraproject.org/wiki/Licensing/BSD_Protection_License;spdx;
+bsd-source-code;BSD Source Code Attribution;;;all,software;https://github.com/robbiehanson/CocoaHTTPServer/blob/master/LICENSE.txt;spdx;
+bsl-1.0;Boost Software License 1.0;;;all,software;http://www.boost.org/LICENSE_1_0.txt;spdx;y
 busl-1.1;Business Source License 1.1;;;all;https://mariadb.com/bsl11/;spdx;
 bahyph;Bahyph License;;;all;https://fedoraproject.org/wiki/Licensing/Bahyph;spdx;
 barr;Barr License;;;all;https://fedoraproject.org/wiki/Licensing/Barr;spdx;
 beerware;Beerware License;;;all;https://fedoraproject.org/wiki/Licensing/Beerware;spdx;
-bittorrent-1.0;BitTorrent Open Source License v1.0;;;all;http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s;spdx;
-bittorrent-1.1;BitTorrent Open Source License v1.1;;;all;http://directory.fsf.org/wiki/License:BitTorrentOSL1.1;spdx;
+bittorrent-1.0;BitTorrent Open Source License v1.0;;;all,software;http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s;spdx;
+bittorrent-1.1;BitTorrent Open Source License v1.1;;;all,software;http://directory.fsf.org/wiki/License:BitTorrentOSL1.1;spdx;
 blueoak-1.0.0;Blue Oak Model License 1.0.0;;;all;https://blueoakcouncil.org/license/1.0.0;spdx;
 borceux;Borceux license;;;all;https://fedoraproject.org/wiki/Licensing/Borceux;spdx;
 cal-1.0;Cryptographic Autonomy License 1.0;;;all;http://cryptographicautonomylicense.com/license-text.html;spdx;y
 cal-1.0-combined-work-exception;Cryptographic Autonomy License 1.0 (Combined Work Exception);;;all;http://cryptographicautonomylicense.com/license-text.html;spdx;y
-catosl-1.1;Computer Associates Trusted Open Source License 1.1;;;all;https://opensource.org/licenses/CATOSL-1.1;spdx;y
-cc-by-1.0;Creative Commons Attribution 1.0 Generic;;;all;https://creativecommons.org/licenses/by/1.0/legalcode;spdx;
-cc-by-2.0;Creative Commons Attribution 2.0 Generic;;;all;https://creativecommons.org/licenses/by/2.0/legalcode;spdx;
-cc-by-2.5;Creative Commons Attribution 2.5 Generic;;;all;https://creativecommons.org/licenses/by/2.5/legalcode;spdx;
-cc-by-3.0;Creative Commons Attribution 3.0 Unported;;;all;https://creativecommons.org/licenses/by/3.0/legalcode;spdx;
-cc-by-3.0-at;Creative Commons Attribution 3.0 Austria;;;all;https://creativecommons.org/licenses/by/3.0/at/legalcode;spdx;
-cc-by-3.0-us;Creative Commons Attribution 3.0 United States;;;all;https://creativecommons.org/licenses/by/3.0/us/legalcode;spdx;
-cc-by-4.0;Creative Commons Attribution 4.0 International;The Creative Commons Attribution license allows re-distribution and re-use of a licensed work on the condition that the creator is appropriately credited.;;recommended,all;https://creativecommons.org/licenses/by/4.0/legalcode;spdx;
-cc-by-nc-1.0;Creative Commons Attribution Non Commercial 1.0 Generic;;;all;https://creativecommons.org/licenses/by-nc/1.0/legalcode;spdx;
-cc-by-nc-2.0;Creative Commons Attribution Non Commercial 2.0 Generic;;;all;https://creativecommons.org/licenses/by-nc/2.0/legalcode;spdx;
-cc-by-nc-2.5;Creative Commons Attribution Non Commercial 2.5 Generic;;;all;https://creativecommons.org/licenses/by-nc/2.5/legalcode;spdx;
-cc-by-nc-3.0;Creative Commons Attribution Non Commercial 3.0 Unported;;;all;https://creativecommons.org/licenses/by-nc/3.0/legalcode;spdx;
-cc-by-nc-4.0;Creative Commons Attribution Non Commercial 4.0 International;;;all;https://creativecommons.org/licenses/by-nc/4.0/legalcode;spdx;
-cc-by-nc-nd-1.0;Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic;;;all;https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode;spdx;
-cc-by-nc-nd-2.0;Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic;;;all;https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode;spdx;
-cc-by-nc-nd-2.5;Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic;;;all;https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode;spdx;
-cc-by-nc-nd-3.0;Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported;;;all;https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode;spdx;
-cc-by-nc-nd-3.0-igo;Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO;;;all;https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode;spdx;
-cc-by-nc-nd-4.0;Creative Commons Attribution Non Commercial No Derivatives 4.0 International;;;all;https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode;spdx;
-cc-by-nc-sa-1.0;Creative Commons Attribution Non Commercial Share Alike 1.0 Generic;;;all;https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode;spdx;
-cc-by-nc-sa-2.0;Creative Commons Attribution Non Commercial Share Alike 2.0 Generic;;;all;https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode;spdx;
-cc-by-nc-sa-2.5;Creative Commons Attribution Non Commercial Share Alike 2.5 Generic;;;all;https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode;spdx;
-cc-by-nc-sa-3.0;Creative Commons Attribution Non Commercial Share Alike 3.0 Unported;;;all;https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode;spdx;
-cc-by-nc-sa-4.0;Creative Commons Attribution Non Commercial Share Alike 4.0 International;;;all;https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode;spdx;
-cc-by-nd-1.0;Creative Commons Attribution No Derivatives 1.0 Generic;;;all;https://creativecommons.org/licenses/by-nd/1.0/legalcode;spdx;
-cc-by-nd-2.0;Creative Commons Attribution No Derivatives 2.0 Generic;;;all;https://creativecommons.org/licenses/by-nd/2.0/legalcode;spdx;
-cc-by-nd-2.5;Creative Commons Attribution No Derivatives 2.5 Generic;;;all;https://creativecommons.org/licenses/by-nd/2.5/legalcode;spdx;
-cc-by-nd-3.0;Creative Commons Attribution No Derivatives 3.0 Unported;;;all;https://creativecommons.org/licenses/by-nd/3.0/legalcode;spdx;
-cc-by-nd-4.0;Creative Commons Attribution No Derivatives 4.0 International;;;all;https://creativecommons.org/licenses/by-nd/4.0/legalcode;spdx;
-cc-by-sa-1.0;Creative Commons Attribution Share Alike 1.0 Generic;;;all;https://creativecommons.org/licenses/by-sa/1.0/legalcode;spdx;
-cc-by-sa-2.0;Creative Commons Attribution Share Alike 2.0 Generic;;;all;https://creativecommons.org/licenses/by-sa/2.0/legalcode;spdx;
-cc-by-sa-2.0-uk;Creative Commons Attribution Share Alike 2.0 England and Wales;;;all;https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode;spdx;
-cc-by-sa-2.5;Creative Commons Attribution Share Alike 2.5 Generic;;;all;https://creativecommons.org/licenses/by-sa/2.5/legalcode;spdx;
-cc-by-sa-3.0;Creative Commons Attribution Share Alike 3.0 Unported;;;all;https://creativecommons.org/licenses/by-sa/3.0/legalcode;spdx;
-cc-by-sa-3.0-at;Creative Commons Attribution-Share Alike 3.0 Austria;;;all;https://creativecommons.org/licenses/by-sa/3.0/at/legalcode;spdx;
-cc-by-sa-4.0;Creative Commons Attribution Share Alike 4.0 International;Permits almost any use subject to providing credit and license notice. Frequently used for media assets and educational materials. The most common license for Open Access scientific publications. Not recommended for software.;;recommended,all;https://creativecommons.org/licenses/by-sa/4.0/legalcode;spdx;
+catosl-1.1;Computer Associates Trusted Open Source License 1.1;;;all,software;https://opensource.org/licenses/CATOSL-1.1;spdx;y
+cc-by-1.0;Creative Commons Attribution 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by/1.0/legalcode;spdx;
+cc-by-2.0;Creative Commons Attribution 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by/2.0/legalcode;spdx;
+cc-by-2.5;Creative Commons Attribution 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by/2.5/legalcode;spdx;
+cc-by-3.0;Creative Commons Attribution 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by/3.0/legalcode;spdx;
+cc-by-3.0-at;Creative Commons Attribution 3.0 Austria;;;all,data;https://creativecommons.org/licenses/by/3.0/at/legalcode;spdx;
+cc-by-3.0-us;Creative Commons Attribution 3.0 United States;;;all,data;https://creativecommons.org/licenses/by/3.0/us/legalcode;spdx;
+cc-by-4.0;Creative Commons Attribution 4.0 International;The Creative Commons Attribution license allows re-distribution and re-use of a licensed work on the condition that the creator is appropriately credited.;;recommended,all,data;https://creativecommons.org/licenses/by/4.0/legalcode;spdx;
+cc-by-nc-1.0;Creative Commons Attribution Non Commercial 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nc/1.0/legalcode;spdx;
+cc-by-nc-2.0;Creative Commons Attribution Non Commercial 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nc/2.0/legalcode;spdx;
+cc-by-nc-2.5;Creative Commons Attribution Non Commercial 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by-nc/2.5/legalcode;spdx;
+cc-by-nc-3.0;Creative Commons Attribution Non Commercial 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by-nc/3.0/legalcode;spdx;
+cc-by-nc-4.0;Creative Commons Attribution Non Commercial 4.0 International;;;all,data;https://creativecommons.org/licenses/by-nc/4.0/legalcode;spdx;
+cc-by-nc-nd-1.0;Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode;spdx;
+cc-by-nc-nd-2.0;Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode;spdx;
+cc-by-nc-nd-2.5;Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode;spdx;
+cc-by-nc-nd-3.0;Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode;spdx;
+cc-by-nc-nd-3.0-igo;Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO;;;all,data;https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode;spdx;
+cc-by-nc-nd-4.0;Creative Commons Attribution Non Commercial No Derivatives 4.0 International;;;all,data;https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode;spdx;
+cc-by-nc-sa-1.0;Creative Commons Attribution Non Commercial Share Alike 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode;spdx;
+cc-by-nc-sa-2.0;Creative Commons Attribution Non Commercial Share Alike 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode;spdx;
+cc-by-nc-sa-2.5;Creative Commons Attribution Non Commercial Share Alike 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode;spdx;
+cc-by-nc-sa-3.0;Creative Commons Attribution Non Commercial Share Alike 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode;spdx;
+cc-by-nc-sa-4.0;Creative Commons Attribution Non Commercial Share Alike 4.0 International;;;all,data;https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode;spdx;
+cc-by-nd-1.0;Creative Commons Attribution No Derivatives 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nd/1.0/legalcode;spdx;
+cc-by-nd-2.0;Creative Commons Attribution No Derivatives 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by-nd/2.0/legalcode;spdx;
+cc-by-nd-2.5;Creative Commons Attribution No Derivatives 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by-nd/2.5/legalcode;spdx;
+cc-by-nd-3.0;Creative Commons Attribution No Derivatives 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by-nd/3.0/legalcode;spdx;
+cc-by-nd-4.0;Creative Commons Attribution No Derivatives 4.0 International;;;all,data;https://creativecommons.org/licenses/by-nd/4.0/legalcode;spdx;
+cc-by-sa-1.0;Creative Commons Attribution Share Alike 1.0 Generic;;;all,data;https://creativecommons.org/licenses/by-sa/1.0/legalcode;spdx;
+cc-by-sa-2.0;Creative Commons Attribution Share Alike 2.0 Generic;;;all,data;https://creativecommons.org/licenses/by-sa/2.0/legalcode;spdx;
+cc-by-sa-2.0-uk;Creative Commons Attribution Share Alike 2.0 England and Wales;;;all,data;https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode;spdx;
+cc-by-sa-2.5;Creative Commons Attribution Share Alike 2.5 Generic;;;all,data;https://creativecommons.org/licenses/by-sa/2.5/legalcode;spdx;
+cc-by-sa-3.0;Creative Commons Attribution Share Alike 3.0 Unported;;;all,data;https://creativecommons.org/licenses/by-sa/3.0/legalcode;spdx;
+cc-by-sa-3.0-at;Creative Commons Attribution-Share Alike 3.0 Austria;;;all,data;https://creativecommons.org/licenses/by-sa/3.0/at/legalcode;spdx;
+cc-by-sa-4.0;Creative Commons Attribution Share Alike 4.0 International;Permits almost any use subject to providing credit and license notice. Frequently used for media assets and educational materials. The most common license for Open Access scientific publications. Not recommended for software.;;recommended,all,data;https://creativecommons.org/licenses/by-sa/4.0/legalcode;spdx;
 cc-pddc;Creative Commons Public Domain Dedication and Certification;;;all;https://creativecommons.org/licenses/publicdomain/;spdx;
-cc0-1.0;Creative Commons Zero v1.0 Universal;CC0 waives copyright interest in a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach.;;recommended,all;https://creativecommons.org/publicdomain/zero/1.0/legalcode;spdx;
-cddl-1.0;Common Development and Distribution License 1.0;;;all;https://opensource.org/licenses/cddl1;spdx;y
-cddl-1.1;Common Development and Distribution License 1.1;;;all;http://glassfish.java.net/public/CDDL+GPL_1_1.html;spdx;
-cdla-permissive-1.0;Community Data License Agreement Permissive 1.0;;;all;https://cdla.io/permissive-1-0;spdx;
-cdla-sharing-1.0;Community Data License Agreement Sharing 1.0;;;all;https://cdla.io/sharing-1-0;spdx;
-cecill-1.0;CeCILL Free Software License Agreement v1.0;;;all;http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html;spdx;
-cecill-1.1;CeCILL Free Software License Agreement v1.1;;;all;http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html;spdx;
-cecill-2.0;CeCILL Free Software License Agreement v2.0;;;all;http://www.cecill.info/licences/Licence_CeCILL_V2-en.html;spdx;
-cecill-2.1;CeCILL Free Software License Agreement v2.1;;;all;http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html;spdx;y
-cecill-b;CeCILL-B Free Software License Agreement;;;all;http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html;spdx;
-cecill-c;CeCILL-C Free Software License Agreement;;;all;http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html;spdx;
+cc0-1.0;Creative Commons Zero v1.0 Universal;CC0 waives copyright interest in a work you've created and dedicates it to the world-wide public domain. Use CC0 to opt out of copyright entirely and ensure your work has the widest reach.;;recommended,all,data,software;https://creativecommons.org/publicdomain/zero/1.0/legalcode;spdx;
+cddl-1.0;Common Development and Distribution License 1.0;;;all,software;https://opensource.org/licenses/cddl1;spdx;y
+cddl-1.1;Common Development and Distribution License 1.1;;;all,software;http://glassfish.java.net/public/CDDL+GPL_1_1.html;spdx;
+cdla-permissive-1.0;Community Data License Agreement Permissive 1.0;;;all,data;https://cdla.io/permissive-1-0;spdx;
+cdla-sharing-1.0;Community Data License Agreement Sharing 1.0;;;all,data;https://cdla.io/sharing-1-0;spdx;
+cecill-1.0;CeCILL Free Software License Agreement v1.0;;;all,software;http://www.cecill.info/licences/Licence_CeCILL_V1-fr.html;spdx;
+cecill-1.1;CeCILL Free Software License Agreement v1.1;;;all,software;http://www.cecill.info/licences/Licence_CeCILL_V1.1-US.html;spdx;
+cecill-2.0;CeCILL Free Software License Agreement v2.0;;;all,software;http://www.cecill.info/licences/Licence_CeCILL_V2-en.html;spdx;
+cecill-2.1;CeCILL Free Software License Agreement v2.1;;;all,software;http://www.cecill.info/licences/Licence_CeCILL_V2.1-en.html;spdx;y
+cecill-b;CeCILL-B Free Software License Agreement;;;all,software;http://www.cecill.info/licences/Licence_CeCILL-B_V1-en.html;spdx;
+cecill-c;CeCILL-C Free Software License Agreement;;;all,software;http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html;spdx;
 cern-ohl-1.1;CERN Open Hardware Licence v1.1;;;all;https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1;spdx;
 cern-ohl-1.2;CERN Open Hardware Licence v1.2;;;all;https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2;spdx;
 cern-ohl-p-2.0;CERN Open Hardware Licence Version 2 - Permissive;;;all;https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2;spdx;
 cern-ohl-s-2.0;CERN Open Hardware Licence Version 2 - Strongly Reciprocal;;;all;https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2;spdx;
 cern-ohl-w-2.0;CERN Open Hardware Licence Version 2 - Weakly Reciprocal;;;all;https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2;spdx;
-cnri-jython;CNRI Jython License;;;all;http://www.jython.org/license.html;spdx;
-cnri-python;CNRI Python License;;;all;https://opensource.org/licenses/CNRI-Python;spdx;y
-cnri-python-gpl-compatible;CNRI Python Open Source GPL Compatible License Agreement;;;all;http://www.python.org/download/releases/1.6.1/download_win/;spdx;
-cpal-1.0;Common Public Attribution License 1.0;;;all;https://opensource.org/licenses/CPAL-1.0;spdx;y
+cnri-jython;CNRI Jython License;;;all,software;http://www.jython.org/license.html;spdx;
+cnri-python;CNRI Python License;;;all,software;https://opensource.org/licenses/CNRI-Python;spdx;y
+cnri-python-gpl-compatible;CNRI Python Open Source GPL Compatible License Agreement;;;all,software;http://www.python.org/download/releases/1.6.1/download_win/;spdx;
+cpal-1.0;Common Public Attribution License 1.0;;;all,software;https://opensource.org/licenses/CPAL-1.0;spdx;y
 cpl-1.0;Common Public License 1.0;;;all;https://opensource.org/licenses/CPL-1.0;spdx;y
 cpol-1.02;Code Project Open License 1.02;;;all;http://www.codeproject.com/info/cpol10.aspx;spdx;
-cua-opl-1.0;CUA Office Public License v1.0;;;all;https://opensource.org/licenses/CUA-OPL-1.0;spdx;y
+cua-opl-1.0;CUA Office Public License v1.0;;;all,software;https://opensource.org/licenses/CUA-OPL-1.0;spdx;y
 caldera;Caldera License;;;all;http://www.lemis.com/grog/UNIX/ancient-source-all.pdf;spdx;
 clartistic;Clarified Artistic License;;;all;http://gianluca.dellavedova.org/2011/01/03/clarified-artistic-license/;spdx;
 condor-1.1;Condor Public License v1.1;;;all;http://research.cs.wisc.edu/condor/license.html#condor;spdx;
 crossword;Crossword License;;;all;https://fedoraproject.org/wiki/Licensing/Crossword;spdx;
 crystalstacker;CrystalStacker License;;;all;https://fedoraproject.org/wiki/Licensing:CrystalStacker?rd=Licensing/CrystalStacker;spdx;
 cube;Cube License;;;all;https://fedoraproject.org/wiki/Licensing/Cube;spdx;
-d-fsl-1.0;Deutsche Freie Software Lizenz;;;all;http://www.dipp.nrw.de/d-fsl/lizenzen/;spdx;
+d-fsl-1.0;Deutsche Freie Software Lizenz;;;all,software;http://www.dipp.nrw.de/d-fsl/lizenzen/;spdx;
 doc;DOC License;;;all;http://www.cs.wustl.edu/~schmidt/ACE-copying.html;spdx;
 dsdp;DSDP License;;;all;https://fedoraproject.org/wiki/Licensing/DSDP;spdx;
 dotseqn;Dotseqn License;;;all;https://fedoraproject.org/wiki/Licensing/Dotseqn;spdx;
-ecl-1.0;Educational Community License v1.0;;;all;https://opensource.org/licenses/ECL-1.0;spdx;y
-ecl-2.0;Educational Community License v2.0;;;all;https://opensource.org/licenses/ECL-2.0;spdx;y
-efl-1.0;Eiffel Forum License v1.0;;;all;http://www.eiffel-nice.org/license/forum.txt;spdx;y
-efl-2.0;Eiffel Forum License v2.0;;;all;http://www.eiffel-nice.org/license/eiffel-forum-license-2.html;spdx;y
+ecl-1.0;Educational Community License v1.0;;;all,software;https://opensource.org/licenses/ECL-1.0;spdx;y
+ecl-2.0;Educational Community License v2.0;;;all,software;https://opensource.org/licenses/ECL-2.0;spdx;y
+efl-1.0;Eiffel Forum License v1.0;;;all,software;http://www.eiffel-nice.org/license/forum.txt;spdx;y
+efl-2.0;Eiffel Forum License v2.0;;;all,software;http://www.eiffel-nice.org/license/eiffel-forum-license-2.html;spdx;y
 epics;EPICS Open License;;;all;https://epics.anl.gov/license/open.php;spdx;
-epl-1.0;Eclipse Public License 1.0;;;all;http://www.eclipse.org/legal/epl-v10.html;spdx;y
-epl-2.0;Eclipse Public License 2.0;;;all;https://www.eclipse.org/legal/epl-2.0;spdx;y
-eudatagrid;EU DataGrid Software License;;;all;http://eu-datagrid.web.cern.ch/eu-datagrid/license.html;spdx;y
-eupl-1.0;European Union Public License 1.0;;;all;http://ec.europa.eu/idabc/en/document/7330.html;spdx;
-eupl-1.1;European Union Public License 1.1;;;all;https://joinup.ec.europa.eu/software/page/eupl/licence-eupl;spdx;y
-eupl-1.2;European Union Public License 1.2;;;all;https://joinup.ec.europa.eu/page/eupl-text-11-12;spdx;y
-entessa;Entessa Public License v1.0;;;all;https://opensource.org/licenses/Entessa;spdx;y
+epl-1.0;Eclipse Public License 1.0;;;all,software;http://www.eclipse.org/legal/epl-v10.html;spdx;y
+epl-2.0;Eclipse Public License 2.0;;;all,software;https://www.eclipse.org/legal/epl-2.0;spdx;y
+eudatagrid;EU DataGrid Software License;;;all,software;http://eu-datagrid.web.cern.ch/eu-datagrid/license.html;spdx;y
+eupl-1.0;European Union Public License 1.0;;;all,sofware;http://ec.europa.eu/idabc/en/document/7330.html;spdx;
+eupl-1.1;European Union Public License 1.1;;;all,software;https://joinup.ec.europa.eu/software/page/eupl/licence-eupl;spdx;y
+eupl-1.2;European Union Public License 1.2;;;all,software;https://joinup.ec.europa.eu/page/eupl-text-11-12;spdx;y
+entessa;Entessa Public License v1.0;;;all,software;https://opensource.org/licenses/Entessa;spdx;y
 erlpl-1.1;Erlang Public License v1.1;;;all;http://www.erlang.org/EPLICENSE;spdx;
 eurosym;Eurosym License;;;all;https://fedoraproject.org/wiki/Licensing/Eurosym;spdx;
 fsfap;FSF All Permissive License;;;all;https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html;spdx;
 fsful;FSF Unlimited License;;;all;https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License;spdx;
 fsfullr;FSF Unlimited License (with License Retention);;;all;https://fedoraproject.org/wiki/Licensing/FSF_Unlimited_License#License_Retention_Variant;spdx;
 ftl;Freetype Project License;;;all;http://freetype.fis.uniroma2.it/FTL.TXT;spdx;
-fair;Fair License;;;all;http://fairlicense.org/;spdx;y
-frameworx-1.0;Frameworx Open License 1.0;;;all;https://opensource.org/licenses/Frameworx-1.0;spdx;y
+fair;Fair License;;;all,software;http://fairlicense.org/;spdx;y
+frameworx-1.0;Frameworx Open License 1.0;;;all,software;https://opensource.org/licenses/Frameworx-1.0;spdx;y
 freeimage;FreeImage Public License v1.0;;;all;http://freeimage.sourceforge.net/freeimage-license.txt;spdx;
 gfdl-1.1-invariants-only;GNU Free Documentation License v1.1 only - invariants;;;all;https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt;spdx;
 gfdl-1.1-invariants-or-later;GNU Free Documentation License v1.1 or later - invariants;;;all;https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt;spdx;
@@ -172,119 +172,119 @@ gfdl-1.3-only;GNU Free Documentation License v1.3 only;;;all;https://www.gnu.org
 gfdl-1.3-or-later;GNU Free Documentation License v1.3 or later;;;all;https://www.gnu.org/licenses/fdl-1.3.txt;spdx;
 gl2ps;GL2PS License;;;all;http://www.geuz.org/gl2ps/COPYING.GL2PS;spdx;
 glwtpl;Good Luck With That Public License;;;all;https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85;spdx;
-gpl-1.0-only;GNU General Public License v1.0 only;;;all;https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html;spdx;
-gpl-1.0-or-later;GNU General Public License v1.0 or later;;;all;https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html;spdx;
-gpl-2.0-only;GNU General Public License v2.0 only;;;all;https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html;spdx;y
-gpl-2.0-or-later;GNU General Public License v2.0 or later;;;all;https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html;spdx;y
-gpl-3.0-only;GNU General Public License v3.0 only;;;all;https://www.gnu.org/licenses/gpl-3.0-standalone.html;spdx;y
-gpl-3.0-or-later;GNU General Public License v3.0 or later;Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.;;recommended,all;https://www.gnu.org/licenses/gpl-3.0-standalone.html;spdx;y
+gpl-1.0-only;GNU General Public License v1.0 only;;;all,software;https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html;spdx;
+gpl-1.0-or-later;GNU General Public License v1.0 or later;;;all,software;https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html;spdx;
+gpl-2.0-only;GNU General Public License v2.0 only;;;all,software;https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html;spdx;y
+gpl-2.0-or-later;GNU General Public License v2.0 or later;;;all,software;https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html;spdx;y
+gpl-3.0-only;GNU General Public License v3.0 only;;;all,software;https://www.gnu.org/licenses/gpl-3.0-standalone.html;spdx;y
+gpl-3.0-or-later;GNU General Public License v3.0 or later;Permissions of this strong copyleft license are conditioned on making available complete source code of licensed works and modifications, which include larger works using a licensed work, under the same license. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights.;;recommended,all,software;https://www.gnu.org/licenses/gpl-3.0-standalone.html;spdx;y
 giftware;Giftware License;;;all;http://liballeg.org/license.html#allegro-4-the-giftware-license;spdx;
 glide;3dfx Glide License;;;all;http://www.users.on.net/~triforce/glidexp/COPYING.txt;spdx;
 glulxe;Glulxe License;;;all;https://fedoraproject.org/wiki/Licensing/Glulxe;spdx;
-hpnd;Historical Permission Notice and Disclaimer;;;all;https://opensource.org/licenses/HPND;spdx;y
-hpnd-sell-variant;Historical Permission Notice and Disclaimer - sell variant;;;all;https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19;spdx;
+hpnd;Historical Permission Notice and Disclaimer;;;all,software;https://opensource.org/licenses/HPND;spdx;y
+hpnd-sell-variant;Historical Permission Notice and Disclaimer - sell variant;;;all,software;https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19;spdx;
 htmltidy;HTML Tidy License;;;all;https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md;spdx;
 haskellreport;Haskell Language Report License;;;all;https://fedoraproject.org/wiki/Licensing/Haskell_Language_Report_License;spdx;
 hippocratic-2.1;Hippocratic License 2.1;;;all;https://firstdonoharm.dev/version/2/1/license.html;spdx;
-ibm-pibs;IBM PowerPC Initialization and Boot Software;;;all;"http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d";spdx;
+ibm-pibs;IBM PowerPC Initialization and Boot Software;;;all,software;"http://git.denx.de/?p=u-boot.git;a=blob;f=arch/powerpc/cpu/ppc4xx/miiphy.c;h=297155fdafa064b955e53e9832de93bfb0cfb85b;hb=9fab4bf4cc077c21e43941866f3f2c196f28670d";spdx;
 icu;ICU License;;;all;http://source.icu-project.org/repos/icu/icu/trunk/license.html;spdx;
 ijg;Independent JPEG Group License;;;all;http://dev.w3.org/cvsweb/Amaya/libjpeg/Attic/README?rev=1.2;spdx;
-ipa;IPA Font License;;;all;https://opensource.org/licenses/IPA;spdx;y
-ipl-1.0;IBM Public License v1.0;;;all;https://opensource.org/licenses/IPL-1.0;spdx;y
-isc;ISC License;;;all;https://www.isc.org/downloads/software-support-policy/isc-license/;spdx;y
+ipa;IPA Font License;;;all,software;https://opensource.org/licenses/IPA;spdx;y
+ipl-1.0;IBM Public License v1.0;;;all,software;https://opensource.org/licenses/IPL-1.0;spdx;y
+isc;ISC License;;;all,software;https://www.isc.org/downloads/software-support-policy/isc-license/;spdx;y
 imagemagick;ImageMagick License;;;all;http://www.imagemagick.org/script/license.php;spdx;
 imlib2;Imlib2 License;;;all;http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING;spdx;
 info-zip;Info-ZIP License;;;all;http://www.info-zip.org/license.html;spdx;
-intel;Intel Open Source License;;;all;https://opensource.org/licenses/Intel;spdx;y
-intel-acpi;Intel ACPI Software License Agreement;;;all;https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement;spdx;
+intel;Intel Open Source License;;;all,software;https://opensource.org/licenses/Intel;spdx;y
+intel-acpi;Intel ACPI Software License Agreement;;;all,software;https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement;spdx;
 interbase-1.0;Interbase Public License v1.0;;;all;https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html;spdx;
 jpnic;Japan Network Information Center License;;;all;https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366;spdx;
 json;JSON License;;;all;http://www.json.org/license.html;spdx;
 jasper-2.0;JasPer License;;;all;http://www.ece.uvic.ca/~mdadams/jasper/LICENSE;spdx;
 lal-1.2;Licence Art Libre 1.2;;;all;http://artlibre.org/licence/lal/licence-art-libre-12/;spdx;
 lal-1.3;Licence Art Libre 1.3;;;all;https://artlibre.org/;spdx;
-lgpl-2.0-only;GNU Library General Public License v2 only;;;all;https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html;spdx;y
-lgpl-2.0-or-later;GNU Library General Public License v2 or later;;;all;https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html;spdx;y
-lgpl-2.1-only;GNU Lesser General Public License v2.1 only;;;all;https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html;spdx;y
-lgpl-2.1-or-later;GNU Lesser General Public License v2.1 or later;;;all;https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html;spdx;y
-lgpl-3.0-only;GNU Lesser General Public License v3.0 only;;;all;https://www.gnu.org/licenses/lgpl-3.0-standalone.html;spdx;y
-lgpl-3.0-or-later;GNU Lesser General Public License v3.0 or later;Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.;;all;https://www.gnu.org/licenses/lgpl-3.0-standalone.html;spdx;y
-lgpllr;Lesser General Public License For Linguistic Resources;;;all;http://www-igm.univ-mlv.fr/~unitex/lgpllr.html;spdx;
-lpl-1.0;Lucent Public License Version 1.0;;;all;https://opensource.org/licenses/LPL-1.0;spdx;y
-lpl-1.02;Lucent Public License v1.02;;;all;http://plan9.bell-labs.com/plan9/license.html;spdx;y
-lppl-1.0;LaTeX Project Public License v1.0;;;all;http://www.latex-project.org/lppl/lppl-1-0.txt;spdx;
-lppl-1.1;LaTeX Project Public License v1.1;;;all;http://www.latex-project.org/lppl/lppl-1-1.txt;spdx;
-lppl-1.2;LaTeX Project Public License v1.2;;;all;http://www.latex-project.org/lppl/lppl-1-2.txt;spdx;
-lppl-1.3a;LaTeX Project Public License v1.3a;;;all;http://www.latex-project.org/lppl/lppl-1-3a.txt;spdx;
-lppl-1.3c;LaTeX Project Public License v1.3c;;;all;http://www.latex-project.org/lppl/lppl-1-3c.txt;spdx;y
+lgpl-2.0-only;GNU Library General Public License v2 only;;;all,software;https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html;spdx;y
+lgpl-2.0-or-later;GNU Library General Public License v2 or later;;;all,software;https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html;spdx;y
+lgpl-2.1-only;GNU Lesser General Public License v2.1 only;;;all,software;https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html;spdx;y
+lgpl-2.1-or-later;GNU Lesser General Public License v2.1 or later;;;all,software;https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html;spdx;y
+lgpl-3.0-only;GNU Lesser General Public License v3.0 only;;;all,software;https://www.gnu.org/licenses/lgpl-3.0-standalone.html;spdx;y
+lgpl-3.0-or-later;GNU Lesser General Public License v3.0 or later;Permissions of this copyleft license are conditioned on making available complete source code of licensed works and modifications under the same license or the GNU GPLv3. Copyright and license notices must be preserved. Contributors provide an express grant of patent rights. However, a larger work using the licensed work through interfaces provided by the licensed work may be distributed under different terms and without source code for the larger work.;;all,software;https://www.gnu.org/licenses/lgpl-3.0-standalone.html;spdx;y
+lgpllr;Lesser General Public License For Linguistic Resources;;;all,software;http://www-igm.univ-mlv.fr/~unitex/lgpllr.html;spdx;
+lpl-1.0;Lucent Public License Version 1.0;;;all,software;https://opensource.org/licenses/LPL-1.0;spdx;y
+lpl-1.02;Lucent Public License v1.02;;;all,software;http://plan9.bell-labs.com/plan9/license.html;spdx;y
+lppl-1.0;LaTeX Project Public License v1.0;;;all,software;http://www.latex-project.org/lppl/lppl-1-0.txt;spdx;
+lppl-1.1;LaTeX Project Public License v1.1;;;all,software;http://www.latex-project.org/lppl/lppl-1-1.txt;spdx;
+lppl-1.2;LaTeX Project Public License v1.2;;;all,software;http://www.latex-project.org/lppl/lppl-1-2.txt;spdx;
+lppl-1.3a;LaTeX Project Public License v1.3a;;;all,software;http://www.latex-project.org/lppl/lppl-1-3a.txt;spdx;
+lppl-1.3c;LaTeX Project Public License v1.3c;;;all,software;http://www.latex-project.org/lppl/lppl-1-3c.txt;spdx;y
 latex2e;Latex2e License;;;all;https://fedoraproject.org/wiki/Licensing/Latex2e;spdx;
 leptonica;Leptonica License;;;all;https://fedoraproject.org/wiki/Licensing/Leptonica;spdx;
 liliq-p-1.1;Licence Libre du Québec – Permissive version 1.1;;;all;https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/;spdx;y
 liliq-r-1.1;Licence Libre du Québec – Réciprocité version 1.1;;;all;https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/;spdx;y
 liliq-rplus-1.1;Licence Libre du Québec – Réciprocité forte version 1.1;;;all;https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/;spdx;y
-libpng;libpng License;;;all;http://www.libpng.org/pub/png/src/libpng-LICENSE.txt;spdx;
+libpng;libpng License;;;all,software;http://www.libpng.org/pub/png/src/libpng-LICENSE.txt;spdx;
 linux-openib;Linux Kernel Variant of OpenIB.org license;;;all;https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h;spdx;
-mit;MIT License;A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.;;recommended,all;https://opensource.org/licenses/MIT;spdx;y
-mit-0;MIT No Attribution;;;all;https://github.com/aws/mit-0;spdx;y
-mit-cmu;CMU License;;;all;https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style;spdx;
-mit-advertising;Enlightenment License (e16);;;all;https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising;spdx;
-mit-enna;enna License;;;all;https://fedoraproject.org/wiki/Licensing/MIT#enna;spdx;
-mit-feh;feh License;;;all;https://fedoraproject.org/wiki/Licensing/MIT#feh;spdx;
-mit-open-group;MIT Open Group variant;;;all;https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING;spdx;
-mitnfa;MIT +no-false-attribs license;;;all;https://fedoraproject.org/wiki/Licensing/MITNFA;spdx;
-mpl-1.0;Mozilla Public License 1.0;;;all;http://www.mozilla.org/MPL/MPL-1.0.html;spdx;y
-mpl-1.1;Mozilla Public License 1.1;;;all;http://www.mozilla.org/MPL/MPL-1.1.html;spdx;y
-mpl-2.0;Mozilla Public License 2.0;;;all;http://www.mozilla.org/MPL/2.0/;spdx;y
-mpl-2.0-no-copyleft-exception;Mozilla Public License 2.0 (no copyleft exception);;;all;http://www.mozilla.org/MPL/2.0/;spdx;y
-ms-pl;Microsoft Public License;;;all;http://www.microsoft.com/opensource/licenses.mspx;spdx;y
-ms-rl;Microsoft Reciprocal License;;;all;http://www.microsoft.com/opensource/licenses.mspx;spdx;y
+mit;MIT License;A short and simple permissive license with conditions only requiring preservation of copyright and license notices. Licensed works, modifications, and larger works may be distributed under different terms and without source code.;;recommended,all,software;https://opensource.org/licenses/MIT;spdx;y
+mit-0;MIT No Attribution;;;all,software;https://github.com/aws/mit-0;spdx;y
+mit-cmu;CMU License;;;all,software;https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style;spdx;
+mit-advertising;Enlightenment License (e16);;;all,software;https://fedoraproject.org/wiki/Licensing/MIT_With_Advertising;spdx;
+mit-enna;enna License;;;all,software;https://fedoraproject.org/wiki/Licensing/MIT#enna;spdx;
+mit-feh;feh License;;;all,software;https://fedoraproject.org/wiki/Licensing/MIT#feh;spdx;
+mit-open-group;MIT Open Group variant;;;all,software;https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING;spdx;
+mitnfa;MIT +no-false-attribs license;;;all,software;https://fedoraproject.org/wiki/Licensing/MITNFA;spdx;
+mpl-1.0;Mozilla Public License 1.0;;;all,software;http://www.mozilla.org/MPL/MPL-1.0.html;spdx;y
+mpl-1.1;Mozilla Public License 1.1;;;all,software;http://www.mozilla.org/MPL/MPL-1.1.html;spdx;y
+mpl-2.0;Mozilla Public License 2.0;;;all,software;http://www.mozilla.org/MPL/2.0/;spdx;y
+mpl-2.0-no-copyleft-exception;Mozilla Public License 2.0 (no copyleft exception);;;all,software;http://www.mozilla.org/MPL/2.0/;spdx;y
+ms-pl;Microsoft Public License;;;all,software;http://www.microsoft.com/opensource/licenses.mspx;spdx;y
+ms-rl;Microsoft Reciprocal License;;;all,software;http://www.microsoft.com/opensource/licenses.mspx;spdx;y
 mtll;Matrix Template Library License;;;all;https://fedoraproject.org/wiki/Licensing/Matrix_Template_Library_License;spdx;
 makeindex;MakeIndex License;;;all;https://fedoraproject.org/wiki/Licensing/MakeIndex;spdx;
-miros;The MirOS Licence;;;all;https://opensource.org/licenses/MirOS;spdx;y
-motosoto;Motosoto License;;;all;https://opensource.org/licenses/Motosoto;spdx;y
+miros;The MirOS Licence;;;all,software;https://opensource.org/licenses/MirOS;spdx;y
+motosoto;Motosoto License;;;all,software;https://opensource.org/licenses/Motosoto;spdx;y
 mulanpsl-1.0;Mulan Permissive Software License, Version 1;;;all;https://license.coscl.org.cn/MulanPSL/;spdx;
 mulanpsl-2.0;Mulan Permissive Software License, Version 2;;;all;https://license.coscl.org.cn/MulanPSL2/;spdx;y
-multics;Multics License;;;all;https://opensource.org/licenses/Multics;spdx;y
+multics;Multics License;;;all,software;https://opensource.org/licenses/Multics;spdx;y
 mup;Mup License;;;all;https://fedoraproject.org/wiki/Licensing/Mup;spdx;
-nasa-1.3;NASA Open Source Agreement 1.3;;;all;http://ti.arc.nasa.gov/opensource/nosa/;spdx;y
+nasa-1.3;NASA Open Source Agreement 1.3;;;all,software;http://ti.arc.nasa.gov/opensource/nosa/;spdx;y
 nbpl-1.0;Net Boolean Public License v1;;;all;"http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=37b4b3f6cc4bf34e1d3dec61e69914b9819d8894";spdx;
 ncgl-uk-2.0;Non-Commercial Government Licence;;;all;https://github.com/spdx/license-list-XML/blob/master/src/Apache-2.0.xml;spdx;
-ncsa;University of Illinois/NCSA Open Source License;;;all;http://otm.illinois.edu/uiuc_openSource;spdx;y
-ngpl;Nethack General Public License;;;all;https://opensource.org/licenses/NGPL;spdx;y
+ncsa;University of Illinois/NCSA Open Source License;;;all,software;http://otm.illinois.edu/uiuc_openSource;spdx;y
+ngpl;Nethack General Public License;;;all,software;https://opensource.org/licenses/NGPL;spdx;y
 nist-pd;NIST Public Domain Notice;;;all;https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt;spdx;
 nist-pd-fallback;NIST Public Domain Notice with license fallback;;;all;https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE;spdx;
 nlod-1.0;Norwegian Licence for Open Government Data;;;all;http://data.norge.no/nlod/en/1.0;spdx;
 nlpl;No Limit Public License;;;all;https://fedoraproject.org/wiki/Licensing/NLPL;spdx;
-nosl;Netizen Open Source License;;;all;http://bits.netizen.com.au/licenses/NOSL/nosl.txt;spdx;
+nosl;Netizen Open Source License;;;all,software;http://bits.netizen.com.au/licenses/NOSL/nosl.txt;spdx;
 npl-1.0;Netscape Public License v1.0;;;all;http://www.mozilla.org/MPL/NPL/1.0/;spdx;
 npl-1.1;Netscape Public License v1.1;;;all;http://www.mozilla.org/MPL/NPL/1.1/;spdx;
-nposl-3.0;Non-Profit Open Software License 3.0;;;all;https://opensource.org/licenses/NOSL3.0;spdx;y
+nposl-3.0;Non-Profit Open Software License 3.0;;;all,software;https://opensource.org/licenses/NOSL3.0;spdx;y
 nrl;NRL License;;;all;http://web.mit.edu/network/isakmp/nrllicense.html;spdx;
-ntp;NTP License;;;all;https://opensource.org/licenses/NTP;spdx;y
-ntp-0;NTP No Attribution;;;all;https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c;spdx;
-naumen;Naumen Public License;;;all;https://opensource.org/licenses/Naumen;spdx;y
+ntp;NTP License;;;all,software;https://opensource.org/licenses/NTP;spdx;y
+ntp-0;NTP No Attribution;;;all,software;https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c;spdx;
+naumen;Naumen Public License;;;all,software;https://opensource.org/licenses/Naumen;spdx;y
 net-snmp;Net-SNMP License;;;all;http://net-snmp.sourceforge.net/about/license.html;spdx;
 netcdf;NetCDF license;;;all;http://www.unidata.ucar.edu/software/netcdf/copyright.html;spdx;
 newsletr;Newsletr License;;;all;https://fedoraproject.org/wiki/Licensing/Newsletr;spdx;
-nokia;Nokia Open Source License;;;all;https://opensource.org/licenses/nokia;spdx;y
+nokia;Nokia Open Source License;;;all,software;https://opensource.org/licenses/nokia;spdx;y
 noweb;Noweb License;;;all;https://fedoraproject.org/wiki/Licensing/Noweb;spdx;
 o-uda-1.0;Open Use of Data Agreement v1.0;;;all;https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md;spdx;
 occt-pl;Open CASCADE Technology Public License;;;all;http://www.opencascade.com/content/occt-public-license;spdx;
-oclc-2.0;OCLC Research Public License 2.0;;;all;http://www.oclc.org/research/activities/software/license/v2final.htm;spdx;y
-odc-by-1.0;Open Data Commons Attribution License v1.0;;;all;https://opendatacommons.org/licenses/by/1.0/;spdx;
-odbl-1.0;ODC Open Database License v1.0;;;all;http://www.opendatacommons.org/licenses/odbl/1.0/;spdx;
-ofl-1.0;SIL Open Font License 1.0;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
-ofl-1.0-rfn;SIL Open Font License 1.0 with Reserved Font Name;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
-ofl-1.0-no-rfn;SIL Open Font License 1.0 with no Reserved Font Name;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
-ofl-1.1;SIL Open Font License 1.1;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
-ofl-1.1-rfn;SIL Open Font License 1.1 with Reserved Font Name;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
-ofl-1.1-no-rfn;SIL Open Font License 1.1 with no Reserved Font Name;;;all;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
-ogc-1.0;OGC Software License, Version 1.0;;;all;https://www.ogc.org/ogc/software/1.0;spdx;
-ogl-canada-2.0;Open Government Licence - Canada;;;all;https://open.canada.ca/en/open-government-licence-canada;spdx;
-ogl-uk-1.0;Open Government Licence v1.0;;;all;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/;spdx;
-ogl-uk-2.0;Open Government Licence v2.0;;;all;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/;spdx;
-ogl-uk-3.0;Open Government Licence v3.0;;;all;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/;spdx;
-ogtsl;Open Group Test Suite License;;;all;http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt;spdx;y
+oclc-2.0;OCLC Research Public License 2.0;;;all,software;http://www.oclc.org/research/activities/software/license/v2final.htm;spdx;y
+odc-by-1.0;Open Data Commons Attribution License v1.0;;;all,data;https://opendatacommons.org/licenses/by/1.0/;spdx;
+odbl-1.0;ODC Open Database License v1.0;;;all,data;http://www.opendatacommons.org/licenses/odbl/1.0/;spdx;
+ofl-1.0;SIL Open Font License 1.0;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
+ofl-1.0-rfn;SIL Open Font License 1.0 with Reserved Font Name;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
+ofl-1.0-no-rfn;SIL Open Font License 1.0 with no Reserved Font Name;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web;spdx;
+ofl-1.1;SIL Open Font License 1.1;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
+ofl-1.1-rfn;SIL Open Font License 1.1 with Reserved Font Name;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
+ofl-1.1-no-rfn;SIL Open Font License 1.1 with no Reserved Font Name;;;all,software;http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web;spdx;y
+ogc-1.0;OGC Software License, Version 1.0;;;all,software;https://www.ogc.org/ogc/software/1.0;spdx;
+ogl-canada-2.0;Open Government Licence - Canada;;;all,data;https://open.canada.ca/en/open-government-licence-canada;spdx;
+ogl-uk-1.0;Open Government Licence v1.0;;;all,data,software;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/;spdx;
+ogl-uk-2.0;Open Government Licence v2.0;;;all,data,software;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/;spdx;
+ogl-uk-3.0;Open Government Licence v3.0;;;all,data,software;http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/;spdx;
+ogtsl;Open Group Test Suite License;;;all,software;http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt;spdx;y
 oldap-1.1;Open LDAP Public License v1.1;;;all;"http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=806557a5ad59804ef3a44d5abfbe91d706b0791f";spdx;
 oldap-1.2;Open LDAP Public License v1.2;;;all;"http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=42b0383c50c299977b5893ee695cf4e486fb0dc7";spdx;
 oldap-1.3;Open LDAP Public License v1.3;;;all;"http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=e5f8117f0ce088d0bd7a8e18ddf37eaa40eb09b1";spdx;
@@ -304,31 +304,31 @@ oldap-2.8;Open LDAP Public License v2.8;;;all;http://www.openldap.org/software/r
 oml;Open Market License;;;all;https://fedoraproject.org/wiki/Licensing/Open_Market_License;spdx;
 opl-1.0;Open Public License v1.0;;;all;http://old.koalateam.com/jackaroo/OPL_1_0.TXT;spdx;
 oset-pl-2.1;OSET Public License version 2.1;;;all;http://www.osetfoundation.org/public-license;spdx;y
-osl-1.0;Open Software License 1.0;;;all;https://opensource.org/licenses/OSL-1.0;spdx;y
-osl-1.1;Open Software License 1.1;;;all;https://fedoraproject.org/wiki/Licensing/OSL1.1;spdx;
-osl-2.0;Open Software License 2.0;;;all;http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html;spdx;y
-osl-2.1;Open Software License 2.1;;;all;http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm;spdx;y
-osl-3.0;Open Software License 3.0;;;all;https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm;spdx;y
+osl-1.0;Open Software License 1.0;;;all,software;https://opensource.org/licenses/OSL-1.0;spdx;y
+osl-1.1;Open Software License 1.1;;;all,software;https://fedoraproject.org/wiki/Licensing/OSL1.1;spdx;
+osl-2.0;Open Software License 2.0;;;all,software;http://web.archive.org/web/20041020171434/http://www.rosenlaw.com/osl2.0.html;spdx;y
+osl-2.1;Open Software License 2.1;;;all,software;http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm;spdx;y
+osl-3.0;Open Software License 3.0;;;all,software;https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm;spdx;y
 openssl;OpenSSL License;;;all;http://www.openssl.org/source/license.html;spdx;
-pddl-1.0;ODC Public Domain Dedication & License 1.0;;;all;http://opendatacommons.org/licenses/pddl/1.0/;spdx;
-php-3.0;PHP License v3.0;;;all;http://www.php.net/license/3_0.txt;spdx;y
-php-3.01;PHP License v3.01;;;all;http://www.php.net/license/3_01.txt;spdx;y
-psf-2.0;Python Software Foundation License 2.0;;;all;https://opensource.org/licenses/Python-2.0;spdx;
+pddl-1.0;ODC Public Domain Dedication & License 1.0;;;all,data;http://opendatacommons.org/licenses/pddl/1.0/;spdx;
+php-3.0;PHP License v3.0;;;all,software;http://www.php.net/license/3_0.txt;spdx;y
+php-3.01;PHP License v3.01;;;all,software;http://www.php.net/license/3_01.txt;spdx;y
+psf-2.0;Python Software Foundation License 2.0;;;all,software;https://opensource.org/licenses/Python-2.0;spdx;
 parity-6.0.0;The Parity Public License 6.0.0;;;all;https://paritylicense.com/versions/6.0.0.html;spdx;
 parity-7.0.0;The Parity Public License 7.0.0;;;all;https://paritylicense.com/versions/7.0.0.html;spdx;
 plexus;Plexus Classworlds License;;;all;https://fedoraproject.org/wiki/Licensing/Plexus_Classworlds_License;spdx;
 polyform-noncommercial-1.0.0;PolyForm Noncommercial License 1.0.0;;;all;https://polyformproject.org/licenses/noncommercial/1.0.0;spdx;
 polyform-small-business-1.0.0;PolyForm Small Business License 1.0.0;;;all;https://polyformproject.org/licenses/small-business/1.0.0;spdx;
-postgresql;PostgreSQL License;;;all;http://www.postgresql.org/about/licence;spdx;y
-python-2.0;Python License 2.0;;;all;https://opensource.org/licenses/Python-2.0;spdx;y
-qpl-1.0;Q Public License 1.0;;;all;http://doc.qt.nokia.com/3.3/license.html;spdx;y
+postgresql;PostgreSQL License;;;all,software;http://www.postgresql.org/about/licence;spdx;y
+python-2.0;Python License 2.0;;;all,software;https://opensource.org/licenses/Python-2.0;spdx;y
+qpl-1.0;Q Public License 1.0;;;all,software;http://doc.qt.nokia.com/3.3/license.html;spdx;y
 qhull;Qhull License;;;all;https://fedoraproject.org/wiki/Licensing/Qhull;spdx;
 rhecos-1.1;Red Hat eCos Public License v1.1;;;all;http://ecos.sourceware.org/old-license.html;spdx;
-rpl-1.1;Reciprocal Public License 1.1;;;all;https://opensource.org/licenses/RPL-1.1;spdx;y
-rpl-1.5;Reciprocal Public License 1.5;;;all;https://opensource.org/licenses/RPL-1.5;spdx;y
-rpsl-1.0;RealNetworks Public Source License v1.0;;;all;https://helixcommunity.org/content/rpsl;spdx;y
+rpl-1.1;Reciprocal Public License 1.1;;;all,software;https://opensource.org/licenses/RPL-1.1;spdx;y
+rpl-1.5;Reciprocal Public License 1.5;;;all,software;https://opensource.org/licenses/RPL-1.5;spdx;y
+rpsl-1.0;RealNetworks Public Source License v1.0;;;all,software;https://helixcommunity.org/content/rpsl;spdx;y
 rsa-md;RSA Message-Digest License;;;all;http://www.faqs.org/rfcs/rfc1321.html;spdx;
-rscpl;Ricoh Source Code Public License;;;all;http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml;spdx;y
+rscpl;Ricoh Source Code Public License;;;all,software;http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml;spdx;y
 rdisc;Rdisc License;;;all;https://fedoraproject.org/wiki/Licensing/Rdisc_License;spdx;
 ruby;Ruby License;;;all;http://www.ruby-lang.org/en/LICENSE.txt;spdx;
 sax-pd;Sax Public Domain Notice;;;all;http://www.saxproject.org/copying.html;spdx;
@@ -338,12 +338,12 @@ sgi-b-1.1;SGI Free Software License B v1.1;;;all;http://oss.sgi.com/projects/Fre
 sgi-b-2.0;SGI Free Software License B v2.0;;;all;http://oss.sgi.com/projects/FreeB/SGIFreeSWLicB.2.0.pdf;spdx;
 shl-0.5;Solderpad Hardware License v0.5;;;all;https://solderpad.org/licenses/SHL-0.5/;spdx;
 shl-0.51;Solderpad Hardware License, Version 0.51;;;all;https://solderpad.org/licenses/SHL-0.51/;spdx;
-sissl;Sun Industry Standards Source License v1.1;;;all;http://www.openoffice.org/licenses/sissl_license.html;spdx;y
-sissl-1.2;Sun Industry Standards Source License v1.2;;;all;http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html;spdx;
+sissl;Sun Industry Standards Source License v1.1;;;all,software;http://www.openoffice.org/licenses/sissl_license.html;spdx;y
+sissl-1.2;Sun Industry Standards Source License v1.2;;;all,software;http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html;spdx;
 smlnj;Standard ML of New Jersey License;;;all;https://www.smlnj.org/license.html;spdx;
 smppl;Secure Messaging Protocol Public License;;;all;https://github.com/dcblake/SMP/blob/master/Documentation/License.txt;spdx;
 snia;SNIA Public License 1.1;;;all;https://fedoraproject.org/wiki/Licensing/SNIA_Public_License;spdx;
-spl-1.0;Sun Public License v1.0;;;all;https://opensource.org/licenses/SPL-1.0;spdx;y
+spl-1.0;Sun Public License v1.0;;;all,software;https://opensource.org/licenses/SPL-1.0;spdx;y
 ssh-openssh;SSH OpenSSH license;;;all;https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10;spdx;
 ssh-short;SSH short notice;;;all;https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h;spdx;
 sspl-1.0;Server Side Public License, v 1;;;all;https://www.mongodb.com/licensing/server-side-public-license;spdx;
@@ -351,8 +351,8 @@ swl;Scheme Widget Library (SWL) Software License Agreement;;;all;https://fedorap
 saxpath;Saxpath License;;;all;https://fedoraproject.org/wiki/Licensing/Saxpath_License;spdx;
 sendmail;Sendmail License;;;all;http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf;spdx;
 sendmail-8.23;Sendmail License 8.23;;;all;https://www.proofpoint.com/sites/default/files/sendmail-license.pdf;spdx;
-simpl-2.0;Simple Public License 2.0;;;all;https://opensource.org/licenses/SimPL-2.0;spdx;y
-sleepycat;Sleepycat License;;;all;https://opensource.org/licenses/Sleepycat;spdx;y
+simpl-2.0;Simple Public License 2.0;;;all,software;https://opensource.org/licenses/SimPL-2.0;spdx;y
+sleepycat;Sleepycat License;;;all,software;https://opensource.org/licenses/Sleepycat;spdx;y
 spencer-86;Spencer License 86;;;all;https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License;spdx;
 spencer-94;Spencer License 94;;;all;https://fedoraproject.org/wiki/Licensing/Henry_Spencer_Reg-Ex_Library_License;spdx;
 spencer-99;Spencer License 99;;;all;http://www.opensource.apple.com/source/tcl/tcl-5/tcl/generic/regfronts.c;spdx;
@@ -372,29 +372,29 @@ unicode-dfs-2016;Unicode License Agreement - Data Files and Software (2016);;;al
 unicode-tou;Unicode Terms of Use;;;all;http://www.unicode.org/copyright.html;spdx;
 unlicense;The Unlicense;;;all;https://unlicense.org/;spdx;y
 vostrom;VOSTROM Public License for Open Source;;;all;https://fedoraproject.org/wiki/Licensing/VOSTROM;spdx;
-vsl-1.0;Vovida Software License v1.0;;;all;https://opensource.org/licenses/VSL-1.0;spdx;y
+vsl-1.0;Vovida Software License v1.0;;;all,software;https://opensource.org/licenses/VSL-1.0;spdx;y
 vim;Vim License;;;all;http://vimdoc.sourceforge.net/htmldoc/uganda.html;spdx;
-w3c;W3C Software Notice and License (2002-12-31);;;all;http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html;spdx;y
-w3c-19980720;W3C Software Notice and License (1998-07-20);;;all;http://www.w3.org/Consortium/Legal/copyright-software-19980720.html;spdx;
-w3c-20150513;W3C Software Notice and Document License (2015-05-13);;;all;https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document;spdx;
+w3c;W3C Software Notice and License (2002-12-31);;;all,software;http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html;spdx;y
+w3c-19980720;W3C Software Notice and License (1998-07-20);;;all,software;http://www.w3.org/Consortium/Legal/copyright-software-19980720.html;spdx;
+w3c-20150513;W3C Software Notice and Document License (2015-05-13);;;all,software;https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document;spdx;
 wtfpl;Do What The F*ck You Want To Public License;;;all;http://www.wtfpl.net/about/;spdx;
-watcom-1.0;Sybase Open Watcom Public License 1.0;;;all;https://opensource.org/licenses/Watcom-1.0;spdx;y
+watcom-1.0;Sybase Open Watcom Public License 1.0;;;all,software;https://opensource.org/licenses/Watcom-1.0;spdx;y
 wsuipa;Wsuipa License;;;all;https://fedoraproject.org/wiki/Licensing/Wsuipa;spdx;
 x11;X11 License;;;all;http://www.xfree86.org/3.3.6/COPYRIGHT2.html#3;spdx;
 xfree86-1.1;XFree86 License 1.1;;;all;http://www.xfree86.org/current/LICENSE4.html;spdx;
 xskat;XSkat License;;;all;https://fedoraproject.org/wiki/Licensing/XSkat_License;spdx;
 xerox;Xerox License;;;all;https://fedoraproject.org/wiki/Licensing/Xerox;spdx;
-xnet;X.Net License;;;all;https://opensource.org/licenses/Xnet;spdx;y
+xnet;X.Net License;;;all,software;https://opensource.org/licenses/Xnet;spdx;y
 ypl-1.0;Yahoo! Public License v1.0;;;all;http://www.zimbra.com/license/yahoo_public_license_1.0.html;spdx;
 ypl-1.1;Yahoo! Public License v1.1;;;all;http://www.zimbra.com/license/yahoo_public_license_1.1.html;spdx;
-zpl-1.1;Zope Public License 1.1;;;all;http://old.zope.org/Resources/License/ZPL-1.1;spdx;
-zpl-2.0;Zope Public License 2.0;;;all;http://old.zope.org/Resources/License/ZPL-2.0;spdx;y
-zpl-2.1;Zope Public License 2.1;;;all;http://old.zope.org/Resources/ZPL/;spdx;
+zpl-1.1;Zope Public License 1.1;;;all,software;http://old.zope.org/Resources/License/ZPL-1.1;spdx;
+zpl-2.0;Zope Public License 2.0;;;all,software;http://old.zope.org/Resources/License/ZPL-2.0;spdx;y
+zpl-2.1;Zope Public License 2.1;;;all,software;http://old.zope.org/Resources/ZPL/;spdx;
 zed;Zed License;;;all;https://fedoraproject.org/wiki/Licensing/Zed;spdx;
 zend-2.0;Zend License v2.0;;;all;https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt;spdx;
 zimbra-1.3;Zimbra Public License v1.3;;;all;http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html;spdx;
 zimbra-1.4;Zimbra Public License v1.4;;;all;http://www.zimbra.com/legal/zimbra-public-license-1-4;spdx;
-zlib;zlib License;;;all;http://www.zlib.net/zlib_license.html;spdx;y
+zlib;zlib License;;;all,software;http://www.zlib.net/zlib_license.html;spdx;y
 blessing;SQLite Blessing;;;all;https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln=4-9;spdx;
 bzip2-1.0.5;bzip2 and libbzip2 License v1.0.5;;;all;https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html;spdx;
 bzip2-1.0.6;bzip2 and libbzip2 License v1.0.6;;;all;"https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6";spdx;
@@ -404,11 +404,11 @@ curl;curl License;;;all;https://github.com/bagder/curl/blob/master/COPYING;spdx;
 diffmark;diffmark license;;;all;https://fedoraproject.org/wiki/Licensing/diffmark;spdx;
 dvipdfm;dvipdfm License;;;all;https://fedoraproject.org/wiki/Licensing/dvipdfm;spdx;
 egenix;eGenix.com Public License 1.1.0;;;all;http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf;spdx;
-etalab-2.0;Etalab Open License 2.0;;;all;https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf;spdx;
+etalab-2.0;Etalab Open License 2.0;;;all,data;https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf;spdx;
 gsoap-1.3b;gSOAP Public License v1.3b;;;all;http://www.cs.fsu.edu/~engelen/license.html;spdx;
 gnuplot;gnuplot License;;;all;https://fedoraproject.org/wiki/Licensing/Gnuplot;spdx;
 imatix;iMatix Standard Function Library Agreement;;;all;http://legacy.imatix.com/html/sfl/sfl4.htm#license;spdx;
-libpng-2.0;PNG Reference Library version 2;;;all;http://www.libpng.org/pub/png/src/libpng-LICENSE.txt;spdx;
+libpng-2.0;PNG Reference Library version 2;;;all,software;http://www.libpng.org/pub/png/src/libpng-LICENSE.txt;spdx;
 libselinux-1.0;libselinux public domain notice;;;all;https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE;spdx;
 libtiff;libtiff License;;;all;https://fedoraproject.org/wiki/Licensing/libtiff;spdx;
 mpich2;mpich2 License;;;all;https://fedoraproject.org/wiki/Licensing/MIT;spdx;
@@ -416,4 +416,4 @@ psfrag;psfrag License;;;all;https://fedoraproject.org/wiki/Licensing/psfrag;spdx
 psutils;psutils License;;;all;https://fedoraproject.org/wiki/Licensing/psutils;spdx;
 xinetd;xinetd License;;;all;https://fedoraproject.org/wiki/Licensing/Xinetd_License;spdx;
 xpp;XPP License;;;all;https://fedoraproject.org/wiki/Licensing/xpp;spdx;
-zlib-acknowledgement;zlib/libpng License with Acknowledgement;;;all;https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement;spdx;
+zlib-acknowledgement;zlib/libpng License with Acknowledgement;;;all,software;https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement;spdx;


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-app-rdm/issues/968

![Screenshot 2021-08-03 at 12 00 32](https://user-images.githubusercontent.com/6756943/127997479-55e31b17-55af-4d38-9b35-83e6dd20a161.png)
![Screenshot 2021-08-03 at 11 58 13](https://user-images.githubusercontent.com/6756943/127997484-b0875cd4-2a3c-42b9-8753-f77786687bd9.png)

Crossreferenced with open definition: https://licenses.opendefinition.org/licenses/groups/all.json
List of licenses to be manually checked:

```
0bsd
adsl
afl-1.1
afl-1.2
afl-2.0
afl-2.1
agpl-1.0-only
agpl-1.0-or-later
agpl-3.0-only
agpl-3.0-or-later
amdplpa
aml
ampas
antlr-pd
antlr-pd-fallback
apafml
apsl-1.0
apsl-1.1
apsl-1.2
abstyles
adobe-2006
adobe-glyph
afmparse
aladdin
apache-1.0
apache-1.1
apache-2.0
artistic-1.0
artistic-1.0-perl
artistic-1.0-cl8
artistic-2.0
bsd-1-clause
bsd-2-clause
bsd-2-clause-patent
bsd-2-clause-views
bsd-3-clause
bsd-3-clause-attribution
bsd-3-clause-clear
bsd-3-clause-lbnl
bsd-3-clause-no-nuclear-license
bsd-3-clause-no-nuclear-license-2014
bsd-3-clause-no-nuclear-warranty
bsd-3-clause-open-mpi
bsd-4-clause
bsd-4-clause-uc
bsd-protection
bsd-source-code
busl-1.1
bahyph
barr
beerware
bittorrent-1.0
bittorrent-1.1
blueoak-1.0.0
borceux
cal-1.0
cal-1.0-combined-work-exception
cc-by-1.0
cc-by-2.0
cc-by-2.5
cc-by-3.0
cc-by-3.0-at
cc-by-3.0-us
cc-by-nc-1.0
cc-by-nc-2.0
cc-by-nc-2.5
cc-by-nc-3.0
cc-by-nc-nd-1.0
cc-by-nc-nd-2.0
cc-by-nc-nd-2.5
cc-by-nc-nd-3.0
cc-by-nc-nd-3.0-igo
cc-by-nc-nd-4.0
cc-by-nc-sa-1.0
cc-by-nc-sa-2.0
cc-by-nc-sa-2.5
cc-by-nc-sa-3.0
cc-by-nc-sa-4.0
cc-by-nd-1.0
cc-by-nd-2.0
cc-by-nd-2.5
cc-by-nd-3.0
cc-by-nd-4.0
cc-by-sa-1.0
cc-by-sa-2.0
cc-by-sa-2.0-uk
cc-by-sa-2.5
cc-by-sa-3.0
cc-by-sa-3.0-at
cc-pddc
cddl-1.1
cdla-permissive-1.0
cdla-sharing-1.0
cecill-1.0
cecill-1.1
cecill-2.0
cecill-b
cecill-c
cern-ohl-1.1
cern-ohl-1.2
cern-ohl-p-2.0
cern-ohl-s-2.0
cern-ohl-w-2.0
cnri-jython
cnri-python
cnri-python-gpl-compatible
cpl-1.0
cpol-1.02
caldera
clartistic
condor-1.1
crossword
crystalstacker
cube
d-fsl-1.0
doc
dsdp
dotseqn
ecl-1.0
efl-1.0
epics
eudatagrid
eupl-1.0
eupl-1.2
entessa
erlpl-1.1
eurosym
fsfap
fsful
fsfullr
ftl
fair
frameworx-1.0
freeimage
gfdl-1.1-invariants-only
gfdl-1.1-invariants-or-later
gfdl-1.1-no-invariants-only
gfdl-1.1-no-invariants-or-later
gfdl-1.1-only
gfdl-1.1-or-later
gfdl-1.2-invariants-only
gfdl-1.2-invariants-or-later
gfdl-1.2-no-invariants-only
gfdl-1.2-no-invariants-or-later
gfdl-1.2-only
gfdl-1.2-or-later
gfdl-1.3-invariants-only
gfdl-1.3-invariants-or-later
gfdl-1.3-no-invariants-only
gfdl-1.3-no-invariants-or-later
gfdl-1.3-only
gfdl-1.3-or-later
gl2ps
glwtpl
gpl-1.0-only
gpl-1.0-or-later
gpl-2.0-only
gpl-2.0-or-later
gpl-3.0-only
gpl-3.0-or-later
giftware
glide
glulxe
hpnd-sell-variant
htmltidy
haskellreport
hippocratic-2.1
ibm-pibs
icu
ijg
imagemagick
imlib2
info-zip
intel
intel-acpi
interbase-1.0
jpnic
json
jasper-2.0
lal-1.2
lal-1.3
lgpl-2.0-only
lgpl-2.0-or-later
lgpl-2.1-only
lgpl-2.1-or-later
lgpl-3.0-only
lgpl-3.0-or-later
lgpllr
lppl-1.0
lppl-1.1
lppl-1.2
lppl-1.3a
lppl-1.3c
latex2e
leptonica
liliq-p-1.1
liliq-r-1.1
liliq-rplus-1.1
libpng
linux-openib
mit-0
mit-cmu
mit-advertising
mit-enna
mit-feh
mit-open-group
mitnfa
mpl-2.0-no-copyleft-exception
mtll
makeindex
miros
motosoto
mulanpsl-1.0
mulanpsl-2.0
multics
mup
nbpl-1.0
ncgl-uk-2.0
nist-pd
nist-pd-fallback
nlod-1.0
nlpl
nosl
npl-1.0
npl-1.1
nrl
ntp-0
naumen
net-snmp
netcdf
newsletr
nokia
noweb
o-uda-1.0
occt-pl
odbl-1.0
ofl-1.0
ofl-1.0-rfn
ofl-1.0-no-rfn
ofl-1.1-rfn
ofl-1.1-no-rfn
ogc-1.0
ogl-canada-2.0
oldap-1.1
oldap-1.2
oldap-1.3
oldap-1.4
oldap-2.0
oldap-2.0.1
oldap-2.1
oldap-2.2
oldap-2.2.1
oldap-2.2.2
oldap-2.3
oldap-2.4
oldap-2.5
oldap-2.6
oldap-2.7
oldap-2.8
oml
opl-1.0
oset-pl-2.1
osl-1.0
osl-1.1
osl-2.0
osl-2.1
openssl
php-3.01
psf-2.0
parity-6.0.0
parity-7.0.0
plexus
polyform-noncommercial-1.0.0
polyform-small-business-1.0.0
postgresql
python-2.0
qhull
rhecos-1.1
rpl-1.1
rsa-md
rdisc
ruby
sax-pd
scea
sgi-b-1.0
sgi-b-1.1
sgi-b-2.0
shl-0.5
shl-0.51
sissl-1.2
smlnj
smppl
snia
ssh-openssh
ssh-short
sspl-1.0
swl
saxpath
sendmail
sendmail-8.23
simpl-2.0
sleepycat
spencer-86
spencer-94
spencer-99
sugarcrm-1.1.3
tapr-ohl-1.0
tcl
tcp-wrappers
tmate
torque-1.1
tosl
tu-berlin-1.0
tu-berlin-2.0
ucl-1.0
upl-1.0
unicode-dfs-2015
unicode-dfs-2016
unicode-tou
unlicense
vostrom
vim
w3c-19980720
w3c-20150513
wtfpl
watcom-1.0
wsuipa
x11
xfree86-1.1
xskat
xerox
xnet
ypl-1.0
ypl-1.1
zpl-1.1
zpl-2.1
zed
zend-2.0
zimbra-1.3
zimbra-1.4
zlib
blessing
bzip2-1.0.5
bzip2-1.0.6
copyleft-next-0.3.0copyleft-next-0.3.1
curl
diffmark
dvipdfm
egenix
etalab-2.0
gsoap-1.3b
gnuplot
imatix
libpng-2.0
libselinux-1.0
libtiff
mpich2
psfrag
psutils
xinetd
xpp
zlib-acknowledgement
```