### PR TITLE
search: fix internal _sort/_facet [+]

### DIFF
--- a/invenio_rdm_records/searchconfig.py
+++ b/invenio_rdm_records/searchconfig.py
@@ -61,8 +61,8 @@ class SearchConfig:
     def __init__(self, config, sort=None, facets=None):
         """Initialize search config."""
         config = config or {}
-        self._sort = None
-        self._facets = None
+        self._sort = []
+        self._facets = []
 
         if 'sort' in config:
             self._sort = SortOptionsSelector(


### PR DESCRIPTION
If 'sort' or 'facets' is omitted/forgotten in RDM_SEARCH the code breaks
because self._sort/self._facets are expected to be iterable. By setting
them to be [] by default, that interface is respected.
