### PR TITLE
Update celery tasks entrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,8 @@ setup(
             'invenio_rdm_records_ext = invenio_rdm_records.views:blueprint',
         ],
         'invenio_celery.tasks': [
-            'invenio_rdm_records = invenio_rdm_records.fixtures.tasks',
+            'invenio_rdm_records_fixtures = invenio_rdm_records.fixtures.tasks',
+            'invenio_rdm_records_services = invenio_rdm_records.services.tasks',
         ],
         'invenio_db.models': [
             'invenio_rdm_records = invenio_rdm_records.records.models',


### PR DESCRIPTION
Previously, celery would complain about the unregistered task `invenio_rdm_records.services.tasks.update_expired_embargos`.
The task was not listed during celery startup:
```
[tasks]
  . invenio_accounts.tasks.clean_session_table
  . invenio_accounts.tasks.send_security_email
  . invenio_communities.fixtures.tasks.create_demo_community
  . invenio_drafts_resources.services.records.tasks.cleanup_drafts
  . invenio_files_rest.tasks.merge_multipartobject
  . invenio_files_rest.tasks.migrate_file
  . invenio_files_rest.tasks.remove_expired_multipartobjects
  . invenio_files_rest.tasks.remove_file_data
  . invenio_files_rest.tasks.schedule_checksum_verification
  . invenio_files_rest.tasks.verify_checksum
  . invenio_iiif.tasks.create_thumbnail
  . invenio_indexer.tasks.delete_record
  . invenio_indexer.tasks.index_record
  . invenio_indexer.tasks.process_bulk_queue
  . invenio_mail.tasks.send_email
  . invenio_oaiserver.tasks.update_affected_records
  . invenio_oaiserver.tasks.update_records_sets
  . invenio_rdm_records.fixtures.tasks.create_demo_record
  . invenio_rdm_records.fixtures.tasks.create_vocabulary_record
  . invenio_records_resources.tasks.extract_file_metadata
```

The logged error message:
```
[2021-08-23 11:30:38,207: ERROR/MainProcess] Received unregistered task of type 'invenio_rdm_records.services.tasks.update_expired_embargos'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you're using relative imports?

Please see
http://docs.celeryq.org/en/latest/internals/protocol.html
for more information.

The full contents of the message body was:
b'\x93\x90\x80\x84\xa9callbacks\xc0\xa8errbacks\xc0\xa5chain\xc0\xa5chord\xc0' (39b)
Traceback (most recent call last):
  File "/home/mmoser/.local/share/virtualenvs/tu-data-hHy_bWtj/lib/python3.8/site-packages/celery/worker/consumer/consumer.py", line 555, in on_task_received
    strategy = strategies[type_]
KeyError: 'invenio_rdm_records.services.tasks.update_expired_embargos'
```