### PR TITLE
gh actions: disable runs on draft prs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   Tests:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
You can see below how the tests won't run on this PR since it is a draft. Shall we also disable CodeQL?