### PR TITLE
Fix use before definition (for Flask 2.x)

### DIFF
--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -23,7 +23,6 @@ from invenio_records_resources.records.systemfields import FilesField, \
 from invenio_vocabularies.contrib.affiliations.api import Affiliation
 from invenio_vocabularies.contrib.subjects.api import Subject
 from invenio_vocabularies.records.api import Vocabulary
-from werkzeug.local import LocalProxy
 
 from . import models
 from .dumpers import EDTFDumperExt, EDTFListDumperExt, GrantTokensDumperExt
@@ -197,7 +196,7 @@ class RDMFileDraft(FileRecord):
     """File associated with a draft."""
 
     model_cls = models.RDMFileDraftMetadata
-    record_cls = LocalProxy(lambda: RDMDraft)
+    record_cls = None  # defined below
 
 
 class RDMDraft(CommonFieldsMixin, Draft):
@@ -219,6 +218,9 @@ class RDMDraft(CommonFieldsMixin, Draft):
     has_draft = HasDraftCheckField()
 
 
+RDMFileDraft.record_cls = RDMDraft
+
+
 #
 # Record API
 #
@@ -226,7 +228,7 @@ class RDMFileRecord(FileRecord):
     """Example record file API."""
 
     model_cls = models.RDMFileRecordMetadata
-    record_cls = LocalProxy(lambda: RDMRecord)
+    record_cls = None  # defined below
 
 
 class RDMRecord(CommonFieldsMixin, Record):
@@ -248,3 +250,6 @@ class RDMRecord(CommonFieldsMixin, Record):
     )
 
     has_draft = HasDraftCheckField(RDMDraft)
+
+
+RDMFileRecord.record_cls = RDMRecord


### PR DESCRIPTION
Fixes the following complaint of `run-tests.sh`:
```
lists of files in version control and sdist match

Warning, treated as error:
autodoc: failed to import module 'ext' from module 'invenio_rdm_records'; the following exception was raised:
Traceback (most recent call last):
  File "/home/maximus/.local/share/virtualenvs/invenio-rdm-records-D8MrXj0B/lib/python3.9/site-packages/sphinx/ext/autodoc/importer.py", line 67, in import_module
    return importlib.import_module(modname)
  File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/__init__.py", line 11, in <module>
    from .ext import InvenioRDMRecords
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/ext.py", line 23, in <module>
    from . import config
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/config.py", line 13, in <module>
    from .services import facets
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/services/__init__.py", line 10, in <module>
    from .config import RDMFileDraftServiceConfig, RDMFileRecordServiceConfig, \
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/services/config.py", line 26, in <module>
    from ..records import RDMDraft, RDMRecord
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/records/__init__.py", line 10, in <module>
    from .api import RDMDraft, RDMFileDraft, RDMFileRecord, RDMParent, RDMRecord
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/records/api.py", line 196, in <module>
    class RDMFileDraft(FileRecord):
  File "/home/maximus/rdm/modules/invenio-records/invenio_records/systemfields/base.py", line 360, in __new__
    declared_fields = _get_inherited_fields(class_, SystemField)
  File "/home/maximus/rdm/modules/invenio-records/invenio_records/systemfields/base.py", line 48, in _get_inherited_fields
    fields.update(_get_fields(base.__dict__, field_class))
  File "/home/maximus/rdm/modules/invenio-records/invenio_records/systemfields/base.py", line 26, in _get_fields
    if isinstance(val, field_class):
  File "/home/maximus/.local/share/virtualenvs/invenio-rdm-records-D8MrXj0B/lib/python3.9/site-packages/werkzeug/local.py", line 432, in __get__
    obj = instance._get_current_object()
  File "/home/maximus/.local/share/virtualenvs/invenio-rdm-records-D8MrXj0B/lib/python3.9/site-packages/werkzeug/local.py", line 554, in _get_current_object
    return self.__local()  # type: ignore
  File "/home/maximus/rdm/modules/invenio-rdm-records/invenio_rdm_records/records/api.py", line 200, in <lambda>
    record_cls = LocalProxy(lambda: RDMDraft)
NameError: name 'RDMDraft' is not defined

Removing network docker_services_cli_default
WARNING: Network docker_services_cli_default not found.
```

This seems to be related to `Flask` 2.x (or `Werkzeug` 2.x), as it does not happen with the 1.x versions of those modules installed.