### PR TITLE
serializer: fix datacite alt identifier doi handling

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -310,8 +310,7 @@ class DataCite43Schema(Schema):
         """Get (main and alternate) identifiers list."""
         serialized_identifiers = []
 
-        # pids go first so the DOI from the record is the main doi
-        # otherwise a doi from identifiers can be used
+        # pids go first so the DOI from the record is included
         pids = obj["pids"]
         for scheme, id_ in pids.items():
             id_scheme = get_scheme_datacite(
@@ -331,12 +330,15 @@ class DataCite43Schema(Schema):
             id_scheme = get_scheme_datacite(
                 scheme, "RDM_RECORDS_IDENTIFIERS_SCHEMES", default=scheme
             )
-
             if id_scheme:
-                serialized_identifiers.append({
-                    "identifier": id_["identifier"],
-                    "identifierType": id_scheme,
-                })
+                # DataCite only accepts a DOI identifier that is the official
+                # registered DOI - ones in the alternate identifier field are
+                # dropped
+                if id_scheme != 'DOI':
+                    serialized_identifiers.append({
+                        "identifier": id_["identifier"],
+                        "identifierType": id_scheme,
+                    })
 
         return serialized_identifiers or missing
 

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -396,6 +396,33 @@ def test_datacite43_xml_serializer(running_app, full_record):
     assert serialized_record.split("\n") == expected_data
 
 
+def test_datacite43_identifiers(running_app, minimal_record):
+    """Test serialization of records with DOI alternate identifiers"""
+    # Mimic user putting DOI in alternate identifier field
+    minimal_record["metadata"]["identifiers"] = [{
+                "identifier": "10.5281/inveniordm.1234",
+                "scheme": "doi"
+            }]
+
+    serializer = DataCite43JSONSerializer()
+    serialized_record = serializer.dump_one(minimal_record)
+
+    assert 'identifiers' not in serialized_record
+
+    minimal_record["pids"] = {
+            "doi": {
+                "identifier": "10.5281/inveniordm.1234",
+                "provider": "datacite",
+                "client": "inveniordm"
+            },
+        }
+
+    serialized_record = serializer.dump_one(minimal_record)
+    assert len(serialized_record['identifiers']) == 1
+    identifier = serialized_record['identifiers'][0]['identifier']
+    assert identifier == "10.5281/inveniordm.1234"
+
+
 def test_datacite43_serializer_with_unknown_id_schemes(
     running_app, full_modified_record
 ):


### PR DESCRIPTION
Resolves #811 by removing alternative identifiers that have type DOI from the DataCite serialization, since DataCite doesn't accept DOIs that are not the registered DOI.