### PR TITLE
services: remove external DOI when changed

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -448,7 +448,13 @@ RDM_PERSISTENT_IDENTIFIER_PROVIDERS = [
         client=providers.DataCiteClient("datacite", config_prefix="DATACITE"),
     ),
     # DOI provider for externally managed DOIs
-    providers.ExternalPIDProvider("external", pid_type="doi"),
+    providers.ExternalPIDProvider(
+        "external",
+        "doi",
+        validators=[
+            providers.BlockedPrefixes(config_names=['DATACITE_PREFIX'])
+        ]
+    ),
     # OAI identifier
     providers.OAIPIDProvider("oai"),
 ]

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -138,16 +138,6 @@ def always_valid(identifier):
     return True
 
 
-RDM_RECORDS_RECORD_PID_SCHEMES = {
-    "doi": {
-        "label": _("DOI"),
-        "validator": idutils.is_doi
-    },
-    "oai": {
-        "label": _("OAI"),
-        "validator": always_valid
-    }
-}
 RDM_RECORDS_PERSONORG_SCHEMES = {
     "orcid": {
         "label": _("ORCID"),
@@ -446,6 +436,7 @@ RDM_PERSISTENT_IDENTIFIER_PROVIDERS = [
     providers.DataCitePIDProvider(
         "datacite",
         client=providers.DataCiteClient("datacite", config_prefix="DATACITE"),
+        label=_("DOI"),
     ),
     # DOI provider for externally managed DOIs
     providers.ExternalPIDProvider(
@@ -453,10 +444,11 @@ RDM_PERSISTENT_IDENTIFIER_PROVIDERS = [
         "doi",
         validators=[
             providers.BlockedPrefixes(config_names=['DATACITE_PREFIX'])
-        ]
+        ],
+        label=_("DOI"),
     ),
     # OAI identifier
-    providers.OAIPIDProvider("oai"),
+    providers.OAIPIDProvider("oai", label=_("OAI ID"),),
 ]
 """A list of configured persistent identifier providers.
 
@@ -474,10 +466,14 @@ RDM_PERSISTENT_IDENTIFIERS = {
     "doi": {
         "providers": ["datacite", "external"],
         "required": True,
+        "label": _("DOI"),
+        "validator": idutils.is_doi,
     },
     "oai": {
         "providers": ["oai"],
         "required": True,
+        "label": _("OAI"),
+        "validator": always_valid,
     },
 }
 """The configured persistent identifiers for records.

--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -109,18 +109,19 @@ class InvenioRDMRecords(object):
             ('RDM_RECORDS_DOI_DATACITE_FORMAT', 'DATACITE_FORMAT'),
         ]
         for old, new in deprecated:
-            if old in app.config:
-                if new in app.config:
+            if new not in app.config:
+                if old in app.config:
                     app.config[new] = app.config[old]
                     warnings.warn(
                         f"{old} has been replaced with {new}. "
                         "Please update your config.",
                         DeprecationWarning
                     )
-                else:
+            else:
+                if old in app.config:
                     warnings.warn(
                         f"{old} is deprecated. Please remove it from your "
-                        "config.",
+                        "config as {new} is already set.",
                         DeprecationWarning
                     )
 

--- a/invenio_rdm_records/services/pids/providers/__init__.py
+++ b/invenio_rdm_records/services/pids/providers/__init__.py
@@ -10,7 +10,7 @@
 
 from .base import PIDProvider
 from .datacite import DataCiteClient, DataCitePIDProvider
-from .external import ExternalPIDProvider, BlockedPrefixes
+from .external import BlockedPrefixes, ExternalPIDProvider
 from .oai import OAIPIDProvider
 
 __all__ = (

--- a/invenio_rdm_records/services/pids/providers/__init__.py
+++ b/invenio_rdm_records/services/pids/providers/__init__.py
@@ -10,10 +10,11 @@
 
 from .base import PIDProvider
 from .datacite import DataCiteClient, DataCitePIDProvider
-from .external import ExternalPIDProvider
+from .external import ExternalPIDProvider, BlockedPrefixes
 from .oai import OAIPIDProvider
 
 __all__ = (
+    "BlockedPrefixes",
     "DataCiteClient",
     "DataCitePIDProvider",
     "ExternalPIDProvider",

--- a/invenio_rdm_records/services/pids/providers/base.py
+++ b/invenio_rdm_records/services/pids/providers/base.py
@@ -18,9 +18,11 @@ class PIDProvider:
     """Base class for PID providers."""
 
     def __init__(self, name, client=None, pid_type=None,
-                 default_status=PIDStatus.NEW, managed=True, **kwargs):
+                 default_status=PIDStatus.NEW, managed=True, label=None,
+                 *kwargs):
         """Constructor."""
         self.name = name
+        self.label = label or name
         self.client = client
         self.pid_type = pid_type
         self.default_status = default_status

--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -9,6 +9,7 @@
 
 from flask import current_app
 from flask_babelex import lazy_gettext as _
+from invenio_db import db
 
 from .base import PIDProvider
 
@@ -46,3 +47,12 @@ class ExternalPIDProvider(PIDProvider):
             errors.append(_("PID value is required for external provider."))
 
         return (True, []) if not errors else (False, errors)
+
+    def delete(self, pid, **kwargs):
+        """Delete a persistent identifier."""
+        # PID is in REGISTERED status and we don't want to keep it around, so
+        # force delete the PID (only supported for NEW status in the API so we
+        # circumvent the API interface here).
+        with db.session.begin_nested():
+            db.session.delete(pid)
+        return True

--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -12,7 +12,7 @@ from flask_babelex import lazy_gettext as _
 from invenio_db import db
 
 from .base import PIDProvider
-from flask import current_app
+
 
 class BlockedPrefixes:
     """Blocked prefixes validator."""
@@ -76,7 +76,8 @@ class ExternalPIDProvider(PIDProvider):
             record, identifier, provider, **kwargs)
 
         if not identifier:
-            errors.append(_("PID value is required for external provider."))
+            errors.append(_("Missing {scheme} for required field.").format(
+                scheme=self.label))
 
         for v in self._validators:
             v(record, identifier, provider, errors)

--- a/tests/services/components/test_pids_component.py
+++ b/tests/services/components/test_pids_component.py
@@ -255,7 +255,7 @@ def test_create_with_required_managed(
         {"test": {"identifier": "", "provider": "external"}},
         [{
             'field': 'pids.test',
-            'message': ['PID value is required for external provider.']
+            'message': ['Missing external for required field.']
         }]
     )
 ])

--- a/tests/services/pids/providers/test_external_pid_provider.py
+++ b/tests/services/pids/providers/test_external_pid_provider.py
@@ -18,7 +18,7 @@ from invenio_rdm_records.services.pids.providers import ExternalPIDProvider
 @pytest.fixture(scope="function")
 def external_provider():
     """Application factory fixture."""
-    return ExternalPIDProvider("external", pid_type="testid")
+    return ExternalPIDProvider("external", "testid", label="DOI")
 
 
 @pytest.fixture(scope="function")
@@ -92,4 +92,4 @@ def test_external_provider_validate_failure(
         record=record, provider="external"
     )
     assert not success
-    assert "PID value is required for external provider." in errors
+    assert "Missing DOI for required field." in errors

--- a/tests/services/pids/test_pids_service.py
+++ b/tests/services/pids/test_pids_service.py
@@ -317,7 +317,7 @@ def test_pids_creation_invalid_external_payload(
 
     draft = service.create(superuser_identity, data)
     assert draft.errors == [
-        {'field': 'pids', 'messages': ['Invalid value for scheme doi']}
+        {'field': 'pids.doi', 'message': ['Missing DOI for required field.']}
     ]
 
 


### PR DESCRIPTION
- Fixes an issue where the persistent identifier in PIDStore was not
  completely deleted for external DOIs, and thus it was not possible for
  new records to use the same DOI. (closes #845)