### PR TITLE
alembic: add dependency for the latest migration script

### DIFF
--- a/invenio_rdm_records/alembic/9e0ac518b9df_create_records_communities_m2m_table.py
+++ b/invenio_rdm_records/alembic/9e0ac518b9df_create_records_communities_m2m_table.py
@@ -15,7 +15,7 @@ from sqlalchemy_utils import UUIDType
 revision = '9e0ac518b9df'
 down_revision = ('8ed1a438601c', '88d1463de5c0')
 branch_labels = ()
-depends_on = 'de9c14cbb0b2'
+depends_on = ('de9c14cbb0b2', 'a14fa442680f')
 
 
 def upgrade():


### PR DESCRIPTION
* because the migration script references the request_metadata table,
  but doesn't have the corresponding revision as a dependency