### PR TITLE
datacite: enforce string type on some datacite config items

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -125,6 +125,8 @@ class InvenioRDMRecords(object):
                         DeprecationWarning
                     )
 
+        self.fix_datacite_configs(app)
+
     def service_configs(self, app):
         """Customized service configs."""
         # Overall record permission policy
@@ -229,3 +231,15 @@ class InvenioRDMRecords(object):
             service=self.subjects_service,
             config=SubjectsResourceConfig,
         )
+
+    def fix_datacite_configs(self, app):
+        """Make sure that the DataCite config items are strings."""
+        datacite_config_items = [
+            'DATACITE_USERNAME',
+            'DATACITE_PASSWORD',
+            'DATACITE_FORMAT',
+            'DATACITE_PREFIX',
+        ]
+        for config_item in datacite_config_items:
+            if config_item in app.config:
+                app.config[config_item] = str(app.config[config_item])


### PR DESCRIPTION
make sure that the credentials, as well as the doi components are of type string, to avoid type errors in the minting process

otherwise, it could happen that some values are parsed in the wrong type (e.g. the DOI prefix as a float rather than a string), if the configuration is provided via environment variables