### PR TITLE
refactor: increase vocabulary prop lookup performance

### DIFF
--- a/invenio_rdm_records/resources/serializers/utils.py
+++ b/invenio_rdm_records/resources/serializers/utils.py
@@ -8,6 +8,7 @@
 
 """Helpers for serializers."""
 
+from elasticsearch_dsl.query import Q
 from invenio_access.permissions import system_identity
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 
@@ -21,12 +22,12 @@ def get_vocabulary_props(vocabulary, fields, id_):
     results = vocabulary_service.read_all(
         system_identity,
         ['id'] + fields,
-        vocabulary
+        vocabulary,
+        extra_filter=Q('term', id=id_),
     )
 
     for h in results.hits:
-        if h["id"] == id_:
-            return h.get("props", {})
+        return h.get("props", {})
 
     raise VocabularyItemNotFoundError(
         f"The '{vocabulary}' vocabulary item '{id_}' was not found.")


### PR DESCRIPTION
adding filter to only match the provided id so it returns one or no item. 
iterating over all the items and comparing them with the provided id takes more time and the further back in the results the wanted item is, the longer it takes.

performance wise, this is at least 2 times quicker - even going up to 50 times quicker (as of right now) depending on the returned list. usually it is around 10 times quicker
![Screenshot from 2021-12-20 13-55-05](https://user-images.githubusercontent.com/72449192/146770349-ef3591d4-36de-4263-8ec0-cb288f4fc5fa.png)

