### PR TITLE
services: refactor configuration customization

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -320,3 +320,9 @@ intersphinx_mapping = {
 
 # Autodoc configuraton.
 autoclass_content = 'both'
+
+# To address <unknown>:1:py:class reference target not found
+# (better ideas welcomed)
+nitpick_ignore = [
+    ('py:class', 'invenio_rdm_records.services.permissions.RDMRecordPermissionPolicy'),  # noqa
+]

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -12,6 +12,7 @@
 import idutils
 
 from .services import facets
+from .services.permissions import RDMRecordPermissionPolicy
 from .services.pids import providers
 
 
@@ -295,7 +296,7 @@ RDM_RECORDS_LOCATION_SCHEMES = {
 #
 # Record permission policy
 #
-RDM_PERMISSION_POLICY = None
+RDM_PERMISSION_POLICY = RDMRecordPermissionPolicy
 """Override the default record permission policy."""
 
 

--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -26,7 +26,6 @@ from . import config
 from .resources import RDMDraftFilesResourceConfig, \
     RDMParentRecordLinksResource, RDMParentRecordLinksResourceConfig, \
     RDMRecordFilesResourceConfig, RDMRecordResource, RDMRecordResourceConfig
-from .searchconfig import SearchConfig
 from .secret_links import LinkNeed, SecretLink
 from .services import RDMFileDraftServiceConfig, RDMFileRecordServiceConfig, \
     RDMRecordService, RDMRecordServiceConfig, SecretLinkService
@@ -129,49 +128,11 @@ class InvenioRDMRecords(object):
 
     def service_configs(self, app):
         """Customized service configs."""
-        # Overall record permission policy
-        permission_policy = app.config.get('RDM_PERMISSION_POLICY')
-        pid_providers = app.config['RDM_PERSISTENT_IDENTIFIER_PROVIDERS']
-        pids = app.config['RDM_PERSISTENT_IDENTIFIERS']
-        doi_enabled = app.config['DATACITE_ENABLED']
-
-        # Available facets and sort options
-        sort_opts = app.config.get('RDM_SORT_OPTIONS')
-        facet_opts = app.config.get('RDM_FACETS')
-
-        # Specific configuration for each search endpoint
-        search_opts = SearchConfig(
-            app.config.get('RDM_SEARCH'),
-            sort=sort_opts,
-            facets=facet_opts,
-        )
-        search_drafts_opts = SearchConfig(
-            app.config.get('RDM_SEARCH_DRAFTS'),
-            sort=sort_opts,
-            facets=facet_opts,
-        )
-        search_versions_opts = SearchConfig(
-            app.config.get('RDM_SEARCH_VERSIONING'),
-            sort=sort_opts,
-            facets=facet_opts,
-        )
 
         class ServiceConfigs:
-            record = RDMRecordServiceConfig.customize(
-                permission_policy=permission_policy,
-                pid_providers=pid_providers,
-                pids=pids,
-                doi_enabled=doi_enabled,
-                search=search_opts,
-                search_drafts=search_drafts_opts,
-                search_versions=search_versions_opts,
-            )
-            file = RDMFileRecordServiceConfig.customize(
-                permission_policy=permission_policy,
-            )
-            file_draft = RDMFileDraftServiceConfig.customize(
-                permission_policy=permission_policy,
-            )
+            record = RDMRecordServiceConfig.build()
+            file = RDMFileRecordServiceConfig.build()
+            file_draft = RDMFileDraftServiceConfig.build()
             affiliations = AffiliationsServiceConfig
             subjects = SubjectsServiceConfig
 

--- a/invenio_rdm_records/services/pids/service.py
+++ b/invenio_rdm_records/services/pids/service.py
@@ -19,7 +19,19 @@ class PIDsService(RecordService):
     def __init__(self, config, manager_cls):
         """Constructor for RecordService."""
         super().__init__(config)
-        self._manager = manager_cls(self.config.pids_providers)
+        self.manager_cls = manager_cls
+
+    @property
+    def _manager(self):
+        """Transitive manager property.
+
+        This is done to:
+        - only access self.config attributes when in an application context
+        - limit code change
+        - limit side-effects (in case using pre-existing `pid_manager` would
+                              cause some.)
+        """
+        return self.manager_cls(self.config.pids_providers)
 
     @property
     def pid_manager(self):


### PR DESCRIPTION
At its core, service config.py (and others really) is a place to
- define the config interface
- define how those config attributes are populated with special attention to
  the fact that InvenioRDM is inherently configurable per instance.

So the idea is to
- make that core functionality clear and predominant
- group related things together e.g. configuration customization is extracted
  out of ext.py completely and placed in customization.py
- favor independent composition of reusable configuration attribute definition
  (using data accessors, an already common pattern in InvenioRDM)
