### PR TITLE
permission: fix community permission

### DIFF
--- a/invenio_rdm_records/fixtures/tasks.py
+++ b/invenio_rdm_records/fixtures/tasks.py
@@ -11,10 +11,9 @@
 import random
 
 from celery import shared_task
-from flask_principal import Identity, UserNeed
+from flask_principal import Identity, Need, UserNeed
 from invenio_access.permissions import any_user, authenticated_user, \
     system_identity
-from invenio_communities.communities import CommunityNeed
 from invenio_communities.invitations.services.request_types import \
     CommunityMemberInvitation
 from invenio_communities.members.errors import AlreadyMemberError
@@ -73,7 +72,7 @@ def _get_random_community(communities):
     # create community owner identity
     owner_id = communities[r]["access"]["owned_by"][0]["user"]
     owner_identity = get_authenticated_identity(owner_id)
-    owner_identity.provides.add(CommunityNeed(uuid))
+    owner_identity.provides.add(Need("community", uuid))
     return uuid, owner_id, owner_identity
 
 

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -14,9 +14,8 @@ from functools import reduce
 from itertools import chain
 
 from elasticsearch_dsl import Q
-from flask_principal import UserNeed
+from flask_principal import Need, UserNeed
 from invenio_access.permissions import authenticated_user
-from invenio_communities.communities.services.permissions import CommunityNeed
 from invenio_records_permissions.generators import Generator
 from invenio_requests.resolvers.registry import ResolverRegistry
 
@@ -210,5 +209,4 @@ class CommunityCurator(Generator):
         """Set of Needs granting permission."""
         if record is None:
             return []
-
-        return [CommunityNeed(c) for c in record.parent.communities.ids]
+        return [Need("community", c) for c in record.parent.communities.ids]

--- a/tests/services/test_service_review.py
+++ b/tests/services/test_service_review.py
@@ -8,10 +8,9 @@
 """Test of the review deposit integration."""
 
 import pytest
-from flask_principal import Identity
+from flask_principal import Identity, Need
 from invenio_access.permissions import any_user, authenticated_user
 from invenio_communities import current_communities
-from invenio_communities.communities import CommunityNeed
 from invenio_communities.communities.records.api import Community
 from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_requests import current_requests_service
@@ -30,7 +29,7 @@ def get_community_owner_identity(community):
     identity = Identity(owner_id)
     identity.provides.add(any_user)
     identity.provides.add(authenticated_user)
-    identity.provides.add(CommunityNeed(str(community.id)))
+    identity.provides.add(Need("community", str(community.id)))
     return identity
 
 


### PR DESCRIPTION
This PR is required as in the latest master of invenio-communities, `CommunityNeed` was removed in this [commit](https://github.com/inveniosoftware/invenio-communities/commit/13a8c772ea914223d193d64dfb0054e95438bf97). I think this is a temporal solution but I am missing quite some context about permissions.