### PR TITLE
global: add invenio-users-resources as a dependency

### DIFF
--- a/invenio_rdm_records/cli.py
+++ b/invenio_rdm_records/cli.py
@@ -15,6 +15,10 @@ from invenio_access.permissions import system_identity
 from invenio_accounts.proxies import current_datastore
 from invenio_communities import current_communities
 from invenio_db import db
+from invenio_users_resources.proxies import \
+    current_groups_service as groups_service
+from invenio_users_resources.proxies import \
+    current_users_service as users_service
 from invenio_vocabularies.proxies import \
     current_service as current_vocabularies_service
 
@@ -211,4 +215,9 @@ def rebuild_index():
     affs_service = current_rdm_records.affiliations_service
     affs_service.rebuild_index(identity=system_identity)
 
-    click.secho("Reindexed records and vocabularies!", fg="green")
+    click.secho("Reindexing users and groups...", fg="green")
+
+    users_service.rebuild_index(identity=system_identity)
+    groups_service.rebuild_index(identity=system_identity)
+
+    click.secho("Reindexing done!", fg="green")

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     'invenio-drafts-resources>=0.15.2,<0.16.0',
     'invenio-oaiserver>=1.4.0',
     'invenio-vocabularies>=0.10.3,<0.11.0',
+    'invenio-users-resources>=0.1.0,<1.0.0',
     'pytz>=2020.4',
     'pyyaml>=5.4.0',
 ]


### PR DESCRIPTION
also have the `rebuild-index` CLI command index the users and groups.
this obviously requires a pypi release of invenio-users-resources to work.

NOTE: this will require a bump of `invenio-accounts` to allow `2.0.X` in `invenio`

note: i accidentally called the origin branch `add-users-profiles` rather than `add-users-resources` as would be more correct