### PR TITLE
global: rename registered services

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -88,7 +88,7 @@ class PersonOrOrgSchema43(Schema):
 
         if ids:
             affiliations_service = (
-                current_service_registry.get("rdm-affiliations")
+                current_service_registry.get("affiliations")
             )
             affiliations = affiliations_service.read_many(system_identity, ids)
 
@@ -421,7 +421,7 @@ class DataCite43Schema(Schema):
 
         if ids:
             subjects_service = (
-                current_service_registry.get("rdm-subjects")
+                current_service_registry.get("subjects")
             )
             subjects = subjects_service.read_many(system_identity, ids)
             validator = validate.URL()

--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -19,16 +19,25 @@ def init(state):
     app = state.app
     # Register services - cannot be done in extension because
     # Invenio-Records-Resources might not have been initialized.
-    registry = app.extensions['invenio-records-resources'].registry
+    sregistry = app.extensions['invenio-records-resources'].registry
     ext = app.extensions['invenio-rdm-records']
-    registry.register(ext.records_service, service_id='records')
-    registry.register(ext.records_service.files, service_id='files')
-    registry.register(
-        ext.records_service.draft_files, service_id='draft-files')
-    registry.register(ext.affiliations_service, service_id='affiliations')
-    registry.register(ext.names_service, service_id='names')
-    registry.register(ext.subjects_service, service_id='subjects')
-    registry.register(ext.oaipmh_server_service, service_id='oaipmh-server')
+    sregistry.register(ext.records_service, service_id='records')
+    sregistry.register(ext.records_service.files, service_id='files')
+    sregistry.register(
+        ext.records_service.draft_files, service_id='draft-files'
+    )
+    sregistry.register(ext.affiliations_service, service_id='affiliations')
+    sregistry.register(ext.names_service, service_id='names')
+    sregistry.register(ext.subjects_service, service_id='subjects')
+    sregistry.register(ext.oaipmh_server_service, service_id='oaipmh-server')
+    # Register indexers
+    iregistry = app.extensions['invenio-indexer'].registry
+    iregistry.register(ext.records_service.indexer, indexer_id='records')
+    iregistry.register(
+        ext.affiliations_service.indexer, indexer_id='affiliations'
+    )
+    iregistry.register(ext.names_service.indexer, indexer_id='names')
+    iregistry.register(ext.subjects_service.indexer, indexer_id='subjects')
 
 
 def create_records_bp(app):

--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -21,13 +21,13 @@ def init(state):
     # Invenio-Records-Resources might not have been initialized.
     registry = app.extensions['invenio-records-resources'].registry
     ext = app.extensions['invenio-rdm-records']
-    registry.register(ext.records_service, service_id='rdm-records')
-    registry.register(ext.records_service.files, service_id='rdm-files')
+    registry.register(ext.records_service, service_id='records')
+    registry.register(ext.records_service.files, service_id='files')
     registry.register(
-        ext.records_service.draft_files, service_id='rdm-draft-files')
-    registry.register(ext.affiliations_service, service_id='rdm-affiliations')
-    registry.register(ext.names_service, service_id='rdm-names')
-    registry.register(ext.subjects_service, service_id='rdm-subjects')
+        ext.records_service.draft_files, service_id='draft-files')
+    registry.register(ext.affiliations_service, service_id='affiliations')
+    registry.register(ext.names_service, service_id='names')
+    registry.register(ext.subjects_service, service_id='subjects')
     registry.register(ext.oaipmh_server_service, service_id='oaipmh-server')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -826,7 +826,7 @@ def description_type_v(app, description_type):
 def subject_v(app):
     """Subject vocabulary record."""
     subjects_service = (
-        current_service_registry.get("rdm-subjects")
+        current_service_registry.get("subjects")
     )
     vocab = subjects_service.create(system_identity, {
         "id": "http://id.nlm.nih.gov/mesh/A-D000007",
@@ -960,7 +960,7 @@ def licenses_v(app, licenses):
 def affiliations_v(app):
     """Affiliation vocabulary record."""
     affiliations_service = (
-        current_service_registry.get("rdm-affiliations")
+        current_service_registry.get("affiliations")
     )
     aff = affiliations_service.create(system_identity, {
         "id": "cern",

--- a/tests/resources/vocabularies/test_affiliations_vocabulary.py
+++ b/tests/resources/vocabularies/test_affiliations_vocabulary.py
@@ -14,7 +14,7 @@ from invenio_vocabularies.contrib.affiliations.api import Affiliation
 
 @pytest.fixture(scope="module")
 def affiliations_service():
-    return current_service_registry.get("rdm-affiliations")
+    return current_service_registry.get("affiliations")
 
 
 @pytest.fixture()

--- a/tests/resources/vocabularies/test_names_vocabulary.py
+++ b/tests/resources/vocabularies/test_names_vocabulary.py
@@ -14,7 +14,7 @@ from invenio_vocabularies.contrib.names.api import Name
 
 @pytest.fixture(scope="module")
 def names_service():
-    return current_service_registry.get("rdm-names")
+    return current_service_registry.get("names")
 
 
 @pytest.fixture()

--- a/tests/resources/vocabularies/test_subjects_vocabulary.py
+++ b/tests/resources/vocabularies/test_subjects_vocabulary.py
@@ -14,7 +14,7 @@ from invenio_vocabularies.contrib.subjects.api import Subject
 
 @pytest.fixture(scope="module")
 def subjects_service():
-    return current_service_registry.get("rdm-subjects")
+    return current_service_registry.get("subjects")
 
 
 @pytest.fixture()


### PR DESCRIPTION
- requires https://github.com/inveniosoftware/invenio-indexer/pull/134
- requires a bump in invenio-records-resources to pass minor (`invenio-indexer>=1.2.3`), take the oppportunity to bump `invenio-records` too after https://github.com/inveniosoftware/invenio-records/pull/281.
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/931