### PR TITLE
Remove iiif initialization

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -95,8 +95,7 @@ class InvenioRDMRecords(object):
         self.init_resource(app)
         app.before_request(verify_token)
         app.extensions['invenio-rdm-records'] = self
-        # Load flask IIIF
-        IIIF(app)
+
 
     def init_config(self, app):
         """Initialize configuration."""


### PR DESCRIPTION
invenio-iiif is already initializing the `flask-iiif` extension. Thus, there is no need to initialize it again here. 