### PR TITLE
views: push app ctx to register indexers

### DIFF
--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -34,12 +34,13 @@ def init(state):
     sregistry.register(ext.iiif_service, service_id="rdm-iiif")
     # Register indexers
     iregistry = app.extensions['invenio-indexer'].registry
-    iregistry.register(ext.records_service.indexer, indexer_id='records')
-    iregistry.register(
-        ext.affiliations_service.indexer, indexer_id='affiliations'
-    )
-    iregistry.register(ext.names_service.indexer, indexer_id='names')
-    iregistry.register(ext.subjects_service.indexer, indexer_id='subjects')
+    with app.app_context():
+        iregistry.register(ext.records_service.indexer, indexer_id='records')
+        iregistry.register(
+            ext.affiliations_service.indexer, indexer_id='affiliations'
+        )
+        iregistry.register(ext.names_service.indexer, indexer_id='names')
+        iregistry.register(ext.subjects_service.indexer, indexer_id='subjects')
 
 
 def create_records_bp(app):


### PR DESCRIPTION
Indexers need the `current_app.config` to access the MQ [exchange configuration](https://github.com/inveniosoftware/invenio-records-resources/blob/master/invenio_records_resources/services/records/service.py#L38). However, on the views.py (blueprint registration) the app context has not yet been pushed causing an _out of application context_ error. Potential solutions:

a) temporarily push the app context (as implemented on the PR)
b) at invenio-records-resources level avoid using the `current_app` on the indexer and instead "hardcord" the exchange and queue in the service configuration (instead of just the name). This might restrict flexibility.
c) change the indexer registration to invenio-records-resources, do some sort of `if not registered:...`. this changes the paradigm that has been used for services so it's not ideal, but it would help on reproducibility and responsability (makes sense that where the indexer gets created is registered, i.e. records-resources).

Ideas? Tips? Comments? Complaints? I'm all ears, not a fan of any of the solutions... 😇 