### PR TITLE
serializers: use g.identity instead of system

### DIFF
--- a/invenio_rdm_records/resources/serializers/csl/schema.py
+++ b/invenio_rdm_records/resources/serializers/csl/schema.py
@@ -10,7 +10,7 @@
 from edtf import parse_edtf
 from edtf.parser.edtf_exceptions import EDTFParseException
 from edtf.parser.parser_classes import Date, Interval
-from invenio_access.permissions import system_identity
+from flask import g
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from marshmallow import Schema, fields, missing, pre_dump
 from marshmallow_utils.fields import SanitizedUnicode, StrippedHTML
@@ -62,7 +62,7 @@ class CSLJSONSchema(Schema):
 
     def _read_resource_type(self, id_):
         """Retrieve resource type record using service."""
-        rec = vocabulary_service.read(system_identity, ("resourcetypes", id_))
+        rec = vocabulary_service.read(g.identity, ("resourcetypes", id_))
         return rec._record
 
     def get_type(self, obj):

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -10,9 +10,8 @@
 
 from edtf import parse_edtf
 from edtf.parser.grammar import ParseException
-from flask import current_app
+from flask import current_app, g
 from flask_babelex import lazy_gettext as _
-from invenio_access.permissions import system_identity
 from invenio_records_resources.proxies import current_service_registry
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from marshmallow import Schema, ValidationError, fields, missing, post_dump, \
@@ -90,7 +89,7 @@ class PersonOrOrgSchema43(Schema):
             affiliations_service = (
                 current_service_registry.get("affiliations")
             )
-            affiliations = affiliations_service.read_many(system_identity, ids)
+            affiliations = affiliations_service.read_many(g.identity, ids)
 
             for affiliation in affiliations:
                 aff = {
@@ -421,7 +420,7 @@ class DataCite43Schema(Schema):
 
         if ids:
             subjects_service = current_service_registry.get("subjects")
-            subjects = subjects_service.read_many(system_identity, ids)
+            subjects = subjects_service.read_many(g.identity, ids)
             validator = validate.URL()
             for subject in subjects:
                 serialized_subj = {
@@ -467,7 +466,7 @@ class DataCite43Schema(Schema):
 
         if ids:
             rights = vocabulary_service.read_many(
-                system_identity, "licenses", ids
+                g.identity, "licenses", ids
             )
             for right in rights:
                 serialized_right = {

--- a/invenio_rdm_records/resources/serializers/dublincore/schema.py
+++ b/invenio_rdm_records/resources/serializers/dublincore/schema.py
@@ -8,7 +8,7 @@
 """Dublin Core based Schema for Invenio RDM Records."""
 
 import bleach
-from invenio_access.permissions import system_identity
+from flask import g
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from marshmallow import Schema, fields, missing
 
@@ -101,7 +101,7 @@ class DublinCoreSchema(Schema):
 
         if ids:
             vocab_rights = vocabulary_service.read_many(
-                system_identity, "licenses", ids
+                g.identity, "licenses", ids
             )
             for right in vocab_rights:
                 title = right.get('title').get(

--- a/invenio_rdm_records/resources/serializers/utils.py
+++ b/invenio_rdm_records/resources/serializers/utils.py
@@ -9,7 +9,7 @@
 """Helpers for serializers."""
 
 from elasticsearch_dsl.query import Q
-from invenio_access.permissions import system_identity
+from flask import g
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 
 from .errors import VocabularyItemNotFoundError
@@ -20,7 +20,7 @@ def get_vocabulary_props(vocabulary, fields, id_):
     # This is ok given that read_all is cached per vocabulary+fields and
     # is reused overtime
     results = vocabulary_service.read_all(
-        system_identity,
+        g.identity,
         ['id'] + fields,
         vocabulary,
         extra_filter=Q('term', id=id_),


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/958

Since all the occurrences happen at _resources_ level it is accepted to access the `g` object. The `current_user` does not provide an identity (it provides `id` and `roles`) and we would need to build the identity from it, which is already stored in `g.identity`.