### PR TITLE
global: Fixes strings marked for translation.

### DIFF
--- a/invenio_rdm_records/oaiserver/services/services.py
+++ b/invenio_rdm_records/oaiserver/services/services.py
@@ -80,7 +80,7 @@ class OAIPMHServerService(Service):
         if not bool(blop.match(spec)):
             raise ValidationError(
                 _(
-                    "The spec should only consist of letters, numbers or {marks}.".format(
+                    "The spec must only consist of letters, numbers or {marks}.".format(
                         marks=",".join(["-", "_", ".", "!", "~", "*", "'", "(", ")"])
                     )
                 ),

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -113,7 +113,7 @@ class PersonOrOrganizationSchema(Schema):
         """Validate names based on type."""
         if data["type"] == "personal":
             if not data.get("family_name"):
-                messages = [_("Family name must be filled.")]
+                messages = [_("Family name cannot be blank.")]
                 raise ValidationError({"family_name": messages})
 
         elif data["type"] == "organizational":
@@ -319,7 +319,7 @@ class LocationSchema(Schema):
                 {
                     "locations": _(
                         "At least one of ['geometry', 'place', \
-                'identifiers', 'description'] shold be present."
+                identifiers', 'description'] must be present."
                     )
                 }
             )

--- a/tests/services/schemas/test_creator_contributor.py
+++ b/tests/services/schemas/test_creator_contributor.py
@@ -161,7 +161,7 @@ def test_creator_person_invalid_no_family_name(app):
 
     assert_raises_messages(
         lambda: CreatorSchema().load(invalid_no_family_name),
-        {"person_or_org": {"family_name": ["Family name must be filled."]}},
+        {"person_or_org": {"family_name": ["Family name cannot be blank."]}},
     )
 
 
@@ -305,7 +305,7 @@ def test_contributor_person_invalid_no_family_name_nor_given_name(app):
 
     assert_raises_messages(
         lambda: ContributorSchema().load(invalid_no_family_name_nor_given_name),
-        {"person_or_org": {"family_name": ["Family name must be filled."]}},
+        {"person_or_org": {"family_name": ["Family name cannot be blank."]}},
     )
 
 


### PR DESCRIPTION
- Using must instead of should (includes removing typo).
- Using "cannot be blank" as everywhere else.

Refs: inveniosoftware/invenio-app-rdm#1707
