### PR TITLE
services: create generic component for custom fields and metadata

### DIFF
--- a/invenio_rdm_records/services/components/custom_fields.py
+++ b/invenio_rdm_records/services/components/custom_fields.py
@@ -1,36 +1,17 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2022 CERN.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""RDM service component for metadata."""
+"""RDM service component for custom fields."""
 
-from copy import copy
-
-from invenio_drafts_resources.services.records.components import ServiceComponent
+from .metadata import MetadataComponent
 
 
-class CustomFieldsComponent(ServiceComponent):
+class CustomFieldsComponent(MetadataComponent):
     """Service component for custom fields."""
 
-    def create(self, identity, data=None, record=None, **kwargs):
-        """Inject parsed metadata to the record."""
-        record["custom"] = data.get("custom", {})
-
-    def update_draft(self, identity, data=None, record=None, **kwargs):
-        """Inject parsed metadata to the record."""
-        record["custom"] = data.get("custom", {})
-
-    def publish(self, identity, draft=None, record=None, **kwargs):
-        """Update draft metadata."""
-        record["custom"] = draft.get("custom", {})
-
-    def edit(self, identity, draft=None, record=None, **kwargs):
-        """Update draft metadata."""
-        draft["custom"] = record.get("custom", {})
-
-    def new_version(self, identity, draft=None, record=None, **kwargs):
-        """Update draft metadata."""
-        draft["custom"] = copy(record.get("custom", {}))
+    field = "custom"
+    new_version_skip_fields = []

--- a/invenio_rdm_records/services/components/metadata.py
+++ b/invenio_rdm_records/services/components/metadata.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2020-2022 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2021 TU Wien.
 #
@@ -17,28 +17,30 @@ from invenio_drafts_resources.services.records.components import ServiceComponen
 class MetadataComponent(ServiceComponent):
     """Service component for metadata."""
 
+    field = "metadata"
     new_version_skip_fields = ["publication_date", "version"]
 
     def create(self, identity, data=None, record=None, **kwargs):
         """Inject parsed metadata to the record."""
-        record.metadata = data.get("metadata", {})
+        setattr(record, self.field, data.get(self.field, {}))
 
     def update_draft(self, identity, data=None, record=None, **kwargs):
         """Inject parsed metadata to the record."""
-        record.metadata = data.get("metadata", {})
+        setattr(record, self.field, data.get(self.field, {}))
 
     def publish(self, identity, draft=None, record=None, **kwargs):
         """Update draft metadata."""
-        record.metadata = draft.get("metadata", {})
+        setattr(record, self.field, draft.get(self.field, {}))
 
     def edit(self, identity, draft=None, record=None, **kwargs):
         """Update draft metadata."""
-        draft.metadata = record.get("metadata", {})
+        setattr(draft, self.field, record.get(self.field, {}))
 
     def new_version(self, identity, draft=None, record=None, **kwargs):
         """Update draft metadata."""
-        draft.metadata = copy(record.get("metadata", {}))
+        setattr(draft, self.field, copy(record.get(self.field, {})))
         # Remove fields that should not be copied to the new version
         # (publication date and version)
+        field_values = getattr(draft, self.field)
         for f in self.new_version_skip_fields:
-            draft.metadata.pop(f, None)
+            field_values.pop(f, None)


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1002

Failing tests are due to Werkzeug and Flask-Login v0.6.2, passing in local

![Screenshot 2022-08-04 at 16 44 01](https://user-images.githubusercontent.com/6756943/182876186-b27600cf-1668-4dc1-9b22-2c22c99e2780.png)

