### PR TITLE
metadata: require publisher field since Datacite requires it

### DIFF
--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -343,7 +343,7 @@ class MetadataSchema(Schema):
     )
     title = SanitizedUnicode(required=True, validate=validate.Length(min=3))
     additional_titles = fields.List(fields.Nested(TitleSchema))
-    publisher = SanitizedUnicode()
+    publisher = SanitizedUnicode(required=True)
     publication_date = EDTFDateString(required=True)
     subjects = fields.List(fields.Nested(SubjectRelationSchema))
     contributors = fields.List(fields.Nested(ContributorSchema))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -521,6 +521,7 @@ def minimal_record():
         },
         "metadata": {
             "publication_date": "2020-06-01",
+            "publisher": "InvenioRDM",
             "resource_type": {"id": "image-photo"},
             "creators": [
                 {

--- a/tests/resources/serializers/test_dublincore_serializer.py
+++ b/tests/resources/serializers/test_dublincore_serializer.py
@@ -74,6 +74,7 @@ def test_dublincorejson_serializer_minimal(running_app, updated_minimal_record):
         "creators": ["Name", "Troy Inc."],
         "dates": ["2020-06-01"],
         "rights": ["info:eu-repo/semantics/openAccess"],
+        "publishers": ["InvenioRDM"],
     }
 
     serializer = DublinCoreJSONSerializer()


### PR DESCRIPTION
Datacite requires the publisher, but we didn't for some reason. This leads to trouble when a record is not created with a publisher.
Another PR will be made to move the publisher field in invenio-app-rdm.

- part of closing #819
- includes a little drive-by refactoring