### PR TITLE
mappings: disable dynamic fields at global level and enable on inner objects

### DIFF
--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "dynamic": false,
     "date_detection": false,
     "numeric_detection": false,
     "properties": {
@@ -33,7 +34,8 @@
         }
       },
       "custom_fields": {
-        "type": "object"
+        "type": "object",
+        "dynamic": true
       },
       "parent": {
         "properties": {

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -1,5 +1,6 @@
 {
   "mappings": {
+    "dynamic": false,
     "date_detection": false,
     "numeric_detection": false,
     "properties": {
@@ -33,7 +34,8 @@
         }
       },
       "custom_fields": {
-        "type": "object"
+        "type": "object",
+        "dynamic": true
       },
       "parent": {
         "properties": {

--- a/tests/fixtures/test_cli.py
+++ b/tests/fixtures/test_cli.py
@@ -142,9 +142,10 @@ def test_create_records_custom_fields(app, location, db, es_clear, cli_runner):
         "properties"
     ]["custom_fields"]
     expected_value = {
+        "dynamic": "true",
         "properties": {
             "cern:myfield": {"type": "text", "fields": {"keyword": {"type": "keyword"}}}
-        }
+        },
     }
     assert record_mapping_field == expected_value
     assert draft_mapping_field == expected_value


### PR DESCRIPTION
- closes #1040 

Tested on an instance (services setup + run) and worked.