### PR TITLE
mappings: add missing fields and make them strict

### DIFF
--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -590,8 +590,7 @@
           "related_identifiers": {
             "properties": {
               "identifier": {
-                "type": "keyword",
-                "copy_to": ["related.identifier"]
+                "type": "keyword"
               },
               "relation_type": {
                 "type": "object",
@@ -745,8 +744,7 @@
                 }
               },
               "title": {
-                "type": "text",
-                "copy_to": ["suggest_title"]
+                "type": "text"
               },
               "type": {
                 "type": "object",
@@ -820,21 +818,6 @@
             "type": "keyword"
           }
         }
-      },
-      "related": {
-        "type": "object",
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          }
-        }
-      },
-      "suggest_title": {
-        "type": "completion",
-        "analyzer": "simple",
-        "preserve_separators": true,
-        "preserve_position_increments": true,
-        "max_input_length": 50
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -1,5 +1,33 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "pids": {
+          "path_match": "pids.*",
+          "match_mapping_type": "object",
+          "mapping": {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "provider": {
+                "type": "keyword"
+              },
+              "client": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "date_detection": false,
     "numeric_detection": false,
@@ -151,22 +179,8 @@
         }
       },
       "pids": {
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          },
-          "scheme": {
-            "type": "keyword"
-          },
-          "client": {
-            "type": "keyword",
-            "index": false
-          },
-          "provider": {
-            "type": "keyword",
-            "index": false
-          }
-        }
+        "type": "object",
+        "dynamic": true
       },
       "has_draft": {
         "type": "boolean"

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -180,6 +180,52 @@
             "properties": {
               "ids": {
                 "type": "keyword"
+              },
+              "default": {
+                "type": "keyword"
+              }
+            }
+          },
+          "review": {
+            "type": "object",
+            "properties": {
+              "$schema": {
+                "type": "keyword",
+                "index": false
+              },
+              "id": {
+                "type": "keyword"
+              },
+              "type": {
+                "type": "keyword"
+              },
+              "title": {
+                "type": "text"
+              },
+              "description": {
+                "type": "text"
+              },
+              "status": {
+                "type": "keyword"
+              },
+              "payload": {
+                "type": "object",
+                "dynamic": true
+              },
+              "topic": {
+                "type": "object",
+                "dynamic": true
+              },
+              "receiver": {
+                "type": "object",
+                "dynamic": true
+              },
+              "created_by": {
+                "type": "object",
+                "dynamic": true
+              },
+              "@v": {
+                "type": "keyword"
               }
             }
           },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -26,6 +26,22 @@
             }
           }
         }
+      },
+      {
+        "i18n_title": {
+          "path_match": "*.title.*",
+          "unmatch": "(metadata.title)|(metadata.additional_titles.title)",
+          "match_mapping_type": "object",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
       }
     ],
     "dynamic": "strict",

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -815,6 +815,9 @@
         "properties": {
           "enabled": {
             "type": "boolean"
+          },
+          "default_preview": {
+            "type": "keyword"
           }
         }
       },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v5.0.0.json
@@ -1,11 +1,39 @@
 {
   "mappings": {
-    "dynamic": false,
+    "dynamic": "strict",
     "date_detection": false,
     "numeric_detection": false,
     "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": false
+      },
+      "uuid": {
+        "type": "keyword",
+        "index": false
+      },
       "id": {
         "type": "keyword"
+      },
+      "pid": {
+        "properties": {
+          "obj_type": {
+            "type": "keyword",
+            "index": false
+          },
+          "pid_type": {
+            "type": "keyword",
+            "index": false
+          },
+          "pk": {
+            "type": "long",
+            "index": false
+          },
+          "status": {
+            "type": "keyword",
+            "index": false
+          }
+        }
       },
       "access": {
         "properties": {
@@ -39,8 +67,36 @@
       },
       "parent": {
         "properties": {
+          "$schema": {
+            "type": "keyword",
+            "index": false
+          },
+          "uuid": {
+            "type": "keyword",
+            "index": false
+          },
           "id": {
             "type": "keyword"
+          },
+          "pid": {
+            "properties": {
+              "obj_type": {
+                "type": "keyword",
+                "index": false
+              },
+              "pid_type": {
+                "type": "keyword",
+                "index": false
+              },
+              "pk": {
+                "type": "long",
+                "index": false
+              },
+              "status": {
+                "type": "keyword",
+                "index": false
+              }
+            }
           },
           "access": {
             "properties": {
@@ -82,6 +138,15 @@
                 "type": "keyword"
               }
             }
+          },
+          "created": {
+            "type": "date"
+          },
+          "updated": {
+            "type": "date"
+          },
+          "version_id": {
+            "type": "long"
           }
         }
       },
@@ -274,7 +339,10 @@
               }
             }
           },
-          "descriptions": {
+          "description": {
+            "type": "text"
+          },
+          "additional_descriptions": {
             "properties": {
               "description": {
                 "type": "text"
@@ -310,6 +378,9 @@
                 }
               }
             }
+          },
+          "formats": {
+            "type": "keyword"
           },
           "funding": {
             "properties": {
@@ -382,40 +453,6 @@
               }
             }
           },
-          "rights": {
-            "type": "object",
-            "properties": {
-              "@v": {
-                "type": "keyword"
-              },
-              "id": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "object",
-                "dynamic": true
-              },
-              "description": {
-                "type": "object",
-                "dynamic": true
-              },
-              "props": {
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "type": "keyword"
-                  },
-                  "scheme": {
-                    "type": "keyword"
-                  }
-                }
-              },
-              "link": {
-                "type": "keyword",
-                "index": false
-              }
-            }
-          },
           "locations": {
             "properties": {
               "features": {
@@ -452,12 +489,21 @@
           "publication_date_range": {
             "type": "date_range"
           },
+          "publisher": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
           "references": {
             "properties": {
               "identifier": {
                 "type": "keyword"
               },
-              "reference_string": {
+              "reference": {
                 "type": "text"
               },
               "scheme": {
@@ -532,6 +578,48 @@
               }
             }
           },
+          "rights": {
+            "type": "object",
+            "properties": {
+              "@v": {
+                "type": "keyword"
+              },
+              "id": {
+                "type": "keyword"
+              },
+              "title": {
+                "type": "object",
+                "dynamic": true
+              },
+              "description": {
+                "type": "object",
+                "dynamic": true
+              },
+              "props": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "keyword"
+                  },
+                  "scheme": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "link": {
+                "type": "keyword",
+                "index": false
+              },
+              "icon": {
+                "type": "keyword",
+                "index": false
+              }
+            }
+          },
+          "sizes": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
           "subjects": {
             "type": "object",
             "properties": {
@@ -554,14 +642,16 @@
               }
             }
           },
-          "suggest_title": {
-            "type": "completion",
-            "analyzer": "simple",
-            "preserve_separators": true,
-            "preserve_position_increments": true,
-            "max_input_length": 50
+          "title": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           },
-          "titles": {
+          "additional_titles": {
             "properties": {
               "lang": {
                 "type": "object",
@@ -604,6 +694,9 @@
           }
         }
       },
+      "expires_at": {
+        "type": "date"
+      },
       "created": {
         "type": "date"
       },
@@ -612,6 +705,12 @@
       },
       "is_published": {
         "type": "boolean"
+      },
+      "version_id": {
+        "type": "long"
+      },
+      "fork_version_id": {
+        "type": "long"
       },
       "versions": {
         "properties": {
@@ -634,6 +733,29 @@
             "type": "keyword"
           }
         }
+      },
+      "files": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "related": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          }
+        }
+      },
+      "suggest_title": {
+        "type": "completion",
+        "analyzer": "simple",
+        "preserve_separators": true,
+        "preserve_position_increments": true,
+        "max_input_length": 50
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -766,6 +766,9 @@
         "properties": {
           "enabled": {
             "type": "boolean"
+          },
+          "default_preview": {
+            "type": "keyword"
           }
         }
       },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -547,8 +547,7 @@
           "related_identifiers": {
             "properties": {
               "identifier": {
-                "type": "keyword",
-                "copy_to": ["related.identifier"]
+                "type": "keyword"
               },
               "relation_type": {
                 "type": "object",
@@ -702,8 +701,7 @@
                 }
               },
               "title": {
-                "type": "text",
-                "copy_to": ["suggest_title"]
+                "type": "text"
               },
               "type": {
                 "type": "object",
@@ -771,21 +769,6 @@
             "type": "keyword"
           }
         }
-      },
-      "related": {
-        "type": "object",
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          }
-        }
-      },
-      "suggest_title": {
-        "type": "completion",
-        "analyzer": "simple",
-        "preserve_separators": true,
-        "preserve_position_increments": true,
-        "max_input_length": 50
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -1,5 +1,33 @@
 {
   "mappings": {
+    "dynamic_templates": [
+      {
+        "pids": {
+          "path_match": "pids.*",
+          "match_mapping_type": "object",
+          "mapping": {
+            "type": "object",
+            "properties": {
+              "identifier": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "provider": {
+                "type": "keyword"
+              },
+              "client": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      }
+    ],
     "dynamic": "strict",
     "date_detection": false,
     "numeric_detection": false,
@@ -151,44 +179,8 @@
         }
       },
       "pids": {
-        "properties": {
-          "identifier": {
-            "type": "keyword"
-          },
-          "scheme": {
-            "type": "keyword"
-          },
-          "client": {
-            "type": "keyword",
-            "index": false
-          },
-          "provider": {
-            "type": "keyword",
-            "index": false
-          },
-          "oai": {
-            "properties": {
-              "identifier": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              },
-              "provider": {
-                "type": "text",
-                "fields": {
-                  "keyword": {
-                    "type": "keyword",
-                    "ignore_above": 256
-                  }
-                }
-              }
-            }
-          }
-        }
+        "type": "object",
+        "dynamic": true
       },
       "has_draft": {
         "type": "boolean"

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -26,6 +26,22 @@
             }
           }
         }
+      },
+      {
+        "i18n_title": {
+          "path_match": "*.title.*",
+          "unmatch": "(metadata.title)|(metadata.additional_titles.title)",
+          "match_mapping_type": "object",
+          "mapping": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          }
+        }
       }
     ],
     "dynamic": "strict",

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -180,6 +180,9 @@
             "properties": {
               "ids": {
                 "type": "keyword"
+              },
+              "default": {
+                "type": "keyword"
               }
             }
           },

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v5.0.0.json
@@ -1,11 +1,39 @@
 {
   "mappings": {
-    "dynamic": false,
+    "dynamic": "strict",
     "date_detection": false,
     "numeric_detection": false,
     "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": false
+      },
+      "uuid": {
+        "type": "keyword",
+        "index": false
+      },
       "id": {
         "type": "keyword"
+      },
+      "pid": {
+        "properties": {
+          "obj_type": {
+            "type": "keyword",
+            "index": false
+          },
+          "pid_type": {
+            "type": "keyword",
+            "index": false
+          },
+          "pk": {
+            "type": "long",
+            "index": false
+          },
+          "status": {
+            "type": "keyword",
+            "index": false
+          }
+        }
       },
       "access": {
         "properties": {
@@ -39,8 +67,36 @@
       },
       "parent": {
         "properties": {
+          "$schema": {
+            "type": "keyword",
+            "index": false
+          },
+          "uuid": {
+            "type": "keyword",
+            "index": false
+          },
           "id": {
             "type": "keyword"
+          },
+          "pid": {
+            "properties": {
+              "obj_type": {
+                "type": "keyword",
+                "index": false
+              },
+              "pid_type": {
+                "type": "keyword",
+                "index": false
+              },
+              "pk": {
+                "type": "long",
+                "index": false
+              },
+              "status": {
+                "type": "keyword",
+                "index": false
+              }
+            }
           },
           "access": {
             "properties": {
@@ -82,6 +138,15 @@
                 "type": "keyword"
               }
             }
+          },
+          "created": {
+            "type": "date"
+          },
+          "updated": {
+            "type": "date"
+          },
+          "version_id": {
+            "type": "long"
           }
         }
       },
@@ -100,6 +165,28 @@
           "provider": {
             "type": "keyword",
             "index": false
+          },
+          "oai": {
+            "properties": {
+              "identifier": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              },
+              "provider": {
+                "type": "text",
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": 256
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -274,7 +361,10 @@
               }
             }
           },
-          "descriptions": {
+          "description": {
+            "type": "text"
+          },
+          "additional_descriptions": {
             "properties": {
               "description": {
                 "type": "text"
@@ -310,6 +400,9 @@
                 }
               }
             }
+          },
+          "formats": {
+            "type": "keyword"
           },
           "funding": {
             "properties": {
@@ -382,40 +475,6 @@
               }
             }
           },
-          "rights": {
-            "type": "object",
-            "properties": {
-              "@v": {
-                "type": "keyword"
-              },
-              "id": {
-                "type": "keyword"
-              },
-              "title": {
-                "type": "object",
-                "dynamic": true
-              },
-              "description": {
-                "type": "object",
-                "dynamic": true
-              },
-              "props": {
-                "type": "object",
-                "properties": {
-                  "url": {
-                    "type": "keyword"
-                  },
-                  "scheme": {
-                    "type": "keyword"
-                  }
-                }
-              },
-              "link": {
-                "type": "keyword",
-                "index": false
-              }
-            }
-          },
           "locations": {
             "properties": {
               "features": {
@@ -452,12 +511,21 @@
           "publication_date_range": {
             "type": "date_range"
           },
+          "publisher": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
+          },
           "references": {
             "properties": {
               "identifier": {
                 "type": "keyword"
               },
-              "reference_string": {
+              "reference": {
                 "type": "text"
               },
               "scheme": {
@@ -532,6 +600,48 @@
               }
             }
           },
+          "rights": {
+            "type": "object",
+            "properties": {
+              "@v": {
+                "type": "keyword"
+              },
+              "id": {
+                "type": "keyword"
+              },
+              "title": {
+                "type": "object",
+                "dynamic": true
+              },
+              "description": {
+                "type": "object",
+                "dynamic": true
+              },
+              "props": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "keyword"
+                  },
+                  "scheme": {
+                    "type": "keyword"
+                  }
+                }
+              },
+              "link": {
+                "type": "keyword",
+                "index": false
+              },
+              "icon": {
+                "type": "keyword",
+                "index": false
+              }
+            }
+          },
+          "sizes": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
           "subjects": {
             "type": "object",
             "properties": {
@@ -554,14 +664,16 @@
               }
             }
           },
-          "suggest_title": {
-            "type": "completion",
-            "analyzer": "simple",
-            "preserve_separators": true,
-            "preserve_position_increments": true,
-            "max_input_length": 50
+          "title": {
+            "type": "text",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           },
-          "titles": {
+          "additional_titles": {
             "properties": {
               "lang": {
                 "type": "object",
@@ -613,6 +725,9 @@
       "is_published": {
         "type": "boolean"
       },
+      "version_id": {
+        "type": "long"
+      },
       "versions": {
         "properties": {
           "index": {
@@ -634,6 +749,29 @@
             "type": "keyword"
           }
         }
+      },
+      "files": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "related": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "keyword"
+          }
+        }
+      },
+      "suggest_title": {
+        "type": "completion",
+        "analyzer": "simple",
+        "preserve_separators": true,
+        "preserve_position_increments": true,
+        "max_input_length": 50
       }
     }
   }


### PR DESCRIPTION
- closes #1051 
- closes #1052

# Why?

Before we did not state the `strict` property on the mappings, therefore they defaulted to *true*. This means that any field we were sending was being indexed (as text + keyword). By chance, it worked. We had this way many of them like formats, sizes, uuid, review data in the parent, etc. Even some very basic fields like "title" and "description" which were missing from the mapping 🤦.

# Why now?

I made the mappings strict as part of the custom fields development, because "why not, since that way we would be covered of users not abusing the mappings and only adding custom where allowed (i.e. under the`custom_fields.` field). Result: I could not find anything (search) by title, description, etc. (because they were not being indexed).

# Solution

Added all missing fields (hope I didn't forget any, but now ES will complain and we can add it).

# Improvement

Dynamic templates for pids and titles with i18n capabilities. Before they were catch-all fields, which could lead to abuse. Now they are strict in content (keys are still dynamic, meaning `en` `de` etc. are up to the user/app).