### PR TITLE
oai: sort options matches service search options

### DIFF
--- a/invenio_rdm_records/administration/views/oai.py
+++ b/invenio_rdm_records/administration/views/oai.py
@@ -33,7 +33,7 @@ class OaiPmhListView(AdminResourceListView):
           "order": 1
         },
         "name": {
-            "text": "Title",
+            "text": "Name",
             "order": 2
         },
         "spec": {
@@ -45,8 +45,12 @@ class OaiPmhListView(AdminResourceListView):
             "order": 4
         },
         "updated": {
-            "text": "Modified",
+            "text": "Updated",
             "order": 5
+        },
+        "created": {
+            "text": "Created",
+            "order": 6
         }
     }
 

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -241,20 +241,20 @@ RDM_SEARCH_VERSIONING = {
 RDM_OAI_PMH_FACETS = {}
 
 RDM_OAI_PMH_SORT_OPTIONS = {
-    "newest": dict(
-        title=_("Newest"),
-        fields=["-created"],
-    ),
-    "oldest": dict(
-        title=_("Oldest"),
-        fields=["created"],
-    ),
-    "title": dict(
-        title=_("Title"),
+    "name": dict(
+        title=_("Name"),
         fields=["name"],
     ),
-    "modified": dict(
-        title=_("Modified"),
+    "spec": dict(
+        title=_("Spec"),
+        fields=["spec"],
+    ),
+    "created": dict(
+        title=_("Created"),
+        fields=["created"],
+    ),
+    "updated": dict(
+        title=_("Updated"),
         fields=["updated"],
     ),
 }
@@ -262,7 +262,7 @@ RDM_OAI_PMH_SORT_OPTIONS = {
 
 RDM_OAI_PMH_SEARCH = {
     "facets": [],
-    "sort": ["newest", "oldest", "title", "modified"],
+    "sort": ["name", "spec", "created", "updated"],
 }
 """OAI-PMH search configuration."""
 


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-administration/issues/79

The issue was that sort options did not match the service's search and sort options. Therefore, sort was defaulting to `created, asc` for most of the fields. 

This implementation should be revisited in my opinion, there are too many implementations of the same thing. E.g.:

1. `invenio-rdm-records` has a config that sets search and sort options, however they are only used for `invenio-administration`. 

https://github.com/inveniosoftware/invenio-rdm-records/blob/5754cbd54171ace2ca54b02110272a5ce5795721/invenio_rdm_records/config.py#L243-L260

2. `invenio_rdm_records.oai_server.services` has a `SearchOptions` instance, whose config is completely independent of (1).

https://github.com/inveniosoftware/invenio-rdm-records/blob/62071cf4b74e5c8d1ccabb9b374116a4867f45e2/invenio_rdm_records/oaiserver/services/config.py#L49-L66 