### PR TITLE
tests: adds extract_messages dry command

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -53,6 +53,7 @@ fi
 
 export LC_TIME=en_US.UTF-8
 python -m check_manifest
+python -m setup extract_messages --dry-run
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-elasticsearch} --mq ${MQ:-redis} --env)"
 # Note: expansion of pytest_args looks like below to not cause an unbound


### PR DESCRIPTION
This is to make sure all marked strings are actually extractable.
