### PR TITLE
search result item: add word-break class to table cell

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/search/SearchResultItem.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/search/SearchResultItem.js
@@ -76,7 +76,11 @@ class SearchResultItemComponent extends Component {
         <Table.Row>
           {columns.map(([property, { text, order }], index) => {
             return (
-              <Table.Cell key={`${text}-${order}`} data-label={text}>
+              <Table.Cell
+                key={`${text}-${order}`}
+                data-label={text}
+                className="word-break-all"
+              >
                 {index === 0 ? (
                   <a
                     href={AdminUIRoutes.detailsView(


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-administration/issues/109

Adds `word-break-all` class to table cell to prevent overflowing.

Needs https://github.com/inveniosoftware/invenio-theme/pull/328
## Screenshot
![Screenshot 2022-09-26 at 13 34 57](https://user-images.githubusercontent.com/21052053/192267480-26185b3d-4d6e-4878-83d4-97a0181b55d8.png)
