### PR TITLE
Additions to support OSTI DOI. Co-authored-by: Zoe Guillen <zoe@pnnl.…

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2019 CERN.
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -329,6 +331,11 @@ RDM_PERSISTENT_IDENTIFIER_PROVIDERS = [
         client=providers.DataCiteClient("datacite", config_prefix="DATACITE"),
         label=_("DOI"),
     ),
+    providers.OSTIPIDProvider(
+        "osti",
+        client=providers.OSTIClient("osti", config_prefix="OSTI"),
+        label=_("DOI"),
+    ),
     # DOI provider for externally managed DOIs
     providers.ExternalPIDProvider(
         "external",
@@ -352,7 +359,9 @@ The name is further used to configure the desired persistent identifiers (see
 ``RDM_PERSISTENT_IDENTIFIERS`` below)
 """
 
-
+# TODO find the logic that automatically removes the DOI if datacite_enabled 
+# is false and add if osti_enabled is also false before removing DOI not 
+# adding "osti" to the list of providers below as we don't want it used by default
 RDM_PERSISTENT_IDENTIFIERS = {
     # DOI automatically removed if DATACITE_ENABLED is False.
     "doi": {
@@ -377,6 +386,29 @@ RDM_PERSISTENT_IDENTIFIERS = {
         "required": True/False,
     }
 """
+
+# Configuration for the OSTIClient used by the OSTIPIDProvider
+OSTI_ENABLED = False
+"""Flag to enable/disable DOI registration to OSTI."""
+
+
+OSTI_USERNAME = ""
+"""OSTI username."""
+
+
+OSTI_PASSWORD = ""
+"""OSTI password."""
+
+OSTI_ACCESSION_NUMBER_PREFIX = ""
+"""Prefix to use to generate OSTI accession_num to uniquely identify records that have gotten DOI's reserved"""
+
+OSTI_TEST_MODE = True
+"""OSTI test mode enabled."""
+
+# until changes can be made in the the UI require RDM instances to set in their invenio.cfg these 2 OSTI required metadata fields
+# this means that all records that have DOI's minted will have the same value set for contract numbers and sponsor orgs
+OSTI_CONTRACT_NOS = ""
+OSTI_SPONSOR_ORG = ""
 
 # Configuration for the DataCiteClient used by the DataCitePIDProvider
 

--- a/invenio_rdm_records/resources/serializers/__init__.py
+++ b/invenio_rdm_records/resources/serializers/__init__.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2020, 2021 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -11,6 +13,7 @@
 
 from .csl import CSLJSONSerializer, StringCitationSerializer
 from .datacite import DataCite43JSONSerializer, DataCite43XMLSerializer
+from .osti import OSTIJSONSerializer
 from .dublincore import DublinCoreJSONSerializer, DublinCoreXMLSerializer
 from .iiif import (
     IIIFCanvasV2JSONSerializer,
@@ -21,6 +24,7 @@ from .iiif import (
 from .ui import UIJSONSerializer
 
 __all__ = (
+    "OSTIJSONSerializer",
     "CSLJSONSerializer",
     "DataCite43JSONSerializer",
     "DataCite43XMLSerializer",

--- a/invenio_rdm_records/resources/serializers/osti/__init__.py
+++ b/invenio_rdm_records/resources/serializers/osti/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
+
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""OSTI Serializers for Invenio RDM Records."""
+from flask_resources.serializers import MarshmallowJSONSerializer
+from .schema import OSTISchema
+
+
+class OSTIJSONSerializer(MarshmallowJSONSerializer):
+    """Marshmallow based OSTI serializer for records."""
+
+    def __init__(self, **options):
+        """Constructor."""
+        super().__init__(schema_cls=OSTISchema, **options)
+
+

--- a/invenio_rdm_records/resources/serializers/osti/schema.py
+++ b/invenio_rdm_records/resources/serializers/osti/schema.py
@@ -1,0 +1,184 @@
+# MSD-LIVE change: custom OSTI serializer used to convert 
+# the json format of an RDM record to the OSTI json schema
+
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""OSTI based Schema for Invenio RDM Records."""
+
+from edtf import parse_edtf, struct_time_to_date
+from edtf.parser.grammar import ParseException
+from flask import current_app
+from flask_babelex import lazy_gettext as _
+from marshmallow import Schema, ValidationError, fields, missing
+from marshmallow_utils.fields import SanitizedUnicode
+from marshmallow_utils.html import strip_html
+from invenio_records_resources.proxies import current_service_registry
+from invenio_access.permissions import system_identity
+
+
+class AuthorSchema(Schema):
+    # OSTI requires last_name so if an org is an author use that as the lastname
+
+    # person_or_org.name is the name entered if Organization is chosen 
+    # as an author, but OSTI requires a first and last name. So if we 
+    # don't have first and last name, use the org's full name as both
+    # if fields.Str(attribute="person_or_org.family_name") is not None:
+    #     last_name = fields.Str(attribute="person_or_org.family_name")
+    # else:
+    #     last_name = fields.Str(attribute="person_or_org.name")
+    #
+    # first_name = fields.Str(attribute="person_or_org.given_name")
+
+    last_name = fields.Method('get_last_name')
+    first_name = fields.Method('get_first_name')
+    # optionally is affiliation_name, private_email 
+    # (N/A as RDM doesn't even ask for it?), orcid_id
+    orcid_id = fields.Method('get_orcid')
+    affiliation_name = fields.Method('get_affiliation')
+
+    def get_first_name(self, obj):
+        given_name = obj["person_or_org"].get("given_name")
+        if given_name is not None:
+            return given_name
+
+        return missing
+
+    def get_last_name(self, obj):
+        fam_name = obj["person_or_org"].get("family_name")
+        name = obj["person_or_org"].get("name")
+        if fam_name is not None:
+            return fam_name
+        elif name is not None:
+            return name
+
+        return missing
+
+    def get_orcid(self, obj):
+        identifiers = obj["person_or_org"].get("identifiers", [])
+        for identifier in identifiers:
+            scheme = identifier["scheme"]
+            if scheme == 'orcid':
+                return identifier["identifier"]
+
+        return missing
+
+    def get_affiliation(self, obj):
+        """Get affiliation list."""
+        affiliations = obj.get("affiliations", [])
+
+        if not affiliations:
+            return missing
+
+        # OSTI only supports 1 affiliation for an author 
+        # so just return the first one
+        affiliation = affiliations[0]
+        id_ = affiliation.get("id")
+        if id_:
+            affiliations_service = current_service_registry.get("affiliations")
+            full_affiliation = affiliations_service.read(system_identity, id_, True)
+            return full_affiliation.data["name"]
+        else:
+            return affiliation["name"]
+
+
+class OSTISchema(Schema):
+    """OSTI Marshmallow Schema."""
+
+    dataset_type = fields.Method('get_type')
+    title = SanitizedUnicode(attribute="metadata.title")
+    # site_url = SanitizedUnicode(attribute="links.self_html")
+    publication_date = fields.Method("get_publication_date")
+    authors = fields.List(
+        fields.Nested(AuthorSchema), attribute='metadata.creators')
+    keywords = fields.Method("get_subjects")
+    # other_identifying_numbers = fields.Method('get_related_identifiers')
+    description = fields.Method('get_descriptions')
+
+    def get_type(self, obj):
+        """Get resource type."""
+        if not obj["metadata"]["resource_type"]:
+            return missing
+        rdm_type = obj["metadata"]["resource_type"]["id"]
+        # default to the OSTI type of Specialized Mix
+        osti_type = 'SM'
+        if rdm_type == 'dataset-modeloutput':
+            osti_type = 'AS' # Animations/Simulations
+        elif rdm_type == 'dataset-observation':
+            osti_type = 'I' # Instrument
+
+        return osti_type
+
+    def _merge_main_and_additional(self, obj, field):
+        """Return merged list of main + additional titles/descriptions."""
+        result = ''
+        main_value = obj["metadata"].get(field)
+
+        if main_value:
+            item = strip_html(main_value)
+            result += item + " "
+
+        additional_values = obj["metadata"].get(f"additional_{field}s", [])
+        for v in additional_values:
+            item = strip_html(v.get(field))
+            result += item + " "
+
+        return result or missing
+
+
+    def get_descriptions(self, obj):
+        """Get descriptions list."""
+        descriptions = self._merge_main_and_additional(
+            obj, "description"
+        )
+        return descriptions
+
+    def get_publication_date(self, obj):
+        """Get publication year from edtf date."""
+        try:
+            if not obj["metadata"]["publication_date"]:
+                return missing
+            publication_date = obj["metadata"]["publication_date"]
+            parsed_date = parse_edtf(publication_date)
+            real_date = struct_time_to_date(parsed_date.lower_strict())
+            return str(real_date.strftime("%m/%d/%Y"))
+        except ParseException:
+            # Should not fail since it was validated at service schema
+            current_app.logger.error("Error parsing publication_date field for"
+                                     f"record {obj['metadata']}")
+            raise ValidationError(_("Invalid publication date value."))
+
+    def get_related_identifiers(self, obj):
+        """Get related identifiers."""
+        metadata = obj["metadata"]
+        identifiers = metadata.get("related_identifiers", [])
+        if not identifiers:
+            return missing
+
+        serialized_identifiers = ''
+        for rel_id in identifiers:
+            serialized_identifiers = rel_id.get("identifier", "")
+            serialized_identifiers += ";"
+
+        return serialized_identifiers or missing
+
+    def get_subjects(self, obj):
+        """Get osti keywords."""
+        subjects = obj["metadata"].get("subjects", [])
+        if not subjects:
+            return missing
+
+        serialized_subjects = ''
+        for subject in subjects:
+            sub_text = subject.get("subject")
+            if sub_text:
+                serialized_subjects += sub_text
+                serialized_subjects += ";"
+
+        return serialized_subjects if serialized_subjects else missing
+

--- a/invenio_rdm_records/services/customizations.py
+++ b/invenio_rdm_records/services/customizations.py
@@ -2,6 +2,8 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -116,7 +118,10 @@ class FromConfigPIDsProviders:
             p.name: p
             for p in obj._app.config.get("RDM_PERSISTENT_IDENTIFIER_PROVIDERS", [])
         }
-        doi_enabled = obj._app.config.get("DATACITE_ENABLED", False)
+        # TODO test this - don't know how doi_enabled is used or why it's returned
+        datacite_enabled = obj._app.config.get("DATACITE_ENABLED", False)
+        osti_enabled = obj._app.config.get("OSTI_ENABLED", False)
+        doi_enabled = datacite_enabled | osti_enabled
 
         return {
             scheme: get_provider_dict(conf, providers)
@@ -131,7 +136,9 @@ class FromConfigRequiredPIDs:
     def __get__(self, obj, objtype=None):
         """Return required pids (descriptor protocol)."""
         pids = obj._app.config.get("RDM_PERSISTENT_IDENTIFIERS", {})
-        doi_enabled = obj._app.config.get("DATACITE_ENABLED", False)
+        datacite_enabled = obj._app.config.get("DATACITE_ENABLED", False)
+        osti_enabled = obj._app.config.get("OSTI_ENABLED", False)
+        doi_enabled = datacite_enabled | osti_enabled
 
         pids = {
             scheme: conf

--- a/invenio_rdm_records/services/pids/providers/__init__.py
+++ b/invenio_rdm_records/services/pids/providers/__init__.py
@@ -2,6 +2,8 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2021 BNL.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -10,6 +12,7 @@
 
 from .base import PIDProvider
 from .datacite import DataCiteClient, DataCitePIDProvider
+from .osti import OSTIClient, OSTIPIDProvider
 from .external import BlockedPrefixes, ExternalPIDProvider
 from .oai import OAIPIDProvider
 
@@ -17,6 +20,8 @@ __all__ = (
     "BlockedPrefixes",
     "DataCiteClient",
     "DataCitePIDProvider",
+    "OSTIClient",
+    "OSTIPIDProvider",
     "ExternalPIDProvider",
     "OAIPIDProvider",
     "PIDProvider",

--- a/invenio_rdm_records/services/pids/providers/osti.py
+++ b/invenio_rdm_records/services/pids/providers/osti.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 PNNL.
+# Copyright (C) 2022 BNL.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""OSTI DOI Provider."""
+
+import json
+import warnings
+from pprint import pprint
+from invenio_rdm_records.resources.serializers import OSTIJSONSerializer
+
+# TODO Import and use the OSTI python client api instead - 
+# consider perhaps just copying it in here as there is hardly anything to it,
+# see: https://github.com/doecode/ostiapi/blob/master/ostiapi/__init__.py
+import ostiapi
+
+from flask import current_app
+from invenio_pidstore.models import PIDStatus
+
+from .base import PIDProvider
+
+class OSTIClient:
+    """OSTI Client."""
+
+    def __init__(self, name, config_prefix=None, **kwargs):
+        """Constructor."""
+        self.name = name
+        self._config_prefix = config_prefix or "OSTI"
+        self._api = None
+
+    def cfgkey(self, key):
+        """Generate a configuration key."""
+        return f"{self._config_prefix}_{key.upper()}"
+
+    def cfg(self, key, default=None):
+        """Get a application config value."""
+        return current_app.config.get(self.cfgkey(key), default)
+
+    # no need for generate_doi() method for OSTI as DOI's 
+    # are reserved through OSTI service API calls
+    
+    def check_credentials(self, **kwargs):
+        """Returns if the client has the credentials properly set up.
+
+        OSTI change - prefix has a different meaning now, not used 
+        as part of the DOI but as part of the accession_num
+        """
+        if not (self.cfg('username') and self.cfg('password')
+                and self.cfg('accession_number_prefix')):
+            warnings.warn(
+                f"The {self.__class__.__name__} is misconfigured. Please "
+                f"set {self.cfgkey('username')}, {self.cfgkey('password')}"
+                f" and {self.cfgkey('accession_number_prefix')} in your configuration.",
+                UserWarning
+            )
+
+    @property
+    def api(self):
+        """OSTI REST API client instance."""
+        if self._api is None:
+            self.check_credentials()
+            self._api = ostiapi
+            if self.cfg('test_mode'):
+                self._api.testmode()
+
+        return self._api
+
+
+class OSTIPIDProvider(PIDProvider):
+    """OSTI Provider class.
+
+    Note that OSTI is only contacted when a DOI is reserved or
+    registered, or any action posterior to it. PID creation requires
+    contacting OSTI to reserve the DOI.
+    """
+
+    def __init__(
+        self,
+        id_,
+        client=None,
+        serializer=None,
+        pid_type="doi",
+        default_status=PIDStatus.NEW,
+        **kwargs):
+        """Constructor."""
+        super().__init__(
+            id_,
+            client=(client or
+                    OSTIClient("osti", config_prefix="OSTI")),
+            pid_type=pid_type,
+            default_status=default_status
+        )
+        self.serializer = serializer or OSTIJSONSerializer()
+        self._config_prefix="OSTI"
+
+    def cfgkey(self, key):
+        """Generate a configuration key."""
+        return f"{self._config_prefix}_{key.upper()}"
+
+    def cfg(self, key, default=None):
+        """Get a application config value."""
+        return current_app.config.get(self.cfgkey(key), default)
+
+
+    def generate_id(self, record, **kwargs):
+        """Generate a unique DOI."""
+        # This is called when user clicks button in UI to reserve a DOI for a draft
+
+        # OSTI change: instead of generating the doi locally by combining the prefix 
+        # and invenio's record's pid call the osti python api to reserve the DOI. 
+        # We can pick the accession_num that will be used later to update the
+        # record in OSTI (like when it's published or when we need to update 
+        # the metadata) so in order for accession_num to uniquely identify the 
+        # record in OSTI and in our system we combine record.pid.pid_value with 
+        # the accession_number_prefix
+        try:
+            prefix = self.cfg('accession_number_prefix')
+            username = self.cfg('username')
+            password = self.cfg('password')
+            # do NOT run the serializer dump_one as it will also validate the record 
+            # and records do not need to have all required fields entered before 
+            # reserving a DOI (the dump_one code will throw an exception if the 
+            # record isn't valid)
+            # doc = self.serializer.dump_one(record)
+            doc = {
+                "title": "Placeholder Title"
+            }
+            if record.get('metadata').get('title'):
+                doc['title']=record.get('metadata').get('title')
+            doc['accession_num'] = f"{prefix}-{record.pid.pid_value}"
+            doc['contract_nos'] = f"{self.cfg('contract_nos')}"
+            doc['sponsor_org'] = f"{self.cfg('sponsor_org')}"
+            current_app.logger.info("doc sent to OSTI: reserve: " f"{doc}")
+            osti_record = self.client.api.reserve(
+                doc,
+                username, password)
+            current_app.logger.info("osti record returned from reserve" f"{osti_record}")
+            error = self.parse_osti_error(osti_record)
+            if error:
+                current_app.logger.error("OSTI returned ERROR status with message " f"{error}" " " f"full record: {osti_record}")
+                return False
+
+            current_app.logger.info("DOI: " f"{osti_record.get('record').get('doi')}")
+            return osti_record.get('record').get('doi')
+        except Exception as e:
+            current_app.logger.error("OSTI provider error when "
+                                       f"reserving a DOI for record {record.pid.pid_value}")
+            current_app.logger.error(e)
+            return False
+
+    def parse_osti_error(self, osti_record):
+        if osti_record.get("status") == "FAILURE":
+            return osti_record.get("status_message")
+
+    def can_modify(self, pid, **kwargs):
+        """Checks if the PID can be modified."""
+        return not pid.is_registered() and not pid.is_reserved()
+
+    def register(self, pid, record, url=None, **kwargs):
+        """Register a DOI via the OSTI API.
+
+        :param pid: the PID to register.
+        :param record: the record metadata for the DOI.
+        :returns: `True` if is registered successfully.
+        """
+        # This is what is called when the record is published 
+        # and the DOI needs to be minted
+        local_success = super().register(pid)
+        if not local_success:
+            return False
+
+        try:
+            doc = self.serializer.dump_one(record)
+            username = self.cfg('username')
+            password = self.cfg('password')
+            prefix = self.cfg('accession_number_prefix')
+
+            # first generate the accession_num (A site-specified unique identifier 
+            # to optionally identify the record) for this record in the same way 
+            # as was done in the generate_id method above and add it to the doc 
+            # that the serializer returns we need to pass this so OSTI will mint 
+            # the already created DOI instead of generating a new one. Always 
+            # generate and send the accession_num to use with future calls to 
+            # OSTI's api for this record (i.e. to mint or update an already minted):
+
+            doc['accession_num'] = f"{prefix}-{record.pid.pid_value}"
+            doc['contract_nos'] = f"{self.cfg('contract_nos')}"
+            doc['sponsor_org'] = f"{self.cfg('sponsor_org')}"
+            doc['site_url'] = url
+            current_app.logger.info("doc sent to OSTI: register" f"{doc}")
+
+            osti_record = self.client.api.post(doc, username, password)
+            error = self.parse_osti_error(osti_record)
+            if error:
+                current_app.logger.error("OSTI returned ERROR status with message " f"{error}" " " f"full record: {osti_record}")
+                return False
+
+            current_app.logger.info("OSTI DOI minted and returned " f"{osti_record}")
+            return True
+        except Exception as e:
+            current_app.logger.error("OSTI provider error when "
+                                       f"registering DOI for {pid.pid_value}")
+            current_app.logger.error(e)
+
+            return False
+
+    def update(self, pid, record, url=None, **kwargs):
+        """Update metadata associated with a DOI.
+
+        This can be called before/after a DOI is registered.
+        :param pid: the PID to register.
+        :param record: the record metadata for the DOI.
+        :returns: `True` if is updated successfully.
+        """
+        # pid providers' update method only called when a record that has already 
+        # been published is 'published' again. In the UI it goes like this: publish 
+        # a record. click the edit button and a new version is created in draft form.
+        # update that draft as many times as you'd like (this update method NOT 
+        # called) but once the updates are done the publish button is clicked on the
+        # new version's draft in the UI and only THEN is this update method is called.
+
+        try:
+            # Set metadata
+            prefix = self.cfg('accession_number_prefix')
+            username = self.cfg('username')
+            password = self.cfg('password')
+            doc = self.serializer.dump_one(record)
+            doc['contract_nos'] = f"{self.cfg('contract_nos')}"
+            doc['sponsor_org'] = f"{self.cfg('sponsor_org')}"
+            doc['accession_num'] = f"{prefix}-{record.pid.pid_value}"
+            doc['site_url'] = url
+
+            current_app.logger.info("doc sent to OSTI: update " f"{doc}")
+            osti_record = self.client.api.post(doc, username, password)
+            error = self.parse_osti_error(osti_record)
+            if error:
+                current_app.logger.error("OSTI returned ERROR status with message "\
+                                    f"{error}" " " f"full record: {osti_record}")
+                return False
+
+            current_app.logger.info("osti record returned from update" \
+                                    f"{json.dumps(osti_record)}")
+            return True
+        except Exception as e:
+            current_app.logger.error("OSTI provider error when "
+                                    f"updating DOI for {pid.pid_value}")
+            current_app.logger.error(e)
+
+            return False
+
+
+    def delete(self, pid, **kwargs):
+        """Delete/unregister a registered DOI.
+
+        If the PID has not been reserved then it's deleted only locally.
+        Otherwise, also it's deleted also remotely.
+        :returns: `True` if is deleted successfully.
+        """
+
+        # according to OSTI docs there is no support for 
+        # delete in either draft or published form
+        current_app.logger.warning("There is no delete api for OSTI provider,\
+                                    this DOI will remain in draft form at OSTI:"
+                                   f" {pid.pid_value}")
+
+        return super().delete(pid, **kwargs)
+
+    def validate(
+        self, record, identifier=None, provider=None, **kwargs
+    ):
+        """Validate the attributes of the identifier.
+
+        :returns: A tuple (success, errors). The first specifies if the
+                  validation was passed successfully. The second one is an
+                  array of error messages.
+        """
+        _, errors = super().validate(record, identifier, provider, **kwargs)
+
+        return (True, []) if not errors else (False, errors)
+        


### PR DESCRIPTION
…gov>

:heart: Thank you for your contribution!

### Description

Please describe briefly your pull request.
These are additions to extend InvenioRDM to support OSTI DOI. These additions are made to v35.21 and were tested from the user interface with v9.1.4 installtion. The DOI reserve, register and update were found to be working as expected with an OSTI test account.

In addition to the code in this commit, following are needed to be added to invenio.cfg. 

# OSTI Config

OSTI_ENABLED = True
OSTI_USERNAME = "osti-username"
OSTI_PASSWORD = "osti-password"
OSTI_ACCESSION_NUMBER_PREFIX = "BNLTEST"
OSTI_TEST_MODE = True
OSTI_CONTRACT_NOS = "12345"
# get from https://www.osti.gov/elink/authorities.jsp
OSTI_SPONSOR_ORG = "USDOE Office of Science and Technology (ST)" 

from invenio_rdm_records.services.pids import providers
RDM_PERSISTENT_IDENTIFIER_PROVIDERS = [
    providers.OSTIPIDProvider(
        "osti",
        client=providers.OSTIClient("osti", config_prefix="OSTI"),
        label=_("DOI"),
    ),
    # This is needed so that if users already have a DOI they can just enter it in the UI
    providers.ExternalPIDProvider(
        "external",
        "doi",
        # no need to block any prefixes so just use default DOI validator (no dups and correct format)
        # validators=[
        #     providers.BlockedPrefixes(config_names=['DATACITE_PREFIX'])
        # ],
        label=_("DOI"),
    ),
]

import idutils
RDM_PERSISTENT_IDENTIFIERS = {
    # look into what required: True does, i see in UI when saving a draft and not entering a DOI:
    # DOI: Missing DOI for required field. The prefix '' is administrated locally.
    "doi": {
        # "providers": ["osti"],
        "providers": [ "osti", "external"],
        "required": False,
        "label": _("DOI"),
        "validator": idutils.is_doi,
        "normalizer": idutils.normalize_doi,
    },
}


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
