### PR TITLE
datacite: fixed award id removal.

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -505,7 +505,6 @@ class DataCite43Schema(Schema):
                     # FIXME: should this be implemented at awards service read
                     # level since all ids are loaded into the system with this
                     # format?
-                    id_ = id_.split("::")[1]
                     award_service = current_service_registry.get("awards")
                     award = award_service.read(system_identity, id_).to_dict()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1038,7 +1038,7 @@ def awards_v(app, funders_v):
     award = awards_service.create(
         system_identity,
         {
-            "id": "755021",
+            "id": "00k4n6c32::755021",
             "identifiers": [
                 {
                     "identifier": "https://cordis.europa.eu/project/id/755021",


### PR DESCRIPTION
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1904


this needs to be properly analysed. Right now, export fails because award's id is stripped and when the award is resolved (for export) it's not found in the DB.