### PR TITLE
Add draft indexer to the registry

### DIFF
--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -30,6 +30,7 @@ def init(state):
     # Register indexers
     iregistry = app.extensions["invenio-indexer"].registry
     iregistry.register(ext.records_service.indexer, indexer_id="records")
+    iregistry.register(ext.records_service.draft_indexer, indexer_id="records-drafts")
 
 
 def create_records_bp(app):


### PR DESCRIPTION
Add the records service's new draft indexer to the central indexer registry provided by `invenio-indexer`.
Requires https://github.com/inveniosoftware/invenio-drafts-resources/pull/208.