### PR TITLE
Sanitize HTML in additional descriptions instead of stripping it

### DIFF
--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2021 Graz University of Technology.
+# Copyright (C) 2022 TU Wien.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -22,7 +23,7 @@ from invenio_vocabularies.resources import L10NString, VocabularyL10Schema
 from marshmallow import Schema, fields, missing
 from marshmallow_utils.fields import FormatDate as FormatDate_
 from marshmallow_utils.fields import FormatEDTF as FormatEDTF_
-from marshmallow_utils.fields import StrippedHTML
+from marshmallow_utils.fields import SanitizedHTML, StrippedHTML
 from marshmallow_utils.fields.babel import gettext_from_dict
 
 from .fields import AccessStatusField
@@ -110,7 +111,7 @@ class AdditionalTitlesSchema(Schema):
 class AdditionalDescriptionsSchema(Schema):
     """Localization of additional descriptions."""
 
-    description = StrippedHTML(attribute="description")
+    description = SanitizedHTML(attribute="description")
     type = fields.Nested(VocabularyL10Schema, attribute="type")
     lang = fields.Nested(VocabularyL10Schema, attribute="lang")
 


### PR DESCRIPTION
The **additional descriptions** input field on the deposit page allows for text formatting, but given that the UI JSON Serializer **stripped** the HTML from that field, no formatting was ever displayed on the landing/preview page of records for those inputs.

# Input

![image](https://user-images.githubusercontent.com/6437519/201347652-72f7af74-4502-49c6-8c87-b687c2e70d8f.png)

# Before

![image](https://user-images.githubusercontent.com/6437519/201347548-70749703-b37e-4f4e-86fe-676c55209853.png)

# After

![image](https://user-images.githubusercontent.com/6437519/201347462-05e087b0-6911-4d6f-a405-bec7960158de.png)