### PR TITLE
datacite: fix reversion in affiliation ROR handling and cleanup

### DIFF
--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -73,7 +73,7 @@ def test_datacite43_serializer(running_app, full_record):
                     {"name": "free-text"},
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "01ggx4157",
+                        "affiliationIdentifier": "https://ror.org/01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     },
                 ],
@@ -113,7 +113,7 @@ def test_datacite43_serializer(running_app, full_record):
                 "affiliation": [
                     {
                         "name": "CERN",
-                        "affiliationIdentifier": "01ggx4157",
+                        "affiliationIdentifier": "https://ror.org/01ggx4157",
                         "affiliationIdentifierScheme": "ROR",
                     }
                 ],
@@ -205,7 +205,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <familyName>Nielsen</familyName>",
         '      <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>',  # noqa
         "      <affiliation>free-text</affiliation>",
-        '      <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>',  # noqa
+        '      <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>',  # noqa
         "    </creator>",
         "  </creators>",
         "  <titles>",
@@ -224,7 +224,7 @@ def test_datacite43_xml_serializer(running_app, full_record):
         "      <givenName>Lars Holm</givenName>",
         "      <familyName>Nielsen</familyName>",
         '      <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>',  # noqa
-        '      <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>',  # noqa
+        '      <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>',  # noqa
         "    </contributor>",
         "  </contributors>",
         "  <dates>",

--- a/tests/test_oai.py
+++ b/tests/test_oai.py
@@ -67,7 +67,7 @@ def test_datacite_serializer(running_app, full_record):
         "      <familyName>Nielsen</familyName>\n"
         '      <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>\n'  # noqa
         "      <affiliation>free-text</affiliation>\n"
-        '      <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
+        '      <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
         "    </creator>\n"
         "  </creators>\n"
         "  <titles>\n"
@@ -86,7 +86,7 @@ def test_datacite_serializer(running_app, full_record):
         "      <givenName>Lars Holm</givenName>\n"
         "      <familyName>Nielsen</familyName>\n"
         '      <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>\n'  # noqa
-        '      <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
+        '      <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
         "    </contributor>\n"
         "  </contributors>\n"
         "  <dates>\n"
@@ -156,7 +156,7 @@ def test_oai_datacite_serializer(running_app, full_record):
         "          <familyName>Nielsen</familyName>\n"
         '          <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>\n'  # noqa
         "          <affiliation>free-text</affiliation>\n"
-        '          <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
+        '          <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
         "        </creator>\n"
         "      </creators>\n"
         "      <titles>\n"
@@ -175,7 +175,7 @@ def test_oai_datacite_serializer(running_app, full_record):
         "          <givenName>Lars Holm</givenName>\n"
         "          <familyName>Nielsen</familyName>\n"
         '          <nameIdentifier nameIdentifierScheme="ORCID">0000-0001-8135-3489</nameIdentifier>\n'  # noqa
-        '          <affiliation affiliationIdentifier="01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
+        '          <affiliation affiliationIdentifier="https://ror.org/01ggx4157" affiliationIdentifierScheme="ROR">CERN</affiliation>\n'  # noqa
         "        </contributor>\n"
         "      </contributors>\n"
         "      <dates>\n"


### PR DESCRIPTION
- closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1157

:heart: Thank you for your contribution!

### Description

This PR fixes a reversion in the DataCite serializer. In v9 ROR affiliations were serialized with the whole url https://ror.org/identifier. That changed in v10 to just the identifier portion due to other identifier cleanup. This is an issue because DataCite expects ROR affiliations to be in their url form and unceremoniously deletes them if not. I've asked DataCite to change this, but we can also fix this directly in our serializer.

I also did a bit of cleanup by using the same approach as funders for determining which identifier to use.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
