### PR TITLE
metadata: remove name from creator/contributor

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,7 +373,6 @@ def full_record(users):
             "creators": [
                 {
                     "person_or_org": {
-                        "name": "Nielsen, Lars Holm",
                         "type": "personal",
                         "given_name": "Lars Holm",
                         "family_name": "Nielsen",
@@ -401,7 +400,6 @@ def full_record(users):
             "contributors": [
                 {
                     "person_or_org": {
-                        "name": "Nielsen, Lars Holm",
                         "type": "personal",
                         "given_name": "Lars Holm",
                         "family_name": "Nielsen",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

In the metadata description [¶](https://inveniordm.docs.cern.ch/reference/metadata/#creators-1-n) name is indicated as not supported for personal creators/contributors, and this is how the metadata flow is currently handled (if you put something in the name field, it's replaced by the given/family name fields).

I'm *not* sure this is the desired/ideal behavior (it might be useful to be able to customize name), so this PR is just making our tests consistent with what we say in the metadata page. It would also be fine to change the behavior.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
