### PR TITLE
add uiSchema to AdminDetailsView props

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/index.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/index.js
@@ -24,6 +24,7 @@ const apiEndpoint = _get(domContainer.dataset, "apiEndpoint");
 const idKeyPath = JSON.parse(_get(domContainer.dataset, "pidPath", "pid"));
 const listUIEndpoint = domContainer.dataset.listEndpoint;
 const resourceSchema = JSON.parse(domContainer.dataset.resourceSchema);
+const uiSchema = JSON.parse(domContainer.dataset.uiConfig);
 
 const createdBySystem = (data) => data?.system_created;
 
@@ -57,6 +58,7 @@ domContainer &&
         resourceName={resourceName}
         listUIEndpoint={listUIEndpoint}
         resourceSchema={resourceSchema}
+        uiSchema={uiSchema}
       >
         <LinksTable />
       </AdminDetailsView>


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-administration/issues/155

Before: using wrong schema (marshmallow) to display fields
<img width="1661" alt="Screenshot 2023-02-16 at 17 50 43" src="https://user-images.githubusercontent.com/61321254/219435802-12161cdd-ca23-446b-9830-241a95414448.png">


After: display the fields corresponding to [the config](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/administration/views/oai.py#L146)
<img width="1666" alt="Screenshot 2023-02-16 at 18 01 02" src="https://user-images.githubusercontent.com/61321254/219436125-55684baa-250b-4cd4-b0c7-71e86e510c22.png">

