### PR TITLE
records: fix permissions when removing records

### DIFF
--- a/invenio_rdm_records/resources/resources.py
+++ b/invenio_rdm_records/resources/resources.py
@@ -185,7 +185,7 @@ class RDMRecordCommunitiesResource(ErrorHandlersMixin, Resource):
     @response_handler()
     def remove(self):
         """Remove communities from the record."""
-        errors = self.service.delete(
+        errors = self.service.remove(
             identity=g.identity,
             record_id=resource_requestctx.view_args["pid_value"],
             data=resource_requestctx.data,

--- a/invenio_rdm_records/services/community_records/service.py
+++ b/invenio_rdm_records/services/community_records/service.py
@@ -76,7 +76,7 @@ class CommunityRecordsService(RecordService):
     def _remove(self, community, record, identity):
         """Remove a community from the record."""
         data = dict(communities=[dict(id=str(community.id))])
-        errors = current_record_communities_service.delete(
+        errors = current_record_communities_service.remove(
             identity, record_id=record.pid.pid_value, data=data
         )
 
@@ -86,7 +86,9 @@ class CommunityRecordsService(RecordService):
     def delete(self, identity, community_id, data, revision_id=None, uow=None):
         """Remove records from a community."""
         community = self.community_cls.pid.resolve(community_id)
+
         self.require_permission(identity, "remove_record", record=community)
+
         valid_data, errors = self.community_record_schema.load(
             data,
             context={
@@ -102,19 +104,18 @@ class CommunityRecordsService(RecordService):
             try:
                 record = self.record_cls.pid.resolve(record_id)
                 errors += self._remove(community, record, identity)
-
             except PIDDoesNotExistError:
                 errors.append(
                     {
                         "record": record_id,
-                        "message": f"The record does not exist.",
+                        "message": "The record does not exist.",
                     }
                 )
             except PermissionDeniedError:
                 errors.append(
                     {
                         "record": record_id,
-                        "message": f"Permission denied.",
+                        "message": "Permission denied.",
                     }
                 )
 

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -196,7 +196,7 @@ class SecretLinks(Generator):
 
 
 class SubmissionReviewer(Generator):
-    """Curators for community submission requests."""
+    """Roles for community's reviewers."""
 
     def needs(self, record=None, **kwargs):
         """Set of Needs granting permission."""
@@ -213,8 +213,8 @@ class SubmissionReviewer(Generator):
         return []
 
 
-class CommunityAction(CommunityRoles):
-    """Member of a community with a given action."""
+class RecordCommunitiesAction(CommunityRoles):
+    """Roles generators of all record's communities for a given member's action."""
 
     def __init__(self, action):
         """Initialize generator."""

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -10,6 +10,7 @@
 """Permissions for Invenio RDM Records."""
 
 from invenio_communities.generators import CommunityCurators
+from invenio_records import Record
 from invenio_records_permissions.generators import (
     AnyUser,
     AuthenticatedUser,
@@ -19,9 +20,9 @@ from invenio_records_permissions.generators import (
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
 
 from .generators import (
-    CommunityAction,
     IfFileIsLocal,
     IfRestricted,
+    RecordCommunitiesAction,
     RecordOwners,
     SecretLinks,
     SubmissionReviewer,
@@ -46,7 +47,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     #
     can_manage = [
         RecordOwners(),
-        CommunityAction("curate"),
+        RecordCommunitiesAction("curate"),
         SystemProcess(),
     ]
     can_curate = can_manage + [SecretLinks("edit")]
@@ -55,7 +56,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_view = can_manage + [
         SecretLinks("view"),
         SubmissionReviewer(),
-        CommunityAction("view"),
+        RecordCommunitiesAction("view"),
     ]
 
     can_authenticated = [AuthenticatedUser(), SystemProcess()]
@@ -138,7 +139,13 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     # Record communities
     #
     # Allow to remove a community from a record
-    can_remove_community = can_manage
+    can_add_community = [RecordOwners()]
+    # Allow to remove a community from a record
+    can_remove_community = [
+        RecordOwners(),
+        CommunityCurators(),
+        SystemProcess(),
+    ]
     # Allow to remove records from a community
     can_remove_record = [CommunityCurators()]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1408,31 +1408,6 @@ def admin(UserFixture, app, db, admin_role_need):
     return u
 
 
-@pytest.fixture()
-def curator(UserFixture, community, app, db):
-    """Creates a curator of the community fixture."""
-    curator = UserFixture(
-        email="curatoruser@inveniosoftware.org",
-        password="curatoruser",
-    )
-    curator.create(app, db)
-    invitation_data = {
-        "members": [
-            {
-                "type": "user",
-                "id": curator.id,
-            }
-        ],
-        "role": "curator",
-        "visible": True,
-    }
-
-    current_communities.service.members.add(
-        system_identity, community.id, invitation_data
-    )
-    return curator
-
-
 @pytest.fixture(scope="module")
 def cli_runner(base_app):
     """Create a CLI runner for testing a CLI command."""

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -32,9 +32,7 @@ def rdm_record_service():
 
 
 @pytest.fixture()
-def community_record(
-    uploader, minimal_record, community, rdm_record_service, running_app, db
-):
+def record_community(uploader, minimal_record, community, rdm_record_service, db):
     """Record that belongs to a community."""
 
     class Record:
@@ -46,7 +44,7 @@ def community_record(
             draft = rdm_record_service.create(uploader.identity, minimal_record)
             # Publish
             record = rdm_record_service.publish(uploader.identity, draft.id)
-            # TODO replace the following code by the service func that adds the record to a community
+            # TODO: remove this extra func when the `add` to a community is implemented
             community_record = community._record
             record._record.parent.communities.add(community_record, default=False)
             record._record.parent.commit()

--- a/tests/resources/test_resources_community_records.py
+++ b/tests/resources/test_resources_community_records.py
@@ -17,10 +17,10 @@ def service():
     return current_community_records_service
 
 
-def test_remove_community(client, curator, community_record, headers, community):
+def test_remove_community(client, curator, record_community, headers, community):
     """Remove a record from the community."""
     client = curator.login(client)
-    record = community_record.create_record()
+    record = record_community.create_record()
     data = {"records": [{"id": record.id}]}
 
     response = client.delete(
@@ -33,10 +33,10 @@ def test_remove_community(client, curator, community_record, headers, community)
 
 
 def test_permission_denied(
-    client, uploader, test_user, community_record, headers, community
+    client, uploader, test_user, record_community, headers, community
 ):
     """Missing permissions when removing a record from the community."""
-    record = community_record.create_record()
+    record = record_community.create_record()
     data = {"records": [{"id": record.id}]}
 
     test_user_client = test_user.login(client)
@@ -65,13 +65,13 @@ def test_error_data(client, curator, headers, community):
 
 
 def test_removal_of_multiple_communities_success(
-    client, curator, community_record, headers, community
+    client, curator, record_community, headers, community
 ):
     """Remove multiple records from a community."""
     client = curator.login(client)
-    record1 = community_record.create_record()
-    record2 = community_record.create_record()
-    record3 = community_record.create_record()
+    record1 = record_community.create_record()
+    record2 = record_community.create_record()
+    record3 = record_community.create_record()
     data = {
         "records": [
             {"id": record1.id},
@@ -90,7 +90,7 @@ def test_removal_of_multiple_communities_success(
 
 
 def test_exceeded_max_number_of_records(
-    client, curator, community_record, headers, community, service
+    client, curator, record_community, headers, community, service
 ):
     """Test raise exceeded max number of records."""
     client = curator.login(client)

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -66,6 +66,7 @@ def record_community(db, uploader, minimal_record, community, rdm_record_service
             # publish and get record
             record = RDMRecord.publish(draft._record)
             record.commit()
+            # TODO: remove this extra func when the `add` to a community is implemented
             record.parent.communities.add(community_record, default=False)
             record.parent.commit()
             record.commit()

--- a/tests/services/test_service_communities.py
+++ b/tests/services/test_service_communities.py
@@ -8,155 +8,159 @@
 """Test record's communities service."""
 
 import pytest
-from invenio_records_resources.services.errors import PermissionDeniedError
 from marshmallow import ValidationError
 
 from invenio_rdm_records.proxies import current_record_communities_service
+from invenio_rdm_records.records import RDMRecord
 from invenio_rdm_records.services.errors import MaxNumberCommunitiesExceeded
 
 
 @pytest.fixture()
-def record_communities_service():
+def service():
     """Get the current records communities service."""
     return current_record_communities_service
 
 
 def test_remove_community_from_record_success(
-    running_app,
+    curator,
     community,
     record_community,
     rdm_record_service,
-    record_communities_service,
+    service,
 ):
     """Test removal of a community from a record."""
-    superuser_identity = running_app.superuser_identity
     data = {"communities": [{"id": community.id}]}
     record = record_community.create_record()
-    errors = record_communities_service.delete(
-        superuser_identity, record.pid.pid_value, data
-    )
+    errors = service.remove(curator.identity, record.pid.pid_value, data)
     assert errors == []
 
-    saved_record = rdm_record_service.read(superuser_identity, record.pid.pid_value)
+    saved_record = rdm_record_service.read(curator.identity, record.pid.pid_value)
     assert not saved_record.data["parent"]["communities"]
 
 
 def test_remove_multiple_communities():
     """Test removal of multiple communities of a record."""
-    # TODO once the multiple publish is implemented.
+    # TODO: implement when the `add` method is implemented
     pass
 
 
-def test_missing_permission(
-    test_user, community, record_community, record_communities_service
-):
-    """Test permissions to delete."""
+def test_remove_as_owner(uploader, community, record_community, service):
+    """Test that the record's owner can remove the record from a community."""
     data = {"communities": [{"id": community.id}]}
     record = record_community.create_record()
 
-    with pytest.raises(PermissionDeniedError):
-        record_communities_service.delete(
-            test_user.identity, record.pid.pid_value, data
-        )
+    service.remove(uploader.identity, record.pid.pid_value, data)
 
 
-def test_owner_permission(
-    uploader, community, record_community, record_communities_service
-):
-    """Test permissions to delete."""
+def test_remove_as_community_curator(curator, community, record_community, service):
+    """Test that the community's curator can remove the record from its community."""
     data = {"communities": [{"id": community.id}]}
     record = record_community.create_record()
 
-    record_communities_service.delete(uploader.identity, record.pid.pid_value, data)
+    service.remove(curator.identity, record.pid.pid_value, data)
 
 
-def test_curator_permission(
-    curator, community, record_community, record_communities_service
-):
-    """Test permissions to delete."""
-    data = {"communities": [{"id": community.id}]}
-    record = record_community.create_record()
-
-    record_communities_service.delete(curator.identity, record.pid.pid_value, data)
-
-
-def test_remove_community_from_record_error(
-    running_app,
+def test_remove_non_existing_community(
+    curator,
     record_community,
     rdm_record_service,
-    record_communities_service,
+    service,
     community,
 ):
-    """Test error on removing a wrong community from a record."""
-    superuser_identity = running_app.superuser_identity
+    """Test removal of a non-existing community returns an error."""
     data = {"communities": [{"id": "wrong-id"}]}
     record = record_community.create_record()
 
-    errors = record_communities_service.delete(
-        superuser_identity, record.pid.pid_value, data
-    )
+    errors = service.remove(curator.identity, record.pid.pid_value, data)
     assert len(errors) == 1
 
-    saved_record = rdm_record_service.read(superuser_identity, record.pid.pid_value)
+    saved_record = rdm_record_service.read(curator.identity, record.pid.pid_value)
     assert saved_record.data["parent"]["communities"] == {"ids": [str(community.id)]}
 
 
-def test_remove_community_from_record_success_w_errors(
-    running_app,
+def test_remove_existing_and_non_existing_community(
+    curator,
     community,
     record_community,
     rdm_record_service,
-    record_communities_service,
+    service,
 ):
-    """Test removal of communities from record with errors."""
-    superuser_identity = running_app.superuser_identity
+    """Test removal of existing and non-existing communities."""
     wrong_data = [{"id": "wrong-id"}, {"id": "wrong-id2"}]
     correct_data = [{"id": community.id}]
     data = {"communities": correct_data + wrong_data}
     record = record_community.create_record()
 
-    errors = record_communities_service.delete(
-        superuser_identity, record.pid.pid_value, data
-    )
+    errors = service.remove(curator.identity, record.pid.pid_value, data)
 
     assert len(errors) == 2
 
-    saved_record = rdm_record_service.read(
-        superuser_identity, record_community.pid.pid_value
-    )
+    saved_record = rdm_record_service.read(curator.identity, record.pid.pid_value)
     assert not saved_record.data["parent"]["communities"]
 
 
-def test_remove_community_from_record_success_w_errors(
-    running_app, community, record_community, record_communities_service
+def test_remove_missing_permission(test_user, community, record_community, service):
+    """Test that a random user cannot remove the record from a community."""
+    data = {"communities": [{"id": community.id}]}
+    record = record_community.create_record()
+
+    errors = service.remove(test_user.identity, record.pid.pid_value, data)
+
+    assert len(errors) == 1
+    assert errors[0]["community"] == community.id
+    assert errors[0]["message"] == "Permission denied."
+
+
+def test_remove_another_community(
+    db,
+    curator,
+    community2,
+    record_community,
+    service,
+    rdm_record_service,
 ):
-    """Test removal of communities from record with errors."""
-    superuser_identity = running_app.superuser_identity
+    """Test error when removing a community by a curator of another community."""
+
+    # TODO: remove this extra func when the `add` to a community is implemented
+    def add_to_community2(record):
+        record.parent.communities.add(community2._record, default=False)
+        record.parent.commit()
+        record.commit()
+        db.session.commit()
+        rdm_record_service.indexer.index(record)
+        RDMRecord.index.refresh()
+        return record
+
+    record = record_community.create_record()
+    record = add_to_community2(record)
+    # record is part of `community` and `community2`
+    # curator is curator of `community`: it cannot remove it from `community2`
+
+    data = {"communities": [{"id": community2.id}]}
+    errors = service.remove(curator.identity, record.pid.pid_value, data)
+
+    assert len(errors) == 1
+    assert errors[0]["community"] == community2.id
+    assert errors[0]["message"] == "Permission denied."
+
+
+def test_remove_too_many_communities(curator, record_community, service):
+    """Test that passing too many communities throws an error."""
     random_community = {"id": "random-id"}
     record = record_community.create_record()
 
     lots_of_communities = []
-    while (
-        len(lots_of_communities)
-        <= record_communities_service.config.max_number_of_removals
-    ):
+    while len(lots_of_communities) <= service.config.max_number_of_removals:
         lots_of_communities.append(random_community)
     data = {"communities": lots_of_communities}
     with pytest.raises(MaxNumberCommunitiesExceeded):
-        record_communities_service.delete(
-            superuser_identity, record.pid.pid_value, data
-        )
+        service.remove(curator.identity, record.pid.pid_value, data)
 
 
-def test_remove_community_empty_payload(
-    running_app, community, record_community, record_communities_service
-):
+def test_remove_empty_communities(curator, record_community, service):
     """Test removal of communities from record with empty payload."""
-    superuser_identity = running_app.superuser_identity
     data = {"communities": []}
     record = record_community.create_record()
 
     with pytest.raises(ValidationError):
-        record_communities_service.delete(
-            superuser_identity, record.pid.pid_value, data
-        )
+        service.remove(curator.identity, record.pid.pid_value, data)

--- a/tests/services/test_service_community_records.py
+++ b/tests/services/test_service_community_records.py
@@ -26,22 +26,20 @@ def service():
 
 
 def test_remove_record_from_community_success(
-    running_app, community, record_community, service
+    curator, community, record_community, service
 ):
     """Test removal of a record from a community."""
-    superuser_identity = running_app.superuser_identity
     record = record_community.create_record()
     data = {"records": [{"id": record.pid.pid_value}]}
-    errors = service.delete(superuser_identity, str(community.id), data)
+    errors = service.delete(curator.identity, str(community.id), data)
 
     assert errors == []
 
 
 def test_remove_records_from_community_success(
-    running_app, community, record_community, service
+    curator, community, record_community, service
 ):
     """Test removal of a multiple records from a community."""
-    superuser_identity = running_app.superuser_identity
     record1 = record_community.create_record()
     record2 = record_community.create_record()
     record3 = record_community.create_record()
@@ -52,7 +50,7 @@ def test_remove_records_from_community_success(
             {"id": record3.pid.pid_value},
         ]
     }
-    errors = service.delete(superuser_identity, str(community.id), data)
+    errors = service.delete(curator.identity, str(community.id), data)
 
     assert errors == []
 
@@ -74,110 +72,88 @@ def test_curator_permission(curator, community, record_community, service):
     assert errors == []
 
 
-def test_remove_record_from_community_error(running_app, community, service):
-    """Test error on removing a wrong record from a community."""
-    superuser_identity = running_app.superuser_identity
+def test_remove_non_existing_record(curator, community, service):
+    """Test error on removing a non-existing record from a community."""
     data = {"records": [{"id": "wrong-id"}]}
-    errors = service.delete(superuser_identity, str(community.id), data)
+    errors = service.delete(curator.identity, str(community.id), data)
 
     assert len(errors) == 1
+    assert errors[0]["message"] == "The record does not exist."
+
+
+def test_remove_record_of_other_community(
+    db, curator, community, community2, record_community, service, rdm_record_service
+):
+    """Test error on removing a record that belongs to another community."""
+
+    # TODO: remove this extra func when the `add` to a community is implemented
+    def add_to_community2(record):
+        record.parent.communities.remove(community._record)
+        record.parent.communities.add(community2._record, default=False)
+        record.parent.commit()
+        record.commit()
+        db.session.commit()
+        rdm_record_service.indexer.index(record)
+        RDMRecord.index.refresh()
+        return record
+
+    record_comm2 = record_community.create_record()
+    record_comm2 = add_to_community2(record_comm2)
+
+    data = {"records": [{"id": record_comm2.pid.pid_value}]}
+    errors = service.delete(curator.identity, str(community.id), data)
+
+    assert len(errors) == 1
+    assert errors[0]["message"] == "The record does not belong to the community."
 
 
 def test_remove_records_from_communities_success_w_errors(
-    running_app, community, record_community, service
+    curator, community, record_community, service
 ):
     """Test removal of records from communities with errors."""
-    superuser_identity = running_app.superuser_identity
     record = record_community.create_record()
     correct_data = [{"id": record.pid.pid_value}]
     wrong_data = [{"id": "wrong-id"}, {"id": "wrong-id2"}]
     data = {"records": correct_data + wrong_data}
-    errors = service.delete(superuser_identity, str(community.id), data)
+    errors = service.delete(curator.identity, str(community.id), data)
 
     assert len(errors) == 2
 
 
-def test_remove_too_many_records(running_app, community, record_community, service):
+def test_remove_too_many_records(curator, community, record_community, service):
     """Test removal of too many records from a community."""
-    superuser_identity = running_app.superuser_identity
     random_record = {"id": "random-id"}
     lots_of_records = []
     while len(lots_of_records) <= service.config.max_number_of_removals:
         lots_of_records.append(random_record)
     data = {"records": lots_of_records}
     with pytest.raises(MaxNumberOfRecordsExceed):
-        service.delete(superuser_identity, str(community.id), data)
+        service.delete(curator.identity, str(community.id), data)
 
 
-def test_remove_w_empty_payload(running_app, community, service):
+def test_remove_w_empty_payload(curator, community, service):
     """Test removal of records from communities with empty payload."""
-    superuser_identity = running_app.superuser_identity
     data = {"records": []}
     with pytest.raises(ValidationError):
-        service.delete(superuser_identity, str(community.id), data)
+        service.delete(curator.identity, str(community.id), data)
 
 
 def test_search_community_records(
-    db, running_app, minimal_record, community, anyuser_identity
+    community, record_community, service, anyuser_identity
 ):
     """Test search for records in a community."""
-    service = current_rdm_records_service
-    community_records = current_community_records_service
-    community = community._record
-
-    def _create_record():
-        """Create a record."""
-        # create draft
-        draft = RDMDraft.create(minimal_record)
-        draft.commit()
-        db.session.commit()
-        # publish and get record
-        record = RDMRecord.publish(draft)
-        record.commit()
-        db.session.commit()
-        return record
-
-    def _add_to_community(record, community, default):
-        """Add record to community."""
-        record.parent.communities.add(community, default=default)
-        record.parent.commit()
-        record.commit()
-        db.session.commit()
-        service.indexer.index(record)
-        RDMRecord.index.refresh()
-
-    # ensure that there no records in the community
-    results = community_records.search(
+    results = service.search(
         anyuser_identity,
-        community_id=community.id,
+        community_id=str(community.id),
     )
     assert results.to_dict()["hits"]["total"] == 0
 
-    # add record to community, with default false
-    record1 = _create_record()
-    _add_to_community(record1, community, False)
+    record_community.create_record()
+    record_community.create_record()
+    record_community.create_record()
 
-    # ensure that the record is in the community
-    results = community_records.search(
+    results = service.search(
         anyuser_identity,
-        community_id=community.id,
+        community_id=str(community.id),
     )
-    assert results.to_dict()["hits"]["total"] == 1
-
-    # add another record to community, with default true
-    record2 = _create_record()
-    _add_to_community(record2, community, True)
-
-    # ensure that the record is in the community
-    results = community_records.search(
-        anyuser_identity,
-        community_id=community.id,
-    )
-    assert results.to_dict()["hits"]["total"] == 2
-
-    # ensure that searching by community slug also works
-    results = community_records.search(
-        anyuser_identity,
-        community_id=community.slug,
-    )
-    assert results.to_dict()["hits"]["total"] == 2
+    assert results.to_dict()["hits"]["total"] == 3

--- a/tests/services/test_service_review.py
+++ b/tests/services/test_service_review.py
@@ -57,15 +57,6 @@ def requests_service():
 
 
 @pytest.fixture()
-def community2(running_app, minimal_community2, db):
-    """Get the current RDM records service."""
-    return current_communities.service.create(
-        running_app.superuser_identity,
-        minimal_community2,
-    )
-
-
-@pytest.fixture()
 def draft(minimal_record, community, service, running_app, db):
     minimal_record["parent"] = {
         "review": {


### PR DESCRIPTION
* adds an extra permission check to ensure that a community curator cannot remove records from communities where he is not a curator.