### PR TITLE
serializer: update tests for date intervals

### DIFF
--- a/tests/resources/serializers/test_ui_serializer.py
+++ b/tests/resources/serializers/test_ui_serializer.py
@@ -144,8 +144,8 @@ def test_ui_serializer(app, full_to_dict_record):
                 }
             ],
         },
-        "publication_date_l10n_long": "January 2018 – September 2020",
-        "publication_date_l10n_medium": "Jan 2018 – Sep 2020",
+        "publication_date_l10n_long": "January 2018\u2009–\u2009September 2020",
+        "publication_date_l10n_medium": "Jan 2018\u2009–\u2009Sep 2020",
         "resource_type": {"id": "publication-article", "title_l10n": "Journal article"},
         "additional_titles": [
             {


### PR DESCRIPTION
* changes the UI serializer test for date interval to apply the unicode space char change as in Babel. See https://github.com/python-babel/babel/commit/d76db13414a6104019edc0dbafa82410e8d08e63

Babel 2.12 upgrades CLDR to v42, which introduces this change to the unicode `space` char.