### PR TITLE
serializers: replace fields.Method by attribute key with dotted access

### DIFF
--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -9,7 +9,7 @@
 
 import datetime
 
-from marshmallow import Schema, fields, missing, post_dump
+from marshmallow import fields, missing, post_dump
 from slugify import slugify
 
 from ..schemas import BaseSchema
@@ -21,7 +21,7 @@ class BibTexSchema(BaseSchema):
 
     id = fields.Str()
     resource_id = fields.Str(attribute="metadata.resource_type.id")
-    version = fields.Method("get_version")
+    version = fields.Str(attribute="metadata.version")
     date_created = fields.Method("get_date_created")
     locations = fields.Method("get_locations")
     titles = fields.Method("get_titles")

--- a/invenio_rdm_records/resources/serializers/csl/schema.py
+++ b/invenio_rdm_records/resources/serializers/csl/schema.py
@@ -57,7 +57,7 @@ class CSLJSONSchema(Schema):
     language = fields.Method("get_language")
     version = SanitizedUnicode(attribute="metadata.version")
     note = fields.Method("get_note")
-    doi = fields.Method("get_doi", data_key="DOI")
+    doi = fields.Str(attribute="pids.doi.identifier", data_key="DOI")
     isbn = fields.Method("get_isbn", data_key="ISBN")
     issn = fields.Method("get_issn", data_key="ISSN")
     publisher = SanitizedUnicode(attribute="metadata.publisher")
@@ -105,10 +105,6 @@ class CSLJSONSchema(Schema):
         languages = metadata.get("languages")
 
         return languages[0]["id"] if languages else missing
-
-    def get_doi(self, obj):
-        """Get DOI."""
-        return obj["pids"].get("doi", {}).get("identifier", missing)
 
     def get_isbn(self, obj):
         """Get ISBN."""

--- a/invenio_rdm_records/resources/serializers/dublincore/schema.py
+++ b/invenio_rdm_records/resources/serializers/dublincore/schema.py
@@ -10,7 +10,7 @@
 import bleach
 from invenio_access.permissions import system_identity
 from invenio_vocabularies.proxies import current_service as vocabulary_service
-from marshmallow import Schema, fields, missing
+from marshmallow import fields, missing
 
 from ..schemas import BaseSchema
 from ..ui.schema import current_default_locale
@@ -31,14 +31,13 @@ class DublinCoreSchema(BaseSchema):
     descriptions = fields.Method("get_descriptions")
     publishers = fields.Method("get_publishers")
     types = fields.Method("get_types")
-    sources = fields.Method("get_sources")
+    # TODO: sources = fields.List(fields.Str(), attribute="metadata.references")
+    sources = fields.Constant(
+        missing
+    )  # Corresponds to references in the metadata schema
     languages = fields.Method("get_languages")
     locations = fields.Method("get_locations")
     formats = fields.Method("get_formats")
-
-    def get_titles(self, obj):
-        """Get titles."""
-        return [obj["metadata"]["title"]]
 
     def get_identifiers(self, obj):
         """Get identifiers."""
@@ -47,10 +46,6 @@ class DublinCoreSchema(BaseSchema):
         items.extend(p["identifier"] for p in obj.get("pids", {}).values())
 
         return items or missing
-
-    def get_creators(self, obj):
-        """Get creators."""
-        return [c["person_or_org"]["name"] for c in obj["metadata"].get("creators", [])]
 
     def get_relations(self, obj):
         """Get relations."""
@@ -153,20 +148,6 @@ class DublinCoreSchema(BaseSchema):
         )
         return subjects or missing
 
-    def get_publishers(self, obj):
-        """Get publishers."""
-        publisher = obj["metadata"].get("publisher")
-        if publisher:
-            return [publisher]
-
-        return missing
-
-    def get_contributors(self, obj):
-        """Get contributors."""
-        return [
-            c["person_or_org"]["name"] for c in obj["metadata"].get("contributors", [])
-        ] or missing
-
     def get_types(self, obj):
         """Get resource type."""
         props = get_vocabulary_props(
@@ -178,10 +159,6 @@ class DublinCoreSchema(BaseSchema):
         )
         t = props.get("eurepo")
         return [t] if t else missing
-
-    def get_sources(self, obj):
-        """Get sources."""
-        return missing
 
     def get_languages(self, obj):
         """Get languages."""

--- a/invenio_rdm_records/resources/serializers/schemas.py
+++ b/invenio_rdm_records/resources/serializers/schemas.py
@@ -40,10 +40,6 @@ class BaseSchema(Schema):
 
         return locations
 
-    def get_version(self, obj):
-        """Get the version of the record."""
-        return obj["metadata"].get("version", missing)
-
     def get_titles(self, obj):
         """Get titles."""
         return [obj["metadata"]["title"]]


### PR DESCRIPTION
We could even move actual fields to the base schema, but that was more complex and error prone work.