### PR TITLE
Document information about `FileKeyNotFoundError`

### DIFF
--- a/invenio_rdm_records/services/iiif/service.py
+++ b/invenio_rdm_records/services/iiif/service.py
@@ -91,7 +91,14 @@ class IIIFService(Service):
         return fp
 
     def get_file(self, identity, uuid, key=None):
-        """."""
+        """Get the file for the given ``uuid``.
+
+        If the ``uuid`` has the shape ``<record|draft>:<pid_value>:<key>``, then the
+        ``key`` argument is ignored.
+        If it is of the shape ``<record|draft>:<pid_value>`` however, the ``key``
+        argument is required.
+        :raises FileKeyNotFoundError: If the record has no file for the ``key``
+        """
         if key:
             type_, id_ = self._iiif_uuid(uuid)
         else:
@@ -111,7 +118,10 @@ class IIIFService(Service):
         quality,
         image_format,
     ):
-        """Run the IIIF image API workflow."""
+        """Run the IIIF image API workflow.
+
+        :raises FileKeyNotFoundError: If the record has no file for the ``key``
+        """
         # Validate IIIF parameters
         IIIFImageAPIWrapper.validate_api(
             uuid=uuid,


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1998

This PR basically just adds a little bit of documentation about the `FileKeyNotFoundError`.

The `IIIFService`  calls `file_service` methods that raise `FileKeyNotFoundError` in `get_file()` and `image_api()`.
It doesn't handle those exceptions, but rather passes them on.

The resources will catch these exceptions and return a 404, because of the error handler registered on a base resource class in https://github.com/inveniosoftware/invenio-records-resources/pull/454.

I verified that the resources have the error handlers registered in a `my-site` with the three PRs installed:
```python
(my-site) mmoser@mx ~/rdm/my-site $ invenio shell
 * Tip: There are .env or .flaskenv files present. Do "pip install python-dotenv" to use them.
Python 3.9.15 (main, Nov  8 2022, 11:31:44)
[GCC 12.2.0] on linux
IPython: 8.11.0
App: invenio [production]
Instance: /home/mmoser/.local/share/virtualenvs/my-site-OggevyoG/var/instance
In [1]: from invenio_records_resources.services.errors import FileKeyNotFoundError

In [2]: from invenio_rdm_records.proxies import current_rdm_records as crr

In [3]: FileKeyNotFoundError in crr.records_resource.error_handlers
Out[3]: True

In [4]: FileKeyNotFoundError in crr.iiif_resource.error_handlers
Out[4]: True
```