### PR TITLE
Turn identifiers into URLs on `schema.dump()` if applicable

### DIFF
--- a/invenio_rdm_records/resources/serializers/csl/schema.py
+++ b/invenio_rdm_records/resources/serializers/csl/schema.py
@@ -7,6 +7,7 @@
 
 """CSL based Schema for Invenio RDM Records."""
 
+import idutils
 from edtf import parse_edtf
 from edtf.parser.edtf_exceptions import EDTFParseException
 from edtf.parser.parser_classes import Date, Interval
@@ -108,7 +109,11 @@ class CSLJSONSchema(Schema):
 
     def get_doi(self, obj):
         """Get DOI."""
-        return obj["pids"].get("doi", {}).get("identifier", missing)
+        doi = obj["pids"].get("doi", {}).get("identifier", None)
+        if doi:
+            return idutils.normalize_doi(doi)
+        else:
+            return missing
 
     def get_isbn(self, obj):
         """Get ISBN."""


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1976

This PR implements one of the ways that the BASE requirements (either `https://doi.org/` or `doi:` prefix for DOIs) can be satisfied, by turning the record's identifiers (both `record.pids` as well as `record.metadata['identifiers']`) into URLs during the `schema.dump()` process, if applicable.

# Before

## OAI-PMH

```xml
<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
	<responseDate>2023-03-10T17:30:29Z</responseDate>
	<request identifier="oai:my-site.com:arxhb-pcn40" verb="GetRecord" metadataPrefix="oai_dc">https://127.0.0.1:5000/oai2d</request>
	<GetRecord>
		<record>
			<header>
				<identifier>oai:my-site.com:arxhb-pcn40</identifier>
				<datestamp>2023-03-10T16:49:06Z</datestamp>
			</header>
			<metadata>
				<oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
					<dc:creator>Miksa, Tomasz</dc:creator>
					<dc:date>2023-01-01</dc:date>
					<dc:identifier>ark:/53355/cl010066723</dc:identifier>
					<dc:identifier>9780521425575</dc:identifier>
					<dc:identifier>10.1234/12345</dc:identifier>
					<dc:identifier>10.1234/abcdefg</dc:identifier>
					<dc:identifier>10.1234/abcq</dc:identifier>
					<dc:identifier>oai:my-site.com:arxhb-pcn40</dc:identifier>
					<dc:publisher>My Site</dc:publisher>
					<dc:rights>info:eu-repo/semantics/closedAccess</dc:rights>
					<dc:rights>Creative Commons Attribution 4.0 International</dc:rights>
					<dc:rights>
https://creativecommons.org/licenses/by/4.0/legalcode
</dc:rights>
					<dc:title>test record for base</dc:title>
					<dc:type>info:eu-repo/semantics/other</dc:type>
				</oai_dc:dc>
			</metadata>
		</record>
	</GetRecord>
</OAI-PMH>
```

## Landing page

![image](https://user-images.githubusercontent.com/6437519/224383663-aef4dd07-3327-4cfa-95e9-86db469c08f8.png)

## Deposit page

![image](https://user-images.githubusercontent.com/6437519/224384135-7f86f70a-26cb-4bc8-a294-8292eb238a20.png)


# After

## OAI-PMH

```xml
<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
	<responseDate>2023-03-10T16:57:50Z</responseDate>
	<request metadataPrefix="oai_dc" identifier="oai:my-site.com:arxhb-pcn40" verb="GetRecord">https://127.0.0.1:5000/oai2d</request>
	<GetRecord>
		<record>
			<header>
				<identifier>oai:my-site.com:arxhb-pcn40</identifier>
				<datestamp>2023-03-10T16:49:06Z</datestamp>
			</header>
			<metadata>
				<oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
					<dc:creator>Miksa, Tomasz</dc:creator>
					<dc:date>2023-01-01</dc:date>
					<dc:identifier>ark:/53355/cl010066723</dc:identifier>
					<dc:identifier>9780521425575</dc:identifier>
					<dc:identifier>https://doi.org/10.1234/12345</dc:identifier>
					<dc:identifier>https://hdl.handle.net/10.1234/abcdefg</dc:identifier>
					<dc:identifier>https://doi.org/10.1234/abcq</dc:identifier>
					<dc:identifier>oai:my-site.com:arxhb-pcn40</dc:identifier>
					<dc:publisher>My Site</dc:publisher>
					<dc:rights>info:eu-repo/semantics/closedAccess</dc:rights>
					<dc:rights>Creative Commons Attribution 4.0 International</dc:rights>
					<dc:rights>
https://creativecommons.org/licenses/by/4.0/legalcode
</dc:rights>
					<dc:title>test record for base</dc:title>
					<dc:type>info:eu-repo/semantics/other</dc:type>
				</oai_dc:dc>
			</metadata>
		</record>
	</GetRecord>
</OAI-PMH>
```

## Landing page

![image](https://user-images.githubusercontent.com/6437519/224384021-0159e131-79ec-46f4-9a8b-47f6b19d1257.png)

## Deposit page

![image](https://user-images.githubusercontent.com/6437519/224384209-723682fd-94e2-4655-b4f0-0cc34fb02b0e.png)
