### PR TITLE
custom_fields: rename CodeMeta to Software

### DIFF
--- a/invenio_rdm_records/contrib/codemeta/custom_fields.py
+++ b/invenio_rdm_records/contrib/codemeta/custom_fields.py
@@ -47,7 +47,7 @@ CODEMETA_CUSTOM_FIELDS = [
 ]
 
 CODEMETA_CUSTOM_FIELDS_UI = {
-    "section": _("CodeMeta"),
+    "section": _("Software"),
     "fields": [
         dict(
             field="code:codeRepository",


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/1247

Renames the CodeMeta section from "CodeMeta" to "Software"