### PR TITLE
Dublin Core Serializer: only pass on accepted kwargs

### DIFF
--- a/invenio_rdm_records/resources/serializers/dublincore/__init__.py
+++ b/invenio_rdm_records/resources/serializers/dublincore/__init__.py
@@ -34,12 +34,18 @@ class DublinCoreXMLSerializer(MarshmallowSerializer):
     records.
     """
 
-    def __init__(self, **options):
+    def __init__(self, schema_context=None, **options):
         """Constructor."""
+        # note: the superclass init will store the passed `schema_context` for
+        # later use (this controls some behavior of the `DublinCoreSchema` when
+        # dumping) and pass the remaining `options` to the `SimpleSerializer`.
+        # because the latter only accepts an `encoder` argument, we need to
+        # ignore the remaining keyword arguments.
+
         super().__init__(
             format_serializer_cls=SimpleSerializer,
             object_schema_cls=DublinCoreSchema,
             list_schema_cls=BaseListSchema,
+            schema_context=schema_context or {},
             encoder=simpledc.tostring,
-            **options,
         )


### PR DESCRIPTION
Recently, I've tweaked the Dublin Core serializer so that it passes on any given keyword arguments [to its super class constructor](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/resources/serializers/dublincore/__init__.py#L44).
The reason for this is that we wanted to pass custom `schema_context` values (e.g. via config), [which influences the Dublin Core schema's behavior](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/resources/serializers/dublincore/schema.py#L63).
This was a bit too liberal however and would cause issues when the super class constructor ([or the code it would call](https://github.com/inveniosoftware/flask-resources/blob/master/flask_resources/serializers/base.py#L55)) doesn't expect arbitrary keyword arguments.

This was the case e.g. in App-RDM, which just sent off [hard-coded JSON-formatting arguments](https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/records_ui/views/records.py#L220-L225) to any serializer.
Luckily, the Dublin Core XML serializer is effectively fully configured and has a lot of hard-coded values that allow us to deduce which keyword arguments we want to pass on (effectively just `schema_context`), and which we want to ignore (all the rest).

Related PR in App-RDM: https://github.com/inveniosoftware/invenio-app-rdm/pull/2163