### PR TITLE
inclusion: fixes add missing tests

### DIFF
--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -32,9 +32,7 @@ from invenio_records_resources.services.base.config import ConfiguratorMixin, Fr
 from invenio_requests.resources.requests.config import RequestSearchRequestArgsSchema
 
 from ..services.errors import (
-    CommunityInclusionInconsistentAccessRestrictions,
-    MaxNumberCommunitiesExceeded,
-    MaxNumberOfRecordsExceed,
+    InvalidAccessRestrictions,
     ReviewExistsError,
     ReviewNotFoundError,
     ReviewStateError,
@@ -161,7 +159,7 @@ class RDMRecordResourceConfig(RecordResourceConfig, ConfiguratorMixin):
                 description=exc.args[0],
             )
         ),
-        CommunityInclusionInconsistentAccessRestrictions: create_error_handler(
+        InvalidAccessRestrictions: create_error_handler(
             lambda exc: HTTPJSONException(
                 code=400,
                 description=exc.args[0],
@@ -248,22 +246,10 @@ class RDMCommunityRecordsResourceConfig(RecordResourceConfig, ConfiguratorMixin)
     """Community's records resource config."""
 
     blueprint_name = "community-records"
-
     url_prefix = "/communities"
-
-    # Community's records
     routes = {"list": "/<pid_value>/records"}
 
     response_handlers = record_serializers
-
-    error_handlers = {
-        MaxNumberOfRecordsExceed: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=400,
-                description=str(e),
-            )
-        ),
-    }
 
 
 class RDMRecordCommunitiesResourceConfig(CommunityResourceConfig, ConfiguratorMixin):
@@ -273,15 +259,7 @@ class RDMRecordCommunitiesResourceConfig(CommunityResourceConfig, ConfiguratorMi
     url_prefix = "/records"
     routes = {"list": "/<pid_value>/communities"}
 
-    error_handlers = {
-        **community_error_handlers,
-        MaxNumberCommunitiesExceeded: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=400,
-                description=str(e),
-            )
-        ),
-    }
+    error_handlers = community_error_handlers
 
 
 class RDMRecordRequestsResourceConfig(ResourceConfig, ConfiguratorMixin):

--- a/invenio_rdm_records/resources/resources.py
+++ b/invenio_rdm_records/resources/resources.py
@@ -196,20 +196,26 @@ class RDMRecordCommunitiesResource(ErrorHandlersMixin, Resource):
     @request_data
     def add(self):
         """Include record in communities."""
-        response = self.service.add(
+        processed, errors = self.service.add(
             identity=g.identity,
             id_=resource_requestctx.view_args["pid_value"],
             data=resource_requestctx.data,
         )
 
-        return response, 200 if response["success"] else 400
+        response = {}
+        if processed:
+            response["processed"] = processed
+        if errors:
+            response["errors"] = errors
+
+        return response, 200 if len(processed) > 0 else 400
 
     @request_view_args
     @request_data
     @response_handler()
     def remove(self):
         """Remove communities from the record."""
-        errors = self.service.remove(
+        processed, errors = self.service.remove(
             identity=g.identity,
             id_=resource_requestctx.view_args["pid_value"],
             data=resource_requestctx.data,
@@ -219,7 +225,7 @@ class RDMRecordCommunitiesResource(ErrorHandlersMixin, Resource):
         if errors:
             response["errors"] = errors
 
-        return response, 200
+        return response, 200 if len(processed) > 0 else 400
 
 
 class RDMRecordRequestsResource(ErrorHandlersMixin, Resource):

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -260,7 +260,7 @@ class DataCite43Schema(Schema):
         except ParseException:
             # Should not fail since it was validated at service schema
             current_app.logger.error(
-                "Error parsing publication_date field for" f"record {obj['metadata']}"
+                f"Error parsing publication_date field for record {obj['metadata']}"
             )
             raise ValidationError(_("Invalid publication date value."))
 

--- a/invenio_rdm_records/services/communities/components.py
+++ b/invenio_rdm_records/services/communities/components.py
@@ -7,10 +7,7 @@
 
 """Record communities service components."""
 
-from invenio_communities.communities.records.systemfields.access import (
-    CommunityAccess,
-    VisibilityEnum,
-)
+from invenio_communities.communities.records.systemfields.access import VisibilityEnum
 from invenio_communities.communities.services.components import (
     CommunityAccessComponent as BaseAccessComponent,
 )
@@ -21,6 +18,7 @@ from invenio_communities.communities.services.components import (
     OwnershipComponent,
     PIDComponent,
 )
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.components import (
     MetadataComponent,
     RelationsComponent,
@@ -37,18 +35,14 @@ class CommunityAccessComponent(BaseAccessComponent):
     def _check_visibility(self, identity, record):
         """Checks if the visibility change is allowed."""
         if VisibilityEnum(record.access.visibility) == VisibilityEnum.RESTRICTED:
-            assert CommunityAccess.validate_visibility_level(VisibilityEnum.PUBLIC)
-
-            total = current_community_records_service.search(
+            count_public_records = current_community_records_service.search(
                 identity,
                 community_id=record.id,
-                extra_filter=dsl.Q(
-                    "term", **{"access.record": str(VisibilityEnum.PUBLIC)}
-                ),
+                extra_filter=dsl.Q("term", **{"access.record": "public"}),
             ).total
-            if total > 0:
+            if count_public_records > 0:
                 raise InvalidCommunityVisibility(
-                    reason="Cannot restrict a community with public records."
+                    reason=_("Cannot restrict a community with public records.")
                 )
 
     def update(self, identity, data=None, record=None, **kwargs):

--- a/invenio_rdm_records/services/community_records/service.py
+++ b/invenio_rdm_records/services/community_records/service.py
@@ -90,7 +90,7 @@ class CommunityRecordsService(RecordService):
     def _remove(self, community, record, identity):
         """Remove a community from the record."""
         data = dict(communities=[dict(id=str(community.id))])
-        errors = current_record_communities_service.remove(
+        _, errors = current_record_communities_service.remove(
             identity, id_=record.pid.pid_value, data=data
         )
 

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -46,7 +46,6 @@ from invenio_records_resources.services.records.links import (
     RecordLink,
     pagination_links,
 )
-from invenio_requests.services.permissions import PermissionPolicy
 from invenio_requests.services.requests import RequestItem, RequestList
 from invenio_requests.services.requests.config import RequestSearchOptions
 from requests import Request
@@ -64,9 +63,9 @@ from .customizations import FromConfigPIDsProviders, FromConfigRequiredPIDs
 from .permissions import RDMRecordPermissionPolicy
 from .result_items import SecretLinkItem, SecretLinkList
 from .schemas import RDMParentSchema, RDMRecordSchema
-from .schemas.community_records import RecordCommunitiesSchema
+from .schemas.community_records import CommunityRecordsSchema
 from .schemas.parent.access import SecretLink
-from .schemas.record_communities import CommunityRecordsSchema
+from .schemas.record_communities import RecordCommunitiesSchema
 
 
 def is_draft_and_has_review(record, ctx):
@@ -172,6 +171,20 @@ class RDMCommunityRecordsConfig(BaseRecordServiceConfig, ConfiguratorMixin):
     community_cls = Community
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy, import_string=True
+    )
+
+    # Search configuration
+    search = FromConfigSearchOptions(
+        "RDM_SEARCH",
+        "RDM_SORT_OPTIONS",
+        "RDM_FACETS",
+        search_option_cls=RDMSearchOptions,
+    )
+    search_versions = FromConfigSearchOptions(
+        "RDM_SEARCH_VERSIONING",
+        "RDM_SORT_OPTIONS",
+        "RDM_FACETS",
+        search_option_cls=RDMSearchVersionsOptions,
     )
 
     # Service schemas

--- a/invenio_rdm_records/services/errors.py
+++ b/invenio_rdm_records/services/errors.py
@@ -20,7 +20,16 @@ class EmbargoNotLiftedError(RDMRecordsException):
 
     def __init__(self, record_id):
         """Initialise error."""
-        super().__init__(f"Embargo could not be lifted for record: {record_id}")
+        self.record_id = record_id
+
+    @property
+    def description(self):
+        """Exception's description."""
+        return _(
+            "Embargo could not be lifted for record: {record_id}".format(
+                record_id=self.record_id
+            )
+        )
 
 
 class ReviewException(RDMRecordsException):
@@ -30,9 +39,7 @@ class ReviewException(RDMRecordsException):
 class ReviewNotFoundError(ReviewException):
     """Review was not found for record/draft."""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize exception."""
-        super().__init__(_("Review not found."), *args, **kwargs)
+    description = _("Review not found.")
 
 
 class ReviewStateError(ReviewException):
@@ -50,21 +57,17 @@ class CommunitySubmissionException(Exception):
 class CommunityAlreadyExists(CommunitySubmissionException):
     """The record is already in the community."""
 
+    description = _("The record is already included in this community.")
+
 
 class CommunityInclusionException(Exception):
     """Base exception for community inclusion requests."""
 
 
-class CommunityInclusionInconsistentAccessRestrictions(CommunityInclusionException):
-    """Inclusion has inconsistent record vs community access restrictions."""
+class InvalidAccessRestrictions(CommunityInclusionException):
+    """Invalid access restrictions for record and community."""
 
-    def __init__(self, *args, **kwargs):
-        """Initialize exception."""
-        super().__init__(
-            _("A public record cannot be included in a restricted community."),
-            *args,
-            **kwargs,
-        )
+    description = _("A public record cannot be included in a restricted community.")
 
 
 class OpenRequestAlreadyExists(CommunitySubmissionException):
@@ -73,7 +76,11 @@ class OpenRequestAlreadyExists(CommunitySubmissionException):
     def __init__(self, request_id):
         """Initialize exception."""
         self.request_id = request_id
-        super().__init__()
+
+    @property
+    def description(self):
+        """Exception's description."""
+        return _("There is already an open inclusion request for this community.")
 
 
 class ValidationErrorWithMessageAsList(Exception):
@@ -120,30 +127,18 @@ class ValidationErrorWithMessageAsList(Exception):
 class RecordCommunityMissing(Exception):
     """Record does not belong to the community."""
 
-    def __init__(self, record_id, communities_id):
+    def __init__(self, record_id, community_id):
         """Initialise error."""
-        super().__init__(
-            f"The record {record_id} does not belong to any of the listed communities {communities_id}."
-        )
+        self.record_id = record_id
+        self.community_id = community_id
 
-
-class MaxNumberCommunitiesExceeded(Exception):
-    """Maximum number of communities exceed."""
-
-    def __init__(self, allowed_number):
-        """Initialise error."""
-        super().__init__(
-            f"Exceeded maximum amount of communities that can be updated at once: {allowed_number}."
-        )
-
-
-class MaxNumberOfRecordsExceed(Exception):
-    """Maximum number of records exceed."""
-
-    def __init__(self, allowed_number):
-        """Initialise error."""
-        super().__init__(
-            f"Exceeded maximum amount of records that can be updated at once: {allowed_number}."
+    @property
+    def description(self):
+        """Exception description."""
+        return _(
+            "The record {record_id} in not included in the community {community_id}.".format(
+                record_id=self.record_id, community_id=self.community_id
+            )
         )
 
 
@@ -152,4 +147,9 @@ class InvalidCommunityVisibility(Exception):
 
     def __init__(self, reason):
         """Constructor."""
-        super().__init__(f"Cannot modify community visibility. {reason}")
+        self.reason = reason
+
+    @property
+    def description(self):
+        """Exception description."""
+        return _("Cannot modify community visibility: {reason}".format(self.reason))

--- a/invenio_rdm_records/services/schemas/community_records.py
+++ b/invenio_rdm_records/services/schemas/community_records.py
@@ -5,32 +5,48 @@
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
-"""Record communities schema."""
+"""Community records schema."""
 
-from marshmallow import Schema, fields, post_load, validate
-from marshmallow_utils.fields import StrippedHTML
-
-from invenio_rdm_records.services.errors import MaxNumberCommunitiesExceeded
+from invenio_i18n import lazy_gettext as _
+from marshmallow import Schema, ValidationError, fields, validate, validates
 
 
-class CommunitySchema(Schema):
+class RecordSchema(Schema):
     """Schema to define a community id."""
 
-    id = fields.String(required=True)
-    comment = StrippedHTML()
-    require_review = fields.Boolean()
+    id = fields.String()
 
 
-class RecordCommunitiesSchema(Schema):
-    """Record communities schema."""
+class CommunityRecordsSchema(Schema):
+    """Record's communities schema."""
 
-    communities = fields.List(
-        fields.Nested(CommunitySchema), validate=validate.Length(min=1), required=True
+    records = fields.List(
+        fields.Nested(RecordSchema), validate=validate.Length(min=1), required=True
     )
 
-    @post_load
-    def _check_max_size(self, data, **kwargs):
+    @validates("records")
+    def validate_records(self, value):
+        """Validate communities."""
         max_number = self.context["max_number"]
-        if max_number < len(data["communities"]):
-            raise MaxNumberCommunitiesExceeded(max_number)
-        return data
+        if max_number < len(value):
+            raise ValidationError(
+                _(
+                    "Too many records passed, {max_number} max allowed.".format(
+                        max_number=max_number
+                    )
+                )
+            )
+
+        # check unique ids
+        uniques = set()
+        duplicated = set()
+        for record in value:
+            rec_id = record["id"]
+            if rec_id in uniques:
+                duplicated.add(rec_id)
+            uniques.add(rec_id)
+
+        if duplicated:
+            raise ValidationError(
+                _("Duplicated records {rec_ids}.".format(rec_ids=duplicated))
+            )

--- a/invenio_rdm_records/services/tasks.py
+++ b/invenio_rdm_records/services/tasks.py
@@ -24,8 +24,6 @@ def update_expired_embargos():
     for record in records.hits:
         try:
             service.lift_embargo(_id=record["id"], identity=system_identity)
-        except EmbargoNotLiftedError:
-            current_app.logger.warning(
-                f"Embargo from record with id {record['id']} was not lifted"
-            )
+        except EmbargoNotLiftedError as ex:
+            current_app.logger.warning(ex.description)
             continue

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -25,12 +25,6 @@ def create_app(instance_path):
     return create_api
 
 
-@pytest.fixture()
-def rdm_record_service():
-    """Get the current RDM records service."""
-    return current_rdm_records_service
-
-
 def link(url):
     """Strip the host part of a link."""
     api_prefix = "https://127.0.0.1:5000/api"

--- a/tests/resources/test_resources_communities.py
+++ b/tests/resources/test_resources_communities.py
@@ -7,36 +7,593 @@
 
 """Tests record's communities resources."""
 
-from invenio_rdm_records.proxies import current_record_communities_service
+from copy import deepcopy
+
+import pytest
+from invenio_requests.records.api import Request, RequestEvent
+
+from invenio_rdm_records.proxies import (
+    current_rdm_records_service,
+    current_record_communities_service,
+)
+from invenio_rdm_records.records.api import RDMDraft, RDMRecord
+from invenio_rdm_records.requests.community_inclusion import CommunityInclusion
 
 
-def test_remove_community(client, uploader, record_community, headers, community):
-    """Test removal of a community from the record."""
+def _add_to_community(db, record, community):
+    record.parent.communities.add(community._record, default=False)
+    record.parent.commit()
+    record.commit()
+    db.session.commit()
+    current_rdm_records_service.indexer.index(record, arguments={"refresh": True})
+    return record
+
+
+def test_uploader_add_record_to_communities(
+    client,
+    uploader,
+    record_community,
+    headers,
+    community,
+    open_review_community,
+    closed_review_community,
+):
+    """Test uploader addition of record to open review and closed review community."""
     client = uploader.login(client)
 
-    data = {"communities": [{"id": community.id}]}
+    data = {
+        "communities": [
+            {"id": open_review_community.id},  # test with id
+            {"id": closed_review_community["slug"]},  # test with slug
+        ]
+    }
     record = record_community.create_record()
-    response = client.delete(
+    response = client.post(
         f"/records/{record.pid.pid_value}/communities",
         headers=headers,
         json=data,
     )
     assert response.status_code == 200
     assert not response.json.get("errors")
-    record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
-    assert not record_saved.json["parent"]["communities"]
+    processed = response.json["processed"]
+    assert len(processed) == 2
+
+    # assert that no communities have been added yet
+    response = client.get(
+        f"/records/{record.pid.pid_value}",
+        headers=headers,
+        json=data,
+    )
+    record_communities = response.json["parent"]["communities"]["ids"]
+    assert len(record_communities) == 1
+    assert community.id in record_communities
+    assert open_review_community.id not in record_communities
+    assert closed_review_community.id not in record_communities
+
+    # assert that requests are "submitted", but not "accepted"
+    for result in processed:
+        request_id = result["request"]
+        response = client.get(
+            f"/requests/{request_id}",
+            headers=headers,
+            json=data,
+        )
+        assert response.json["status"] == "submitted"
+        assert response.json["type"] == CommunityInclusion.type_id
+        assert response.json["is_open"] is True
+
+    client = uploader.logout(client)
+    # check search results
+    for community_id, expected_n_results in [
+        (community.id, 1),
+        (open_review_community.id, 0),
+        (closed_review_community.id, 0),
+    ]:
+        response = client.get(
+            f"/communities/{community_id}/records",
+            headers=headers,
+            json=data,
+        )
+        assert response.json["hits"]["total"] == expected_n_results
 
 
-def test_permission_denied(
-    client, uploader, test_user, record_community, headers, community
+def test_community_owner_add_record_to_communities(
+    client,
+    headers,
+    curator,
+    inviter,
+    community,
+    open_review_community,
+    closed_review_community,
+    record_community,
+):
+    """Test owner inclusion of record to open review and closed review community."""
+    client = curator.login(client)
+
+    data = {
+        "communities": [
+            {"id": open_review_community.id},
+            {"id": closed_review_community.id},
+        ]
+    }
+    inviter(curator.id, open_review_community.id, "curator")
+    inviter(curator.id, closed_review_community.id, "curator")
+    record = record_community.create_record(uploader=curator)
+
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert not response.json.get("errors")
+    processed = response.json["processed"]
+    assert len(processed) == 2
+
+    response = client.get(
+        f"/records/{record.pid.pid_value}",
+        headers=headers,
+        json=data,
+    )
+    record_communities = response.json["parent"]["communities"]["ids"]
+    # assert that only the curator's community has been added
+    assert len(record_communities) == 2
+    assert community.id in record_communities
+    assert open_review_community.id in record_communities
+    assert closed_review_community.id not in record_communities
+
+    # assert that the request of the curator is "accepted"
+    for result in processed:
+        community_id = result["community"]
+        request_id = result["request"]
+        response = client.get(
+            f"/requests/{request_id}",
+            headers=headers,
+            json=data,
+        )
+        request = response.json
+        assert request["type"] == CommunityInclusion.type_id
+        if community_id == open_review_community.id:
+            assert request["status"] == "accepted"
+            assert request["is_open"] is False
+        elif community_id == closed_review_community.id:
+            assert request["status"] == "submitted"
+            assert request["is_open"] is True
+        else:
+            raise
+
+    client = curator.logout(client)
+    # check search results
+    for community_id, expected_n_results in [
+        (community.id, 1),
+        (open_review_community.id, 1),
+        (closed_review_community.id, 0),
+    ]:
+        response = client.get(
+            f"/communities/{community_id}/records",
+            headers=headers,
+            json=data,
+        )
+        assert response.json["hits"]["total"] == expected_n_results
+
+
+def test_community_owner_add_record_to_communities_forcing_review_with_comment(
+    client,
+    headers,
+    curator,
+    inviter,
+    community,
+    open_review_community,
+    record_community,
+):
+    """Test owner addition of record to open review by forcing a review with a comment."""
+    client = curator.login(client)
+
+    expected_comment = "Could someone review it?"
+    data = {
+        "communities": [
+            {
+                "id": open_review_community.id,
+                "require_review": True,
+                "comment": expected_comment,
+            },
+        ]
+    }
+    inviter(curator.id, open_review_community.id, "curator")
+    record = record_community.create_record(uploader=curator)
+
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert not response.json.get("errors")
+    processed = response.json["processed"]
+    assert len(processed) == 1
+
+    response = client.get(
+        f"/records/{record.pid.pid_value}",
+        headers=headers,
+        json=data,
+    )
+    record_communities = response.json["parent"]["communities"]["ids"]
+    # assert that the community was not added
+    assert len(record_communities) == 1
+    assert community.id in record_communities
+    assert open_review_community.id not in record_communities
+
+    # assert that the request of the curator is in review ("submitted")
+    result = processed[0]
+    community_id = result["community"]
+    request_id = result["request"]
+
+    Request.index.refresh()
+    RequestEvent.index.refresh()
+
+    response = client.get(
+        f"/requests/{request_id}",
+        headers=headers,
+        json=data,
+    )
+    request = response.json
+    assert request["type"] == CommunityInclusion.type_id
+    assert request["status"] == "submitted"
+    assert request["is_open"] is True
+
+    # check comment
+    response = client.get(
+        f"/requests/{request_id}/timeline",
+        headers=headers,
+        json=data,
+    )
+    comments = response.json
+    assert comments["hits"]["total"] == 1
+    comment_content = comments["hits"]["hits"][0]["payload"]["content"]
+    assert comment_content == expected_comment
+
+    client = curator.logout(client)
+    # check search results
+    for community_id, expected_n_results in [
+        (community.id, 1),
+        (open_review_community.id, 0),
+    ]:
+        response = client.get(
+            f"/communities/{community_id}/records",
+            headers=headers,
+            json=data,
+        )
+        assert response.json["hits"]["total"] == expected_n_results
+
+
+def test_restrict_community_before_accepting_inclusion(
+    client,
+    uploader,
+    record_community,
+    headers,
+    community_owner,
+    open_review_community,
+):
+    """Test should not include when community is changed to restricted before accept."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": open_review_community.id},
+        ]
+    }
+    first_version_record = record_community.create_record()
+
+    # create inclusion request
+    response = client.post(
+        f"/records/{first_version_record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert len(response.json["processed"]) == 1
+    request_id = response.json["processed"][0]["request"]
+
+    # change the community to restricted
+    client = uploader.logout(client)
+    client = community_owner.login(client)
+    restricted = deepcopy(open_review_community.data)
+    restricted["access"]["visibility"] = "restricted"
+    response = client.put(
+        f"/communities/{open_review_community.id}",
+        headers=headers,
+        json=restricted,
+    )
+    assert response.status_code == 200
+
+    # accept request should fail
+    response = client.post(
+        f"/requests/{request_id}/actions/accept",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 400
+
+
+def test_create_new_version_after_inclusion_request(
+    client,
+    uploader,
+    record_community,
+    headers,
+    community_owner,
+    open_review_community,
+):
+    """Test that the new record's version should be in the community after inclusion."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": open_review_community.id},
+        ]
+    }
+    first_version_record = record_community.create_record()
+    response = client.post(
+        f"/records/{first_version_record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert len(response.json["processed"]) == 1
+    request_id = response.json["processed"][0]["request"]
+
+    # create a new version of the record
+    response = client.post(
+        f"/records/{first_version_record.pid.pid_value}/versions",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 201
+    second_version_record = response.json
+    second_version_record_id = response.json["id"]
+
+    # update title and publication date of the second version
+    second_version_record["metadata"]["title"] = "second version"
+    second_version_record["metadata"]["publication_date"] = "2023-01-01"
+    response = client.put(
+        f"/records/{second_version_record_id}/draft",
+        headers=headers,
+        json=second_version_record,
+    )
+    assert response.status_code == 200
+
+    # accept the inclusion request of the first version
+    client = uploader.logout(client)
+    client = community_owner.login(client)
+    response = client.post(
+        f"/requests/{request_id}/actions/accept",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 200
+    Request.index.refresh()
+    RDMRecord.index.refresh()
+
+    # check search results, first version should be in
+    client = uploader.logout(client)
+    client = community_owner.logout(client)
+    response = client.get(
+        f"/communities/{open_review_community.id}/records",
+        headers=headers,
+    )
+    assert response.json["hits"]["total"] == 1
+    hit = response.json["hits"]["hits"][0]
+    assert hit["id"] == first_version_record["id"]
+    assert hit["metadata"]["title"] == first_version_record["metadata"]["title"]
+
+    # publish the new version version of the record
+    client = community_owner.logout(client)
+    client = uploader.login(client)
+    response = client.post(
+        f"/records/{second_version_record_id}/draft/actions/publish",
+        headers=headers,
+        json={},
+    )
+    assert response.status_code == 202
+    second_version_record_id = response.json["id"]
+    Request.index.refresh()
+    RDMRecord.index.refresh()
+
+    # check search results, second version should be in
+    client = uploader.logout(client)
+    client = community_owner.logout(client)
+    response = client.get(
+        f"/communities/{open_review_community.id}/records",
+        headers=headers,
+    )
+    assert response.json["hits"]["total"] == 1
+    hit = response.json["hits"]["hits"][0]
+    assert hit["id"] == second_version_record_id
+    assert hit["metadata"]["title"] == second_version_record["metadata"]["title"]
+
+
+def test_include_public_record_in_restricted_community(
+    client,
+    uploader,
+    record_community,
+    headers,
+    restricted_community,
+):
+    """Test include public record in restricted community."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": restricted_community.id},
+        ]
+    }
+    record = record_community.create_record()
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert response.json["errors"]
+    assert (
+        "cannot be included in a restricted community"
+        in response.json["errors"][0]["message"]
+    )
+
+
+def test_include_community_already_in(
+    client,
+    uploader,
+    record_community,
+    headers,
+    community,
+):
+    """Test cannot include to a community already included."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": community.id},
+        ]
+    }
+    record = record_community.create_record()
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert "already included" in response.json["errors"][0]["message"]
+
+
+def test_include_community_already_request_open(
+    client,
+    uploader,
+    record_community,
+    headers,
+    open_review_community,
+):
+    """Test cannot include multiple times."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": open_review_community.id},
+        ]
+    }
+    record = record_community.create_record()
+    # first inclusion: success
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 200
+    assert not response.json.get("errors")
+    processed = response.json["processed"]
+    assert len(processed) == 1
+
+    # second inclusion: error
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert "already an open inclusion request" in response.json["errors"][0]["message"]
+    assert not response.json.get("processed")
+
+
+def test_invalid_record_or_draft(
+    client,
+    headers,
+    uploader,
+    community,
+    minimal_record,
+):
+    """Test invalid record."""
+    client = uploader.login(client)
+
+    data = {
+        "communities": [
+            {"id": community.id},
+        ]
+    }
+
+    response = client.post(
+        "/records/not-existing/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 404
+
+    draft = RDMDraft.create(minimal_record)
+    response = client.post(
+        f"/records/{draft.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 404
+
+
+def test_remove_community(
+    client, uploader, curator, record_community, headers, community
+):
+    """Test removal of a community from the record."""
+    for user in [uploader, curator]:
+        record = record_community.create_record()
+
+        data = {"communities": [{"id": community.id}]}
+        client = user.login(client)
+        response = client.delete(
+            f"/records/{record.pid.pid_value}/communities",
+            headers=headers,
+            json=data,
+        )
+        assert response.status_code == 200
+        assert not response.json.get("errors")
+        record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
+        assert not record_saved.json["parent"]["communities"]
+
+        client = user.logout(client)
+        # check search results
+        response = client.get(
+            f"/communities/{community.id}/records",
+            headers=headers,
+            json=data,
+        )
+        assert response.json["hits"]["total"] == 0
+
+
+def test_remove_missing_permission(
+    client, test_user, record_community, headers, community
 ):
     """Test remove of a community from the record by an unauthorized user."""
     data = {"communities": [{"id": community.id}]}
 
-    test_user_client = test_user.login(client)
+    client = test_user.login(client)
     record = record_community.create_record()
 
-    response = test_user_client.delete(
+    response = client.delete(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json=data,
+    )
+    assert response.status_code == 400
+    assert len(response.json["errors"]) == 1
+    record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
+    assert record_saved.json["parent"]["communities"] == {"ids": [str(community.id)]}
+
+
+def test_remove_existing_non_existing_community(
+    client, uploader, record_community, headers, community
+):
+    """Test remove of an existing and a non-existing community from the record."""
+    data = {"communities": [{"id": "wrong-id"}, {"id": community.id}]}
+
+    client = uploader.login(client)
+    record = record_community.create_record()
+
+    response = client.delete(
         f"/records/{record.pid.pid_value}/communities",
         headers=headers,
         json=data,
@@ -44,28 +601,64 @@ def test_permission_denied(
     assert response.status_code == 200
     assert len(response.json["errors"]) == 1
     record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
-    assert record_saved.json["parent"]["communities"] == {"ids": [str(community.id)]}
+    assert not record_saved.json["parent"]["communities"]
 
 
-def test_error_data(client, uploader, record_community, headers, community):
-    """Test remove of a non-existing community from the record."""
-    data = {"communities": [{"id": "wrong-id"}]}
+@pytest.mark.parametrize(
+    "payload",
+    [[{"id": "wrong-id"}], [{"id": "duplicated-id"}, {"id": "duplicated-id"}], []],
+)
+def test_add_remove_non_existing_community(
+    client, uploader, record_community, headers, community, payload
+):
+    """Test add/remove of a non-existing community from the record."""
+    data = {"communities": payload}
 
-    uploader_client = uploader.login(client)
+    client = uploader.login(client)
     record = record_community.create_record()
+    for operation in [client.post, client.delete]:
+        response = operation(
+            f"/records/{record.pid.pid_value}/communities",
+            headers=headers,
+            json=data,
+        )
+        assert response.status_code == 400
+        record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
+        assert record_saved.json["parent"]["communities"] == {
+            "ids": [str(community.id)]
+        }
 
-    response = uploader_client.delete(
+
+def test_remove_another_community(
+    client,
+    headers,
+    db,
+    curator,
+    community2,
+    record_community,
+):
+    """Test error when removing a community by a curator of another community."""
+    client = curator.login(client)
+    record = record_community.create_record()
+    record = _add_to_community(db, record, community2)
+    # record is part of `community` and `community2`
+    # curator is curator of `community`: it cannot remove it from `community2`
+
+    data = {"communities": [{"id": community2.id}]}
+    response = client.delete(
         f"/records/{record.pid.pid_value}/communities",
         headers=headers,
         json=data,
     )
-    assert response.status_code == 200
-    assert len(response.json["errors"]) == 1
-    record_saved = client.get(f"/records/{record.pid.pid_value}", headers=headers)
-    assert record_saved.json["parent"]["communities"] == {"ids": [str(community.id)]}
+    assert response.status_code == 400
+    errors = response.json["errors"]
+
+    assert len(errors) == 1
+    assert errors[0]["community"] == community2.id
+    assert errors[0]["message"] == "Permission denied."
 
 
-def test_exceeded_max_number_of_communities(
+def test_add_remove_exceeded_max_number_of_communities(
     client, uploader, record_community, headers, community
 ):
     """Test raise exceeded max number of communities."""
@@ -80,15 +673,42 @@ def test_exceeded_max_number_of_communities(
     ):
         lots_of_communities.append(random_community)
     data = {"communities": lots_of_communities}
-    response = client.delete(
+    for operation in [client.post, client.delete]:
+        response = operation(
+            f"/records/{record.pid.pid_value}/communities",
+            headers=headers,
+            json=data,
+        )
+        assert response.status_code == 400
+
+
+def test_search_communities(
+    client,
+    headers,
+    db,
+    community,
+    community2,
+    record_community,
+    minimal_restricted_record,
+):
+    """Test search record's communities."""
+    record = record_community.create_record()
+    record = _add_to_community(db, record, community2)
+
+    response = client.get(
         f"/records/{record.pid.pid_value}/communities",
         headers=headers,
-        json=data,
     )
-    assert response.status_code == 400
+    hits = response.json["hits"]
+    assert hits["total"] == 2
+    communities_ids = [str(community.id), str(community2.id)]
+    expected = [hits["hits"][0]["id"], hits["hits"][1]["id"]]
+    assert sorted(communities_ids) == sorted(expected)
 
-
-# TODO once upload to multiple communities is implemented
-def test_removal_of_multiple_communities():
-    """Remove multiple communities from a record."""
-    pass
+    # test that anonymous cannot search communities in a restricted record
+    record = record_community.create_record(record_dict=minimal_restricted_record)
+    response = client.get(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+    )
+    assert response.status_code == 403

--- a/tests/services/conftest.py
+++ b/tests/services/conftest.py
@@ -18,8 +18,6 @@ from flask_principal import Identity, UserNeed
 from invenio_access.permissions import any_user, authenticated_user
 from invenio_app.factory import create_api
 
-from invenio_rdm_records.proxies import current_rdm_records_service
-
 
 @pytest.fixture(scope="module")
 def create_app(instance_path):
@@ -42,9 +40,3 @@ def authenticated_identity():
     identity.provides.add(UserNeed(1))
     identity.provides.add(authenticated_user)
     return identity
-
-
-@pytest.fixture()
-def rdm_record_service():
-    """Get the current RDM records service."""
-    return current_rdm_records_service

--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -11,8 +11,7 @@
 
 import pytest
 
-from invenio_rdm_records.proxies import current_rdm_records, current_rdm_records_service
-from invenio_rdm_records.records import RDMDraft, RDMRecord
+from invenio_rdm_records.proxies import current_rdm_records
 from invenio_rdm_records.services.errors import EmbargoNotLiftedError
 
 

--- a/tests/services/test_service_communities.py
+++ b/tests/services/test_service_communities.py
@@ -6,471 +6,106 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Test record's communities service."""
-import time
 
 import pytest
-from invenio_records_resources.services.errors import PermissionDeniedError
-from invenio_requests import current_events_service, current_requests_service
-from marshmallow import ValidationError
+from invenio_communities.proxies import current_communities
 
-from invenio_rdm_records.proxies import (
-    current_community_records_service,
-    current_record_communities_service,
-)
-from invenio_rdm_records.requests.community_inclusion import CommunityInclusion
-from invenio_rdm_records.services.errors import MaxNumberCommunitiesExceeded
-
-
-@pytest.fixture()
-def service():
-    """Get the current records communities service."""
-    return current_record_communities_service
-
-
-@pytest.fixture()
-def requests_service():
-    """Get the current RDM requests service."""
-    return current_requests_service
-
-
-@pytest.fixture()
-def events_service():
-    """Get the current RDM events service."""
-    return current_events_service
+from invenio_rdm_records.proxies import current_rdm_records
+from invenio_rdm_records.services.errors import InvalidCommunityVisibility
 
 
 @pytest.fixture()
 def community_records_service():
-    """Get the current community records service."""
-    return current_community_records_service
+    """Get the current records communities service."""
+    return current_rdm_records.community_records_service
 
 
-def add_to_community(db, rdm_record_service, record, community):
-    record.parent.communities.add(community._record, default=False)
-    record.parent.commit()
-    record.commit()
-    db.session.commit()
-    rdm_record_service.indexer.index(record, arguments={"refresh": True})
-    return record
+@pytest.fixture()
+def community_service():
+    """Get the current communities service."""
+    return current_communities.service
 
 
-def test_uploader_add_record_to_communities(
-    uploader,
-    community,
-    open_review_community,
-    closed_review_community,
+def test_make_community_restricted_with_public_record(
+    running_app,
     record_community,
-    service,
-    rdm_record_service,
-    requests_service,
-    anyuser_identity,
-    community_records_service,
-):
-    """Test uploader addition of record to open review and closed review community."""
-    data = {
-        "communities": [
-            {"id": open_review_community.id},
-            {"id": closed_review_community.id},
-        ]
-    }
-    record = record_community.create_record()
-
-    results = service.add(uploader.identity, record.pid.pid_value, data)
-    assert not results["errors"]
-    assert len(results["success"]) == 2
-
-    record_item = rdm_record_service.read(uploader.identity, record.pid.pid_value)
-    record_communities = record_item.data["parent"]["communities"]["ids"]
-    # assert that no communities have been added yet
-    assert len(record_communities) == 1
-    assert community.id in record_communities
-    assert open_review_community.id not in record_communities
-    assert closed_review_community.id not in record_communities
-
-    # assert that requests are "submitted", but not "accepted"
-    for result in results["success"]:
-        request_id = result["request"]
-        request = requests_service.read(uploader.identity, request_id).to_dict()
-        assert request["status"] == "submitted"
-        assert request["type"] == CommunityInclusion.type_id
-        assert request["is_open"] is True
-
-    # check search results
-    for community_id, expected_n_results in [
-        (community.id, 1),
-        (open_review_community.id, 0),
-        (closed_review_community.id, 0),
-    ]:
-        results = community_records_service.search(
-            anyuser_identity,
-            community_id=str(community_id),
-        )
-        assert results.to_dict()["hits"]["total"] == expected_n_results
-
-
-def test_community_owner_add_record_to_communities(
-    curator,
-    inviter,
     community,
-    open_review_community,
-    closed_review_community,
-    record_community,
-    service,
-    rdm_record_service,
-    requests_service,
-    anyuser_identity,
     community_records_service,
+    community_service,
 ):
-    """Test owner addition of record to open review and closed review community."""
-    data = {
-        "communities": [
-            {"id": open_review_community.id},
-            {"id": closed_review_community.id},
-        ]
-    }
-    inviter(curator.id, open_review_community.id, "curator")
-    inviter(curator.id, closed_review_community.id, "curator")
-    record = record_community.create_record(uploader=curator)
+    """Change a community with public records from public to restricted."""
+    identity = running_app.superuser_identity
 
-    results = service.add(curator.identity, record.pid.pid_value, data)
-    assert not results["errors"]
-    assert len(results["success"]) == 2
-
-    record_item = rdm_record_service.read(curator.identity, record.pid.pid_value)
-    record_communities = record_item.data["parent"]["communities"]["ids"]
-    # assert that only the curator's community has been added
-    assert len(record_communities) == 2
-    assert community.id in record_communities
-    assert open_review_community.id in record_communities
-    assert closed_review_community.id not in record_communities
-
-    # assert that the request of the curator is "accepted"
-    for result in results["success"]:
-        community_id = result["community"]
-        request_id = result["request"]
-        request = requests_service.read(curator.identity, request_id).to_dict()
-        assert request["type"] == CommunityInclusion.type_id
-        if community_id == open_review_community.id:
-            assert request["status"] == "accepted"
-            assert request["is_open"] is False
-        elif community_id == closed_review_community.id:
-            assert request["status"] == "submitted"
-            assert request["is_open"] is True
-        else:
-            raise
-
-    # check search results
-    for community_id, expected_n_results in [
-        (community.id, 1),
-        (open_review_community.id, 1),
-        (closed_review_community.id, 0),
-    ]:
-        results = community_records_service.search(
-            anyuser_identity,
-            community_id=str(community_id),
-        )
-        assert results.to_dict()["hits"]["total"] == expected_n_results
-
-
-def test_community_owner_add_record_to_communities_forcing_review_with_comment(
-    curator,
-    inviter,
-    community,
-    open_review_community,
-    record_community,
-    service,
-    rdm_record_service,
-    requests_service,
-    events_service,
-    anyuser_identity,
-    community_records_service,
-):
-    """Test owner addition of record to open review by forcing a review with a comment."""
-    test_comment = "Could someone review it?"
-    data = {
-        "communities": [
-            {
-                "id": open_review_community.id,
-                "require_review": True,
-                "comment": test_comment,
-            },
-        ]
-    }
-    inviter(curator.id, open_review_community.id, "curator")
-    record = record_community.create_record(uploader=curator)
-
-    results = service.add(curator.identity, record.pid.pid_value, data)
-    assert not results["errors"]
-    assert len(results["success"]) == 1
-
-    record_item = rdm_record_service.read(curator.identity, record.pid.pid_value)
-    record_communities = record_item.data["parent"]["communities"]["ids"]
-    # assert that the community was not added
-    assert len(record_communities) == 1
-    assert community.id in record_communities
-    assert open_review_community.id not in record_communities
-
-    # assert that the request of the curator is in review ("submitted")
-    for result in results["success"]:
-        community_id = result["community"]
-        request_id = result["request"]
-        request = requests_service.read(curator.identity, request_id).to_dict()
-        assert request["type"] == CommunityInclusion.type_id
-        if community_id == open_review_community.id:
-            assert request["status"] == "submitted"
-            assert request["is_open"] is True
-        else:
-            raise
-        # TODO FIXME: Small delay to ensure that comment is indexed in ES
-        time.sleep(3)
-        comments = events_service.search(curator.identity, request_id)
-        assert comments.total == 1
-        comment_content = comments.to_dict()["hits"]["hits"][0]["payload"]["content"]
-        assert comment_content == test_comment
-
-    # check search results
-    for community_id, expected_n_results in [
-        (community.id, 1),
-        (open_review_community.id, 0),
-    ]:
-        results = community_records_service.search(
-            anyuser_identity,
-            community_id=str(community_id),
-        )
-        assert results.to_dict()["hits"]["total"] == expected_n_results
-
-
-# TODO add tests
-# test add a record to a community via slug, not only community UUID
-# - test corner cases:
-#   - no communities passed
-#   - too many communities passed
-#   - passed a community non-existing
-#   - passed a community but the record is already in
-#   - passed a community for which a request was already created
-#   - passed an invalid record pid: does not exists or it is a draft (not published yet)
-# - test what happens there is a request opened, and I create a new version of the record and publish. Everythig works?
-#     It should be ok because we work on the parent record. Publish might be blocked because of the `ReviewRequest` class.
-#     The draft parent.communities should be updated as the record parent.communities
-# - test what happens when including a public record in a public community and in a restricted community
-
-
-def test_remove_record_from_community_success(
-    curator,
-    community,
-    record_community,
-    rdm_record_service,
-    service,
-    anyuser_identity,
-    community_records_service,
-):
-    """Test removal of a community from a record."""
-    data = {"communities": [{"id": community.id}]}
-    record = record_community.create_record()
-    errors = service.remove(curator.identity, record.pid.pid_value, data)
-    assert errors == []
-
-    record_item = rdm_record_service.read(curator.identity, record.pid.pid_value)
-    assert not record_item.data["parent"]["communities"]
-
-    # check search results
-    results = community_records_service.search(
-        anyuser_identity,
-        community_id=str(community.id),
+    record_community.create_record()
+    assert (
+        community_records_service.search(
+            identity,
+            community_id=community.id,
+        ).total
+        == 1
     )
-    assert results.to_dict()["hits"]["total"] == 0
+    data = community.to_dict()
+    assert data["access"]["visibility"] == "public"
+    # edit the community visibility
+    data["access"]["visibility"] = "restricted"
+
+    with pytest.raises(InvalidCommunityVisibility):
+        community_service.update(identity, community.id, data)
 
 
-def test_remove_multiple_communities():
-    """Test removal of multiple communities of a record."""
-    # TODO: implement when the `add` method is implemented
-    pass
-
-
-def test_remove_as_owner(uploader, community, record_community, service):
-    """Test that the record's owner can remove the record from a community."""
-    data = {"communities": [{"id": community.id}]}
-    record = record_community.create_record()
-
-    service.remove(uploader.identity, record.pid.pid_value, data)
-
-
-def test_remove_as_community_curator(curator, community, record_community, service):
-    """Test that the community's curator can remove the record from its community."""
-    data = {"communities": [{"id": community.id}]}
-    record = record_community.create_record()
-
-    service.remove(curator.identity, record.pid.pid_value, data)
-
-
-def test_remove_non_existing_community(
-    curator,
+def test_make_community_restricted_with_restricted_record(
+    running_app,
     record_community,
-    rdm_record_service,
-    service,
-    community,
-):
-    """Test removal of a non-existing community returns an error."""
-    data = {"communities": [{"id": "wrong-id"}]}
-    record = record_community.create_record()
-
-    errors = service.remove(curator.identity, record.pid.pid_value, data)
-    assert len(errors) == 1
-
-    record_item = rdm_record_service.read(curator.identity, record.pid.pid_value)
-    assert record_item.data["parent"]["communities"] == {"ids": [str(community.id)]}
-
-
-def test_remove_existing_and_non_existing_community(
-    curator,
-    community,
-    record_community,
-    rdm_record_service,
-    service,
-):
-    """Test removal of existing and non-existing communities."""
-    wrong_data = [{"id": "wrong-id"}, {"id": "wrong-id2"}]
-    correct_data = [{"id": community.id}]
-    data = {"communities": correct_data + wrong_data}
-    record = record_community.create_record()
-
-    errors = service.remove(curator.identity, record.pid.pid_value, data)
-
-    assert len(errors) == 2
-
-    record_item = rdm_record_service.read(curator.identity, record.pid.pid_value)
-    assert not record_item.data["parent"]["communities"]
-
-
-def test_remove_missing_permission(test_user, community, record_community, service):
-    """Test that a random user cannot remove the record from a community."""
-    data = {"communities": [{"id": community.id}]}
-    record = record_community.create_record()
-
-    errors = service.remove(test_user.identity, record.pid.pid_value, data)
-
-    assert len(errors) == 1
-    assert errors[0]["community"] == community.id
-    assert errors[0]["message"] == "Permission denied."
-
-
-def test_remove_another_community(
-    db,
-    curator,
-    community2,
-    record_community,
-    service,
-    rdm_record_service,
-):
-    """Test error when removing a community by a curator of another community."""
-    record = record_community.create_record()
-    record = add_to_community(db, rdm_record_service, record, community2)
-    # record is part of `community` and `community2`
-    # curator is curator of `community`: it cannot remove it from `community2`
-
-    data = {"communities": [{"id": community2.id}]}
-    errors = service.remove(curator.identity, record.pid.pid_value, data)
-
-    assert len(errors) == 1
-    assert errors[0]["community"] == community2.id
-    assert errors[0]["message"] == "Permission denied."
-
-
-def test_remove_too_many_communities(curator, record_community, service):
-    """Test that passing too many communities throws an error."""
-    random_community = {"id": "random-id"}
-    record = record_community.create_record()
-
-    lots_of_communities = []
-    while len(lots_of_communities) <= service.config.max_number_of_removals:
-        lots_of_communities.append(random_community)
-    data = {"communities": lots_of_communities}
-    with pytest.raises(MaxNumberCommunitiesExceeded):
-        service.remove(curator.identity, record.pid.pid_value, data)
-
-
-def test_remove_empty_communities(curator, record_community, service):
-    """Test removal of communities from record with empty payload."""
-    data = {"communities": []}
-    record = record_community.create_record()
-
-    with pytest.raises(ValidationError):
-        service.remove(curator.identity, record.pid.pid_value, data)
-
-
-# def test_restricted_community_with_public_record(
-#     running_app, search_clear, community, record_community, community_service
-# ):
-#     """Change a community with public records from public to restricted."""
-#     identity = running_app.superuser_identity
-#     data = community.to_dict()
-#     assert data["access"]["visibility"] == "public"
-#     data["access"]["visibility"] = "restricted"
-
-#     with pytest.raises(InvalidCommunityVisibility):
-#         community_service.update(identity, community.id, data)
-
-
-# def test_restricted_community_with_restricted_record(
-#     running_app, search_clear, community, restricted_record_community, community_service
-# ):
-#     """Change a community with restricted records from public to restricted."""
-#     identity = running_app.superuser_identity
-#     # edit the community
-#     data = community.to_dict()
-#     assert data["access"]["visibility"] == "public"
-#     data["access"]["visibility"] = "restricted"
-
-#     comm = community_service.update(identity, community.id, data)
-#     assert comm["access"]["visibility"] == "restricted"
-
-
-# def test_public_community_with_restricted_record(
-#     running_app,
-#     search_clear,
-#     restricted_community,
-#     restricted_record_restricted_community,
-#     community_service,
-# ):
-#     """Change a community with restricted records from restricted to public."""
-#     identity = running_app.superuser_identity
-#     # edit the community
-#     data = restricted_community.to_dict()
-#     assert data["access"]["visibility"] == "restricted"
-#     data["access"]["visibility"] = "public"
-
-#     comm = community_service.update(identity, restricted_community.id, data)
-#     assert comm["access"]["visibility"] == "public"
-
-
-def test_search_communities(
-    db,
-    service,
-    rdm_record_service,
-    community,
-    community2,
-    record_community,
-    anyuser_identity,
     minimal_restricted_record,
+    community,
+    community_records_service,
+    community_service,
 ):
-    """."""
-    record = record_community.create_record()
-    record = add_to_community(db, rdm_record_service, record, community2)
+    """Change a community with restricted records from public to restricted."""
+    identity = running_app.superuser_identity
 
-    results = service.search(
-        anyuser_identity,
-        record.pid.pid_value,
+    record_community.create_record(record_dict=minimal_restricted_record)
+    assert (
+        community_records_service.search(
+            identity,
+            community_id=community.id,
+        ).total
+        == 1
     )
-    hits = results.to_dict()["hits"]
-    assert hits["total"] == 2
-    communities_ids = [str(community.id), str(community2.id)]
-    expected = [hits["hits"][0]["id"], hits["hits"][1]["id"]]
-    assert sorted(communities_ids) == sorted(expected)
+    data = community.to_dict()
+    assert data["access"]["visibility"] == "public"
+    # edit the community visibility
+    data["access"]["visibility"] = "restricted"
 
-    # test that anonymous cannot search communities in a restricted record
-    record = record_community.create_record(record_dict=minimal_restricted_record)
-    with pytest.raises(PermissionDeniedError):
-        service.search(
-            anyuser_identity,
-            record.pid.pid_value,
-        )
+    comm = community_service.update(identity, community.id, data)
+    assert comm["access"]["visibility"] == "restricted"
+
+
+def test_make_community_public_with_restricted_record(
+    running_app,
+    record_community,
+    minimal_restricted_record,
+    restricted_community,
+    community_records_service,
+    community_service,
+):
+    """Change a community with restricted records from restricted to public."""
+    identity = running_app.superuser_identity
+
+    record_community.create_record(
+        record_dict=minimal_restricted_record, community=restricted_community
+    )
+    assert (
+        community_records_service.search(
+            identity,
+            community_id=restricted_community.id,
+        ).total
+        == 1
+    )
+    data = restricted_community.to_dict()
+    assert data["access"]["visibility"] == "restricted"
+    # edit the community visibility
+    data["access"]["visibility"] = "public"
+
+    comm = community_service.update(identity, restricted_community.id, data)
+    assert comm["access"]["visibility"] == "public"

--- a/tests/services/test_service_review.py
+++ b/tests/services/test_service_review.py
@@ -23,7 +23,7 @@ from invenio_rdm_records.records.api import RDMDraft
 from invenio_rdm_records.records.systemfields.draft_status import DraftStatus
 from invenio_rdm_records.requests.community_submission import CommunitySubmission
 from invenio_rdm_records.services.errors import (
-    CommunityInclusionInconsistentAccessRestrictions,
+    InvalidAccessRestrictions,
     ReviewExistsError,
     ReviewNotFoundError,
     ReviewStateError,
@@ -376,7 +376,7 @@ def test_submit_public_record_review_to_restricted_community(
 ):
     """Test creation of review after draft was created."""
     # Create draft
-    with pytest.raises(CommunityInclusionInconsistentAccessRestrictions):
+    with pytest.raises(InvalidAccessRestrictions):
         service.review.submit(
             running_app.superuser_identity, public_draft_review_restricted.id
         )


### PR DESCRIPTION
- ensure record and community restriction are valid when accepting the inclusion request
- add missing tests
- remove wrong `f-string` on translations
- closes #1246