### PR TITLE
deposit: fixed thesis field.

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/customFields/Thesis.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/customFields/Thesis.js
@@ -31,7 +31,7 @@ export class Thesis extends Component {
         <Grid padded>
           <Grid.Column width="16">
             <Input
-              fieldPath={`${fieldPath}.university`}
+              fieldPath={fieldPath}
               label={university.label}
               placeholder={university.placeholder}
             />


### PR DESCRIPTION
Thesis data is already loaded under key `custom_fields.thesis:university`, e.g:
```javascript
"initialValues" = {
    "custom_fields": {
        "thesis:university": "MIT"
    }
}
```

Therefore, it's a string and not an object (we were trying to access `custom_fields.thesis:university.university`)