### PR TITLE
don't create admin@inveniosoftware.org user by default

### DIFF
--- a/invenio_rdm_records/fixtures/records.py
+++ b/invenio_rdm_records/fixtures/records.py
@@ -1,25 +1,21 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Northwestern University.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 """Communities fixture module."""
 
-from ..utils import get_or_create_user
+from invenio_access.permissions import system_user_id
+
 from .fixture import FixtureMixin
-from .tasks import create_demo_record
 
 
 class RecordsFixture(FixtureMixin):
     """Records fixture."""
 
-    def __init__(self, search_paths, filename, create_record_func, delay=True):
-        """Initialize the record's fixture."""
-        super().__init__(search_paths, filename, create_record_func, delay)
-        self.admin = get_or_create_user("admin@inveniosoftware.org")
-
     def create(self, entry):
         """Load a single record."""
-        self.create_record(self.admin.id, entry, publish=True)
+        self.create_record(system_user_id, entry, publish=True)


### PR DESCRIPTION
Although that User doesn't have any privileges, its presence is
initially alarming and it does create an account that can be used
by anyone. Given that it's not necessary, we might as well not have it.
