### PR TITLE
fields: export all file-uploader components

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/index.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/index.js
@@ -10,7 +10,7 @@ export { DescriptionsField } from "./DescriptionsField";
 export { LanguagesField } from "./LanguagesField";
 export { CreatibutorsField } from "./CreatibutorsField";
 export { DatesField } from "./DatesField";
-export { FileUploader } from "./FileUploader";
+export * from "./FileUploader";
 export { PIDField, IdentifiersField } from "./Identifiers";
 export { LicenseField } from "./License";
 export { PublicationDateField } from "./PublicationDateField";


### PR DESCRIPTION
Closes https://github.com/zenodo/who-rdm/issues/68

This PR is needed for the deposit form to work in WHO after upgrading. The `FileUploaderArea` component is in use in the WHO deposit, but not exported from `invenio-rdm-records` (along with the other components in the FileUploader folder).