### PR TITLE
deposit form: enable file modifications depending on external DOi

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploader.js
@@ -39,6 +39,7 @@ export const FileUploaderComponent = ({
   importButtonText,
   isFileImportInProgress,
   decimalSizeDisplay,
+  externalDOI,
   ...uiProps
 }) => {
   // We extract the working copy of the draft stored as `values` in formik
@@ -242,6 +243,7 @@ export const FileUploaderComponent = ({
                   filesEnabled={filesEnabled}
                   deleteFile={deleteFile}
                   decimalSizeDisplay={decimalSizeDisplay}
+                  externalDOI={externalDOI}
                 />
               </Grid.Row>
             )}
@@ -261,32 +263,34 @@ export const FileUploaderComponent = ({
                     <p>
                       <Icon name="warning sign" />
                       {i18next.t(
-                        "File addition, removal or modification are not allowed after you have published your upload."
+                        "If your record doesn't have existing DOI - file addition, removal or modification are not allowed after you have published your upload."
                       )}
                     </p>
                   </Message>
                 </Grid.Column>
               </Grid.Row>
             ) : (
-              <Grid.Row className="file-upload-note pt-5">
-                <Grid.Column width={16}>
-                  <Message info>
-                    <NewVersionButton
-                      record={record}
-                      onError={() => {}}
-                      className=""
-                      disabled={!permissions.can_new_version}
-                      style={{ float: "right" }}
-                    />
-                    <p style={{ marginTop: "5px", display: "inline-block" }}>
-                      <Icon name="info circle" size="large" />
-                      {i18next.t(
-                        "You must create a new version to add, modify or delete files."
-                      )}
-                    </p>
-                  </Message>
-                </Grid.Column>
-              </Grid.Row>
+              !externalDOI && (
+                <Grid.Row className="file-upload-note pt-5">
+                  <Grid.Column width={16}>
+                    <Message info>
+                      <NewVersionButton
+                        record={record}
+                        onError={() => {}}
+                        className=""
+                        disabled={!permissions.can_new_version}
+                        style={{ float: "right" }}
+                      />
+                      <p style={{ marginTop: "5px", display: "inline-block" }}>
+                        <Icon name="info circle" size="large" />
+                        {i18next.t(
+                          "You must create a new version to add, modify or delete files."
+                        )}
+                      </p>
+                    </Message>
+                  </Grid.Column>
+                </Grid.Row>
+              )
             )}
           </Overridable>
         </Grid>
@@ -343,6 +347,7 @@ FileUploaderComponent.propTypes = {
   deleteFile: PropTypes.func.isRequired,
   decimalSizeDisplay: PropTypes.bool,
   permissions: PropTypes.object,
+  externalDOI: PropTypes.bool,
 };
 
 FileUploaderComponent.defaultProps = {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
@@ -26,7 +26,7 @@ import {
 } from "semantic-ui-react";
 import { humanReadableBytes } from "react-invenio-forms";
 
-const FileTableHeader = ({ isDraftRecord }) => (
+const FileTableHeader = ({ isDraftRecord, externalDOI }) => (
   <Table.Header>
     <Table.Row>
       <Table.HeaderCell>
@@ -38,16 +38,17 @@ const FileTableHeader = ({ isDraftRecord }) => (
       </Table.HeaderCell>
       <Table.HeaderCell>{i18next.t("Filename")}</Table.HeaderCell>
       <Table.HeaderCell>{i18next.t("Size")}</Table.HeaderCell>
-      {isDraftRecord && (
+      {(isDraftRecord || externalDOI) && (
         <Table.HeaderCell textAlign="center">{i18next.t("Progress")}</Table.HeaderCell>
       )}
-      {isDraftRecord && <Table.HeaderCell />}
+      {(isDraftRecord || externalDOI) && <Table.HeaderCell />}
     </Table.Row>
   </Table.Header>
 );
 
 FileTableHeader.propTypes = {
   isDraftRecord: PropTypes.bool,
+  externalDOI: PropTypes.bool.isRequired,
 };
 
 FileTableHeader.defaultProps = {
@@ -61,6 +62,7 @@ const FileTableRow = ({
   defaultPreview,
   setDefaultPreview,
   decimalSizeDisplay,
+  externalDOI,
 }) => {
   const [isCancelling, setIsCancelling] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -125,7 +127,7 @@ const FileTableRow = ({
       <Table.Cell data-label={i18next.t("Size")} width={2}>
         {file.size ? humanReadableBytes(file.size, decimalSizeDisplay) : ""}
       </Table.Cell>
-      {isDraftRecord && (
+      {(isDraftRecord || externalDOI) && (
         <Table.Cell
           className="file-upload-pending"
           data-label={i18next.t("Progress")}
@@ -145,7 +147,7 @@ const FileTableRow = ({
           {file.uploadState?.isPending && <span>{i18next.t("Pending")}</span>}
         </Table.Cell>
       )}
-      {isDraftRecord && (
+      {(isDraftRecord || externalDOI) && (
         <Table.Cell textAlign="right" width={2}>
           {(file.uploadState?.isFinished || file.uploadState?.isFailed) &&
             (isDeleting ? (
@@ -186,6 +188,7 @@ FileTableRow.propTypes = {
   defaultPreview: PropTypes.string,
   setDefaultPreview: PropTypes.func.isRequired,
   decimalSizeDisplay: PropTypes.bool,
+  externalDOI: PropTypes.bool.isRequired,
 };
 
 FileTableRow.defaultProps = {
@@ -202,8 +205,9 @@ const FileUploadBox = ({
   uploadButtonIcon,
   uploadButtonText,
   openFileDialog,
+  externalDOI,
 }) =>
-  isDraftRecord && (
+  (isDraftRecord || externalDOI) && (
     <Segment
       basic
       padded="very"
@@ -242,6 +246,7 @@ FileUploadBox.propTypes = {
   uploadButtonIcon: PropTypes.node,
   uploadButtonText: PropTypes.string,
   openFileDialog: PropTypes.func,
+  externalDOI: PropTypes.bool.isRequired,
 };
 
 FileUploadBox.defaultProps = {
@@ -257,12 +262,13 @@ const FilesListTable = ({
   filesList,
   deleteFile,
   decimalSizeDisplay,
+  externalDOI,
 }) => {
   const { setFieldValue, values: formikDraft } = useFormikContext();
   const defaultPreview = _get(formikDraft, "files.default_preview", "");
   return (
     <Table>
-      <FileTableHeader isDraftRecord={isDraftRecord} />
+      <FileTableHeader isDraftRecord={isDraftRecord} externalDOI={externalDOI} />
       <Table.Body>
         {filesList.map((file) => {
           return (
@@ -276,6 +282,7 @@ const FilesListTable = ({
                 setFieldValue("files.default_preview", filename)
               }
               decimalSizeDisplay={decimalSizeDisplay}
+              externalDOI={externalDOI}
             />
           );
         })}
@@ -289,6 +296,7 @@ FilesListTable.propTypes = {
   filesList: PropTypes.array,
   deleteFile: PropTypes.func,
   decimalSizeDisplay: PropTypes.bool,
+  externalDOI: PropTypes.bool.isRequired,
 };
 
 FilesListTable.defaultProps = {
@@ -347,6 +355,7 @@ FileUploaderArea.propTypes = {
   uploadButtonIcon: PropTypes.string,
   uploadButtonText: PropTypes.string,
   decimalSizeDisplay: PropTypes.bool,
+  externalDOI: PropTypes.bool.isRequired,
 };
 
 FileUploaderArea.defaultProps = {

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -479,3 +479,11 @@ For example:
         ...
     }]
 """
+
+# Feature flag to enable/disable locking file modifications for record with external DOIs on edit record action.
+RDM_LOCK_FILES_FOR_EXTERNAL_DOI = False
+"""Flag to show whether add/delete files of a record on edit action should be locked."""
+
+# Configuration for locking files for external DOIs.
+RDM_EXTERNAL_DOI_PROVIDER_KEY = "external"
+"""The keyword that represents external DOIs provider."""

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -16,9 +16,10 @@ from itertools import chain
 
 from flask import current_app
 from flask_principal import UserNeed
-from invenio_access.permissions import authenticated_user
 from invenio_communities.generators import CommunityRoleNeed, CommunityRoles
 from invenio_communities.proxies import current_roles
+
+# from invenio_records.dictutils import dict_lookup
 from invenio_records_permissions.generators import Generator
 from invenio_records_resources.services.files.transfer import TransferType
 from invenio_search.engine import dsl
@@ -134,7 +135,7 @@ class IfDraft(ConditionalGenerator):
 
 
 class IfFileIsLocal(ConditionalGenerator):
-    """Conditional generator for file storage class."""
+    """Generator for file storage class."""
 
     def _condition(self, record, file_key=None, **kwargs):
         """Check if the record is a draft."""
@@ -153,6 +154,26 @@ class IfFileIsLocal(ConditionalGenerator):
                     break
 
         return is_file_local
+
+
+# class IfRecordWithExternalDOI(ConditionalGenerator):
+#     """Generator that depends on whether the record has external DOI or not."""
+#
+#     def _condition(self, record, **kwargs):
+#         """Check if the record has external DOI."""
+#         is_feature_enabled = not current_app.config["RDM_LOCK_FILES_FOR_EXTERNAL_DOI"]
+#         if is_feature_enabled:
+#             try:
+#                 is_external_doi = (
+#                     dict_lookup(record, "pids.doi.provider")
+#                     == current_app.config["RDM_EXTERNAL_DOI_PROVIDER_KEY"]
+#                 )
+#             except KeyError:
+#                 is_external_doi = False
+#         else:
+#             return False
+#
+#         return is_external_doi
 
 
 class RecordOwners(Generator):

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -19,7 +19,7 @@ from invenio_records_permissions.generators import (
 )
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
 
-from .generators import (
+from .generators import (  # IfRecordWithExternalDOI,
     IfConfig,
     IfFileIsLocal,
     IfRestricted,
@@ -106,6 +106,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_update_draft = can_review
     # Allow uploading, updating and deleting files in drafts
     can_draft_create_files = can_review
+    # can_draft_modify_files = [IfRecordWithExternalDOI(then_=can_review, else_=[])]
     can_draft_set_content_files = [
         # review is the same as create_files
         IfFileIsLocal(then_=can_review, else_=[SystemProcess()])


### PR DESCRIPTION
* disable "New version" button on extrenal DOI
* enable file upload components on external DOI
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2259


Warning message preview:
<img width="1630" alt="Screenshot 2023-06-21 at 11 01 53" src="https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/5953d0a7-0c03-4fc2-b489-df5b469fd54b">

File upload box for records with external DOI:
<img width="1635" alt="Screenshot 2023-06-21 at 11 02 48" src="https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/4a4bc2d0-6733-4db1-b7ee-5e9482e6b4f3">

For the comparison: file upload box for records with our DOI (not touched):
<img width="1641" alt="Screenshot 2023-06-21 at 11 03 25" src="https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/2fbdd156-4e03-4ae8-a0d6-a82498b0c896">
