### PR TITLE
journal: ui serializer formatting improvements

### DIFF
--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -158,27 +158,30 @@ class MeetingSchema(Schema):
 def compute_publishing_information(obj, dummyctx):
     """Computes 'publishing information' string from custom fields."""
 
-    def _format_journal(journal, publication_date):
+    def _format_journal(journal):
         """Formats a journal object into a string based on its attributes.
 
         Example:
-            _format_journal({"title": "The Effects of Climate Change", "volume": 10, "issue": 2, "pages": "15-22", "issn": "1234-5678"}, "2022")
-            >>> 'The Effects of Climate Change: 10 (2022) no. 1234-5678 pp. 15-22 (2)'
+            _format_journal({"title": "The Effects of Climate Change", "volume": 10, "issue": 2, "pages": "15-22", "issn": "1234-5678"})
+            >>> 'The Effects of Climate Change, 10(2), 15-22, ISSN:1234-5678.'
         """
         journal_title = journal.get("title")
-        if not journal_title:
-            return ""
-
         journal_issn = journal.get("issn")
         journal_issue = journal.get("issue")
+        journal_volume = journal.get("volume")
         journal_pages = journal.get("pages")
-        publication_date = f"({publication_date})" if publication_date else None
-        title = f"{journal_title}:"
-        issn = f"no. {journal_issn}" if journal_issn else None
-        issue = f"({journal_issue})" if journal_issue else None
-        pages = f"pp. {journal_pages}" if journal_pages else None
-        fields = [title, journal.get("volume"), publication_date, issn, pages, issue]
-        formatted = " ".join(filter(None, fields))
+        title = f"{journal_title}" if journal_title else None
+        vol_issue = f"{journal_volume}" if journal_volume else None
+        if journal_issue:
+            if vol_issue:
+                vol_issue += f"({journal_issue})"
+            else:
+                vol_issue = f"{journal_issue}"
+        pages = f"{journal_pages}" if journal_pages else None
+        issn = f"ISSN: {journal_issn}" if journal_issn else None
+        fields = [title, vol_issue, pages, issn]
+        formatted = ", ".join(filter(None, fields))
+        formatted += "."
 
         return formatted if formatted else ""
 
@@ -193,7 +196,6 @@ def compute_publishing_information(obj, dummyctx):
 
     attr = "custom_fields"
     field = obj.get(attr, {})
-    publication_date = obj.get("metadata", {}).get("publication_date")
     publisher = obj.get("metadata", {}).get("publisher")
 
     # Retrieve publishing related custom fields
@@ -203,7 +205,7 @@ def compute_publishing_information(obj, dummyctx):
 
     result = {}
     if journal:
-        journal_string = _format_journal(journal, publication_date)
+        journal_string = _format_journal(journal)
         if journal_string:
             result.update({"journal": journal_string})
 


### PR DESCRIPTION
:heart: Thank you for your contribution!


### Description

This PR includes a number of improvements to how journal metadata is displayed in the UI. I'm kind of touching citation styles here, which is always controversial. My goal is to address inconsistencies between the default citation and "Published In" section, including the following behavior that is odd:

![Screenshot 2023-06-22 at 10 43 36 AM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/725284a3-bd8a-4f73-8449-a1386712c7b3)

- Issue is at the end of the section, not near volume
- ISSN labeled with "no."
- "pp." appears for both page ranges and article numbers
- Section only appears if a journal title is present (there are no required fields for the journal metadata)
- Full publication date in the middle of the block (this isn't present in Zenodo)
![Screenshot 2023-06-22 at 10 35 46 AM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/af4e33d6-0e4c-47c8-ae45-08310919758a)
![Screenshot 2023-06-22 at 10 36 06 AM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/566081f6-b34b-45a8-b655-89456826b07c)

I've tried to use the  default citation style (APA) as much as I could.

Full metadata:
![Screenshot 2023-06-22 at 1 06 51 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/e81e203d-da62-4b8b-b124-c99f6a878261)

Without ISSN:
![Screenshot 2023-06-22 at 1 05 48 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/ab4b1d9a-3c84-4270-a378-e52aacd77aba)

Without Issue:
![Screenshot 2023-06-22 at 1 07 37 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/0a6170c7-9dd3-4799-96fc-c2894ec3cc37)

Without Volume:
![Screenshot 2023-06-22 at 1 48 59 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/2267e902-6ef4-4bc0-9c05-b8444f07ac17)

Without Title:
![Screenshot 2023-06-22 at 2 26 28 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/105eccc2-d52b-4f98-934c-88893b3d2c02)

 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
