### PR TITLE
permissions: fix checks when new record

### DIFF
--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -137,7 +137,7 @@ class IfFileIsLocal(ConditionalGenerator):
     """Conditional generator for file storage class."""
 
     def _condition(self, record, file_key=None, **kwargs):
-        """Check if the record is a draft."""
+        """Check if the file is local."""
         is_file_local = True
         if file_key:
             file_record = record.files.get(file_key)
@@ -153,6 +153,14 @@ class IfFileIsLocal(ConditionalGenerator):
                     break
 
         return is_file_local
+
+
+class IfNewRecord(ConditionalGenerator):
+    """Conditional generator for cases where we have a new record/draft."""
+
+    def _condition(self, record=None, **kwargs):
+        """Check if there is a record."""
+        return record is None
 
 
 class RecordOwners(Generator):

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -10,7 +10,6 @@
 """Permissions for Invenio RDM Records."""
 
 from invenio_communities.generators import CommunityCurators
-from invenio_records import Record
 from invenio_records_permissions.generators import (
     AnyUser,
     AuthenticatedUser,
@@ -22,6 +21,7 @@ from invenio_records_permissions.policies.records import RecordPermissionPolicy
 from .generators import (
     IfConfig,
     IfFileIsLocal,
+    IfNewRecord,
     IfRestricted,
     RecordCommunitiesAction,
     RecordOwners,
@@ -122,11 +122,19 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_draft_delete_files = can_review
     # Allow enabling/disabling files
     can_manage_files = [
-        IfConfig("RDM_ALLOW_METADATA_ONLY_RECORDS", then_=can_review, else_=[]),
+        IfConfig(
+            "RDM_ALLOW_METADATA_ONLY_RECORDS",
+            then_=[IfNewRecord(then_=can_authenticated, else_=can_review)],
+            else_=[],
+        ),
     ]
     # Allow managing record access
     can_manage_record_access = [
-        IfConfig("RDM_ALLOW_RESTRICTED_RECORDS", then_=can_review, else_=[]),
+        IfConfig(
+            "RDM_ALLOW_RESTRICTED_RECORDS",
+            then_=[IfNewRecord(then_=can_authenticated, else_=can_review)],
+            else_=[],
+        )
     ]
 
     #


### PR DESCRIPTION
* closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2262
* Fixes the permission check for cases where there is no record object to make checks against (e.g. when rendering the empty draft form).