### PR TITLE
creatibutors: switch remove and edit button order

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
@@ -79,6 +79,9 @@ export const CreatibutorsFieldItem = ({
         className={hidden ? "deposit-drag-listitem hidden" : "deposit-drag-listitem"}
       >
         <List.Content floated="right">
+          <Button size="mini" type="button" onClick={() => removeCreatibutor(index)}>
+            {i18next.t("Remove")}
+          </Button>
           <CreatibutorsModal
             addLabel={addLabel}
             editLabel={editLabel}
@@ -96,9 +99,6 @@ export const CreatibutorsFieldItem = ({
               </Button>
             }
           />
-          <Button size="mini" type="button" onClick={() => removeCreatibutor(index)}>
-            {i18next.t("Remove")}
-          </Button>
         </List.Content>
         <Ref innerRef={drag}>
           <List.Icon name="bars" className="drag-anchor" />


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The current button order for editing creatributors is confusing, since users moving along the right hand side of the screen can accidentally delete a creatributor when they are editing a record. This PR swaps the order to put the safer (and more visually noticeable) editing option on the right hand side.

Current:
![Screenshot 2023-07-28 at 4 14 19 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/1222988a-3269-4649-b182-35195218b1a1)


This PR:
![Screenshot 2023-07-28 at 4 19 12 PM](https://github.com/inveniosoftware/invenio-rdm-records/assets/10798874/26a81f54-f3d9-42d6-8175-4fcc3e11cd10)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
