### PR TITLE
Alembic: Remove extra revisions branch

### DIFF
--- a/invenio_rdm_records/alembic/ff860d48fb4b_create_media_files_table.py
+++ b/invenio_rdm_records/alembic/ff860d48fb4b_create_media_files_table.py
@@ -1,6 +1,6 @@
 #
 # This file is part of Invenio.
-# Copyright (C) 2016-2018 CERN.
+# Copyright (C) 2023 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -14,7 +14,7 @@ from sqlalchemy_utils import JSONType, UUIDType
 
 # revision identifiers, used by Alembic.
 revision = "ff860d48fb4b"
-down_revision = "9e0ac518b9df"
+down_revision = "cfcb8cb78708"
 branch_labels = ()
 depends_on = None
 


### PR DESCRIPTION
I've noticed that two alembic revisions in rdm-records have the same down_revision, effectively creating an extra branch:
https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/alembic/a6bfa06b1a6d_add_origin_and_description_to_secret_links.py#L15
https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/alembic/ff860d48fb4b_create_media_files_table.py#L17

Given that the latest releases of RDM-Records are only used in the development versions of App-RDM v12 Beta 2, this shouldn't disrupt anybody's production services.