### PR TITLE
systemfields: assign has_files according to enabled files

### DIFF
--- a/invenio_rdm_records/records/systemfields/access/field/record.py
+++ b/invenio_rdm_records/records/systemfields/access/field/record.py
@@ -174,7 +174,9 @@ class RecordAccessField(SystemField):
 
         data = self.get_dictkey(instance)
         if data:
-            obj = self._access_obj_class.from_dict(data, has_files=len(instance.files))
+            obj = self._access_obj_class.from_dict(
+                data, has_files=instance.files.enabled
+            )
         else:
             obj = self._access_obj_class()
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
closes https://github.com/inveniosoftware/invenio-app-rdm/issues/1825, https://github.com/inveniosoftware/invenio-app-rdm/issues/1233, https://github.com/zenodo/rdm-project/issues/195

The `has_files` attribute is used to define the record access status. Aligning this with the [AccessStatusField](https://github.com/inveniosoftware/invenio-rdm-records/blob/0728b74cfd98c92616485b71d259fc224a8a60f9/invenio_rdm_records/resources/serializers/ui/fields.py#L141) to ensure the access status is displayed correctly.

![image](https://github.com/inveniosoftware/invenio-rdm-records/assets/72449192/cd6d62db-d5b5-42c2-b2c8-15b6a948ca6d)

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
