### PR TITLE
tokens: make RAT subject schema configurable

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
@@ -41,7 +41,7 @@ export class DepositApiClient {
       withCredentials: true,
       xsrfCookieName: "csrftoken",
       xsrfHeaderName: "X-CSRFToken",
-      headers: this.apiHeaders.json,
+      headers: this.apiHeaders["vnd+json"],
     };
     this.axiosWithConfig = axios.create(this.apiConfig);
     this.cancelToken = axios.CancelToken;
@@ -117,7 +117,6 @@ export class RDMDepositApiClient extends DepositApiClient {
     const payload = this.recordSerializer.serialize(draft);
     return this._createResponse(() =>
       this.axiosWithConfig.post(this.createDraftURL, payload, {
-        headers: this.apiHeaders["vnd+json"],
         params: { expand: 1 },
       })
     );
@@ -131,7 +130,6 @@ export class RDMDepositApiClient extends DepositApiClient {
   async readDraft(draftLinks) {
     return this._createResponse(() =>
       this.axiosWithConfig.get(draftLinks.self, {
-        headers: this.apiHeaders["vnd+json"],
         params: { expand: 1 },
       })
     );
@@ -146,7 +144,6 @@ export class RDMDepositApiClient extends DepositApiClient {
     const payload = this.recordSerializer.serialize(draft);
     return this._createResponse(() =>
       this.axiosWithConfig.put(draftLinks.self, payload, {
-        headers: this.apiHeaders["vnd+json"],
         params: { expand: 1 },
       })
     );

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 import idutils
 from invenio_i18n import lazy_gettext as _
 
+from . import tokens
 from .resources.serializers import DataCite43JSONSerializer
 from .services import facets
 from .services.config import lock_edit_published_files
@@ -521,6 +522,8 @@ RDM_RESOURCE_ACCESS_TOKENS_WHITELISTED_JWT_ALGORITHMS = ["HS256", "HS384", "HS51
 RDM_RESOURCE_ACCESS_TOKEN_REQUEST_ARG = "resource_access_token"
 """URL argument to provide resource access token."""
 
+RDM_RESOURCE_ACCESS_TOKENS_SUBJECT_SCHEMA = tokens.resource_access.SubjectSchema
+"""Resource access token Marshmallow schema for parsing JWT subject."""
 
 RDM_LOCK_EDIT_PUBLISHED_FILES = lock_edit_published_files
 """Lock editing already published files (enforce record versioning)."""

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -124,7 +124,10 @@ class RDMRecordResourceConfig(RecordResourceConfig, ConfiguratorMixin):
 
     request_search_args = RDMSearchRequestArgsSchema
 
-    response_handlers = record_serializers
+    response_handlers = FromConfig(
+        "RDM_RECORDS_SERIALIZERS",
+        default=record_serializers,
+    )
 
     error_handlers = {
         DeserializerError: create_error_handler(
@@ -343,7 +346,10 @@ class RDMCommunityRecordsResourceConfig(RecordResourceConfig, ConfiguratorMixin)
     url_prefix = "/communities"
     routes = {"list": "/<pid_value>/records"}
 
-    response_handlers = record_serializers
+    response_handlers = FromConfig(
+        "RDM_RECORDS_SERIALIZERS",
+        default=record_serializers,
+    )
 
 
 class RDMRecordCommunitiesResourceConfig(CommunityResourceConfig, ConfiguratorMixin):

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -44,6 +44,7 @@ from .deserializers import ROCrateJSONDeserializer
 from .deserializers.errors import DeserializerError
 from .errors import HTTPJSONException, HTTPJSONValidationWithMessageAsListException
 from .serializers import (
+    BibtexSerializer,
     CSLJSONSerializer,
     DataCite43JSONSerializer,
     DataCite43XMLSerializer,
@@ -81,6 +82,7 @@ record_serializers = {
         StringCitationSerializer(url_args_retriever=csl_url_args_retriever),
         headers={"content-type": "text/plain"},
     ),
+    "application/x-bibtex": ResponseHandler(BibtexSerializer()),
     "application/dcat+xml": ResponseHandler(DCATSerializer()),
 }
 

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -106,7 +106,7 @@ def is_record_and_has_parent_doi(record, ctx):
 def has_doi(record, ctx):
     """Determine if a record has a DOI."""
     pids = record.pids or {}
-    return "doi" in pids
+    return "doi" in pids and pids["doi"].get("identifier") is not None
 
 
 def is_iiif_compatible(file_, ctx):

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -174,7 +174,8 @@ class RDMRecordCommunitiesConfig(ServiceConfig, ConfiguratorMixin):
     """Record communities service config."""
 
     service_id = "record-communities"
-    record_cls = RDMRecord
+
+    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy, import_string=True
     )
@@ -194,7 +195,7 @@ class RDMRecordCommunitiesConfig(ServiceConfig, ConfiguratorMixin):
 class RDMRecordRequestsConfig(ServiceConfig, ConfiguratorMixin):
     """Record community inclusion config."""
 
-    request_record_cls = RDMRecord
+    request_record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
     service_id = "record-requests"
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy, import_string=True
@@ -214,7 +215,7 @@ class RDMCommunityRecordsConfig(BaseRecordServiceConfig, ConfiguratorMixin):
     """Community records service config."""
 
     service_id = "community-records"
-    record_cls = RDMRecord
+    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
     community_cls = Community
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy, import_string=True
@@ -253,8 +254,8 @@ class RDMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     """RDM record draft service config."""
 
     # Record and draft classes
-    record_cls = RDMRecord
-    draft_cls = RDMDraft
+    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
+    draft_cls = FromConfig("RDM_DRAFT_CLS", default=RDMDraft)
 
     # Schemas
     schema = RDMRecordSchema
@@ -486,7 +487,8 @@ class RDMRecordMediaFilesServiceConfig(RDMRecordServiceConfig):
 class RDMFileRecordServiceConfig(FileServiceConfig, ConfiguratorMixin):
     """Configuration for record files."""
 
-    record_cls = RDMRecord
+    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
+
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy
     )
@@ -545,7 +547,8 @@ class RDMFileDraftServiceConfig(FileServiceConfig, ConfiguratorMixin):
 
     service_id = "draft-files"
 
-    record_cls = RDMDraft
+    record_cls = FromConfig("RDM_DRAFT_CLS", default=RDMDraft)
+
     permission_action_prefix = "draft_"
     permission_policy_cls = FromConfig(
         "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy

--- a/invenio_rdm_records/services/schemas/files.py
+++ b/invenio_rdm_records/services/schemas/files.py
@@ -19,12 +19,16 @@ from marshmallow_utils.permissions import FieldPermissionsMixin
 class FileSchema(Schema):
     """File schema."""
 
-    checksum = fields.String()
+    # File fields
+    id = fields.String(attribute="file.id")
+    checksum = fields.String(attribute="file.checksum")
     ext = fields.String(attribute="file.ext")
+    size = fields.Integer(attribute="file.size")
+    mimetype = fields.String(attribute="file.mimetype")
+
+    # FileRecord fields
     key = SanitizedUnicode()
     metadata = fields.Dict()
-    mimetype = fields.String(attribute="file.mimetype")
-    size = fields.Integer(attribute="file.size")
 
 
 class FilesSchema(Schema, FieldPermissionsMixin):

--- a/invenio_rdm_records/services/schemas/parent/access.py
+++ b/invenio_rdm_records/services/schemas/parent/access.py
@@ -80,9 +80,8 @@ class ParentAccessSchema(Schema, FieldPermissionsMixin):
 
     field_dump_permissions = {
         # omit fields from dumps except for users with 'manage' permissions
-        # allow only 'settings'
+        # allow only 'settings' and 'owned_by'
         "grants": "manage",
-        "owned_by": "manage",
         "links": "manage",
     }
 

--- a/invenio_rdm_records/tokens/resource_access.py
+++ b/invenio_rdm_records/tokens/resource_access.py
@@ -12,6 +12,7 @@ from datetime import datetime, timedelta
 import jwt
 from flask import current_app
 from invenio_oauth2server.models import Token
+from marshmallow import Schema, fields
 
 from .errors import (
     ExpiredTokenError,
@@ -20,6 +21,14 @@ from .errors import (
     MissingTokenIDError,
 )
 from .scopes import tokens_generate_scope
+
+
+class SubjectSchema(Schema):
+    """Resource access token JWT subject schema."""
+
+    pid_value = fields.Str(data_key="record_id", required=True)
+    file_key = fields.Str(data_key="file", missing=None)
+    permission = fields.Str(data_key="access", missing=None)
 
 
 def validate_rat(token):


### PR DESCRIPTION
- services: make record/draft API classes configurable
- schema: expose checksum and file ID
- resources: make record serializers configurable
- resources: add "x-bibtex" record serialization
- access: serialize "owned_by" field
- deposit-ui: use "vnd.inveniordm.v1+json" always
- services: handle no-value DOI for links
- tokens: make RAT subject schema configurable
