### PR TITLE
deposit modals: fix modal headlines and list options styling for crea…

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
@@ -251,9 +251,7 @@ export class CreatibutorsModal extends Component {
         key: creatibutor.id,
         content: (
           <Header>
-            <Header.Content>
-              {creatibutor.name} {idString.length ? <>({idString})</> : null}
-            </Header.Content>
+            {creatibutor.name} {idString.length ? <>({idString})</> : null}
             <Header.Subheader>{affNames}</Header.Subheader>
           </Header>
         ),
@@ -392,14 +390,8 @@ export class CreatibutorsModal extends Component {
               closeIcon
               closeOnDimmerClick={false}
             >
-              <Modal.Header as="h6" className="pt-10 pb-10">
-                <Grid>
-                  <Grid.Column floated="left" width={4}>
-                    <Header as="h2">
-                      <ActionLabel />
-                    </Header>
-                  </Grid.Column>
-                </Grid>
+              <Modal.Header as="h2" className="pt-10 pb-10">
+                <ActionLabel />
               </Modal.Header>
               <Modal.Content>
                 <Form>

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/License/LicenseModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/License/LicenseModal.js
@@ -111,20 +111,14 @@ export class LicenseModal extends Component {
             closeIcon
             closeOnDimmerClick={false}
           >
-            <Modal.Header as="h6" className="pt-10 pb-10">
-              <Grid>
-                <Grid.Column floated="left">
-                  <Header as="h2">
-                    {action === ModalActions.ADD
-                      ? i18next.t(`Add {{mode}} license`, {
-                          mode: mode,
-                        })
-                      : i18next.t(`Change {{mode}} license`, {
-                          mode: mode,
-                        })}
-                  </Header>
-                </Grid.Column>
-              </Grid>
+            <Modal.Header as="h2" className="pt-10 pb-10">
+              {action === ModalActions.ADD
+                ? i18next.t(`Add {{mode}} license`, {
+                    mode: mode,
+                  })
+                : i18next.t(`Change {{mode}} license`, {
+                    mode: mode,
+                  })}
             </Modal.Header>
             <Modal.Content scrolling>
               {mode === ModalTypes.STANDARD && (


### PR DESCRIPTION
Closes https://github.com/zenodo/rdm-project/issues/238

Fixes
- wrong semantic html (and styling) for modal headers
- wrong styling for creatibutor suggestion list options

<img width="912" alt="Screenshot 2023-09-13 at 16 13 36" src="https://github.com/inveniosoftware/invenio-rdm-records/assets/21052053/281c6303-39f4-43e2-a469-f01bfef5d7e0">
