### PR TITLE
serializers: use cached communities slugs

### DIFF
--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -9,12 +9,15 @@
 
 """DataCite based Schema for Invenio RDM Records."""
 
+import time
+
 from edtf import parse_edtf
 from edtf.parser.grammar import ParseException
-from flask import current_app, g
+from flask import current_app
 from flask_resources.serializers import BaseSerializerSchema
 from invenio_access.permissions import system_identity
 from invenio_communities import current_communities
+from invenio_communities.communities.services.service import get_cached_community_slug
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.proxies import current_service_registry
 from invenio_vocabularies.proxies import current_service as vocabulary_service
@@ -432,11 +435,13 @@ class DataCite43Schema(BaseSerializerSchema):
 
         # adding communities
         communities = obj.get("parent", {}).get("communities", {}).get("ids", [])
+        service_id = current_communities.service.id
+        one_hour_cache = round(time.time() / 60 * 60)
         for community_id in communities:
-            community = current_communities.service.read(
-                id_=community_id, identity=g.identity
+            slug = get_cached_community_slug(
+                community_id, service_id, ttl_hash=lambda x: one_hour_cache
             )
-            url = f"{current_app.config['SITE_UI_URL']}/communities/{community.data['slug']}"
+            url = f"{current_app.config['SITE_UI_URL']}/communities/{slug}"
             serialized_identifiers.append(
                 {
                     "relatedIdentifier": url,

--- a/invenio_rdm_records/resources/serializers/dublincore/schema.py
+++ b/invenio_rdm_records/resources/serializers/dublincore/schema.py
@@ -7,12 +7,15 @@
 
 """Dublin Core based Schema for Invenio RDM Records."""
 
+import time
+
 import bleach
 import idutils
-from flask import current_app, g
+from flask import current_app
 from flask_resources.serializers import BaseSerializerSchema
 from invenio_access.permissions import system_identity
 from invenio_communities import current_communities
+from invenio_communities.communities.services.service import get_cached_community_slug
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from marshmallow import fields, missing
 
@@ -103,11 +106,13 @@ class DublinCoreSchema(BaseSerializerSchema, CommonFieldsMixin):
 
         # Communities
         communities = obj["parent"].get("communities", {}).get("ids", [])
+        service_id = current_communities.service.id
+        one_hour_cache = round(time.time() / 60 * 60)
         for community_id in communities:
-            community = current_communities.service.read(
-                id_=community_id, identity=g.identity
+            slug = get_cached_community_slug(
+                community_id, service_id, ttl_hash=lambda x: one_hour_cache
             )
-            url = f"{current_app.config['SITE_UI_URL']}/communities/{community.data['slug']}"
+            url = f"{current_app.config['SITE_UI_URL']}/communities/{slug}"
             rels.append(self._transform_identifier(url, "url"))
 
         # Parent doi

--- a/invenio_rdm_records/resources/serializers/marcxml/schema.py
+++ b/invenio_rdm_records/resources/serializers/marcxml/schema.py
@@ -7,12 +7,15 @@
 
 """MARCXML based Schema for Invenio RDM Records."""
 
+import time
+
 import bleach
 from dateutil.parser import parse
 from flask import current_app, g
 from flask_resources.serializers import BaseSerializerSchema
 from invenio_access.permissions import system_identity
 from invenio_communities import current_communities
+from invenio_communities.communities.services.service import get_cached_community_slug
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from marshmallow import fields, missing
 
@@ -42,7 +45,7 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
     # sources = fields.Constant(missing)  # Corresponds to references in the metadata schema
     formats = fields.Method("get_formats", data_key="520 1")
     parent_id = fields.Method("get_parent_id", data_key="024 1")
-    community_ids = fields.Method("get_community_ids", data_key="980  ")
+    community_ids = fields.Method("get_communities", data_key="980  ")
     sizes = fields.Method("get_sizes", data_key="520 2")
     version = fields.Method("get_version", data_key="024 3")
     funding = fields.Method(
@@ -127,24 +130,24 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
         sizes = [{"a": s} for s in sizes_list]
         return sizes
 
-    def get_community_ids(self, obj):
-        """Get community ids."""
-        communities = obj["parent"].get("communities", {}).get("ids", [])
-
-        if not communities:
-            return missing
-
-        result = []
-        for community_id in communities:
-            community = current_communities.service.read(
-                id_=community_id, identity=g.identity
+    def _get_communities_slugs(self, ids):
+        """Get communities slugs."""
+        service_id = current_communities.service.id
+        one_hour_cache = round(time.time() / 60 * 60)
+        return [
+            get_cached_community_slug(
+                community_id, service_id, ttl_hash=lambda x: one_hour_cache
             )
-            slug = community.data["slug"]
-            # Communities are prefixed with ``user-``
-            comm = {"a": f"user-{slug}"}
-            result.append(comm)
+            for community_id in ids
+        ]
 
-        return result
+    def get_communities(self, obj):
+        """Get communities."""
+        ids = obj["parent"].get("communities", {}).get("ids", [])
+        if not ids:
+            return missing
+        # Communities are prefixed with ``user-``
+        return [{"a": f"user-{slug}"} for slug in self._get_communities_slugs(ids)]
 
     def get_parent_id(self, obj):
         """Get parent id."""
@@ -194,18 +197,11 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
             result.update({"o": identifier})
 
             # Communities
-            communities = obj["parent"].get("communities", {}).get("ids", [])
-            for community_id in communities:
-                # Resolve community to fetch its slug
-                community = current_communities.service.read(
-                    id_=community_id, identity=g.identity
-                )
-                slug = community.data["slug"]
-
-                comm = f"user-{slug}"
-
-                # Add "p": [comm] or extend if there's already other communities
-                result.setdefault("p", []).append(comm)
+            ids = obj["parent"].get("communities", {}).get("ids", [])
+            for slug in self._get_communities_slugs(ids):
+                user_slug = f"user-{slug}"
+                # Add "p": [user_slug] or extend if there are already other communities
+                result.setdefault("p", []).append(user_slug)
 
         return result or missing
 


### PR DESCRIPTION
* use the cached slug when fetching the community slug in the serializers

Requires: https://github.com/inveniosoftware/invenio-communities/pull/1036