### PR TITLE
assets: remove redundant recover on file upload fail

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.js
@@ -133,7 +133,6 @@ export class RDMDepositFilesService extends DepositFilesService {
     // the next upload in the queue
     this.uploaderQueue.markCompleted(file);
     this._startNextUpload();
-
     const response = await this.fileApiClient.finalizeFileUpload(commitFileURL);
     return response.data;
   };
@@ -169,7 +168,7 @@ export class RDMDepositFilesService extends DepositFilesService {
         fileData.links
       );
     } catch (error) {
-      await this.delete(initializedFileMetadata.links);
+      console.error(error);
       const isCancelled = this.fileApiClient.isCancelled(error);
       this._onError(file, isCancelled);
     }

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.test.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.test.js
@@ -170,9 +170,6 @@ describe("DepositFilesService tests", () => {
       expect(fakeOnUploadFailed).toHaveBeenCalledTimes(1);
       let filename = fakeOnUploadFailed.mock.calls[0][0];
       expect(filename).toEqual(expectedFilename);
-      expect(fakeApiDeleteFile).toHaveBeenCalledTimes(1);
-      let fileLinks = fakeApiDeleteFile.mock.calls[0][0];
-      expect(fileLinks).toEqual(fakeFileData.links);
       expect(fakeOnUploadStarted).not.toHaveBeenCalled();
       expect(fakeOnUploadProgress).not.toHaveBeenCalled();
       expect(fakeOnUploadCompleted).not.toHaveBeenCalled();
@@ -194,7 +191,6 @@ describe("DepositFilesService tests", () => {
       expect(fakeOnUploadFailed).toHaveBeenCalledTimes(1);
       let filename = fakeOnUploadFailed.mock.calls[0][0];
       expect(filename).toEqual(expectedFilename);
-      expect(fakeApiDeleteFile).toHaveBeenCalledTimes(1);
       expect(fakeOnUploadCompleted).not.toHaveBeenCalled();
       expect(fakeOnUploadCancelled).not.toHaveBeenCalled();
     });
@@ -210,9 +206,6 @@ describe("DepositFilesService tests", () => {
       expect(fakeOnUploadCancelled).toHaveBeenCalledTimes(1);
       let filename = fakeOnUploadCancelled.mock.calls[0][0];
       expect(filename).toEqual(expectedFilename);
-      expect(fakeApiDeleteFile).toHaveBeenCalledTimes(1);
-      let fileLinks = fakeApiDeleteFile.mock.calls[0][0];
-      expect(fileLinks).toEqual(fakeFileData.links);
       expect(fakeOnUploadStarted).not.toHaveBeenCalled();
       expect(fakeOnUploadProgress).not.toHaveBeenCalled();
       expect(fakeOnUploadCompleted).not.toHaveBeenCalled();

--- a/invenio_rdm_records/resources/serializers/marcxml/schema.py
+++ b/invenio_rdm_records/resources/serializers/marcxml/schema.py
@@ -135,9 +135,7 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
         service_id = current_communities.service.id
         one_hour_cache = round(time.time() / 3600)
         return [
-            get_cached_community_slug(
-                community_id, service_id, ttl_hash=one_hour_cache
-            )
+            get_cached_community_slug(community_id, service_id, ttl_hash=one_hour_cache)
             for community_id in ids
         ]
 

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -96,7 +96,6 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     #
     # Allow searching of records
     can_search = can_all
-    can_search_all = [UserManager, SystemProcess()]
 
     # Allow reading metadata of a record
     can_read = [


### PR DESCRIPTION
* chore: remove leftover permissions
* closes https://github.com/zenodo/rdm-project/issues/253

# Attention: 
this and dependent PRs need to be reviewed and tested **very** thoroughly