### PR TITLE
stats: reindex in bunches of 10k entries at a time

### DIFF
--- a/invenio_rdm_records/services/tasks.py
+++ b/invenio_rdm_records/services/tasks.py
@@ -72,11 +72,15 @@ def reindex_stats(stats_indices):
         all_parents.add(parent_id)
 
     if all_parents:
-        records_q = dsl.Q("terms", parent__id=list(all_parents))
-        current_rdm_records.records_service.reindex(
-            params={"allversions": True},
-            identity=system_identity,
-            search_query=records_q,
-        )
+        all_parents_list = list(all_parents)
+        step = 10000
+        end = len(list(all_parents))
+        for i in range(0, end, step):
+            records_q = dsl.Q("terms", parent__id=all_parents_list[i : i + step])
+            current_rdm_records.records_service.reindex(
+                params={"allversions": True},
+                identity=system_identity,
+                search_query=records_q,
+            )
     bm.set_bookmark(reindex_start_time)
     return "%d documents reindexed" % len(all_parents)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
See errors like [1]. Long story short, if there are too many records to reindex at the same time (more than 65k), the service complains. This patch ensures that the reindex is done in bulks of 10k.


[1] https://flower-zenodo-rdm.app.cern.ch/task/84739159-fb66-41a9-9741-c03918685c34