### PR TITLE
serializers: fix bibtex for github record-releases

### DIFF
--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -83,8 +83,7 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
         """Get creator."""
         creator = obj["metadata"]["creators"][0]["person_or_org"]
         return {
-            "given_name": creator["given_name"],
-            "family_name": creator["family_name"],
+            "name": creator["name"],
         }
 
     def get_booktitle(self, obj):
@@ -277,7 +276,7 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
         if creator is None:
             return id
 
-        name = creator.get("family_name", creator.get("given_name"))
+        name = creator.get("name")
         pubdate = data.get("date_created", {}).get("year", None)
         year = id
         if pubdate is not None:

--- a/tests/resources/serializers/test_bibtex_serializer.py
+++ b/tests/resources/serializers/test_bibtex_serializer.py
@@ -22,7 +22,11 @@ def updated_minimal_record(minimal_record):
     for creator in minimal_record["metadata"]["creators"]:
         name = creator["person_or_org"].get("name")
         if not name:
-            creator["person_or_org"]["name"] = "Name"
+            creator["person_or_org"]["name"] = (
+                creator["person_or_org"].get("family_name")
+                + ", "
+                + creator["person_or_org"].get("given_name")
+            )
 
     return minimal_record
 
@@ -45,8 +49,8 @@ def test_bibtex_serializer_minimal_record(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@misc{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@misc{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  month        = mar,",
@@ -66,7 +70,7 @@ def test_bibtex_serializer_full_record(running_app, updated_full_record):
 
     expected_data = "\n".join(
         [
-            "@misc{nielsen_2023_abcde-fghij,",
+            "@misc{nielsen_lars_holm_2023_abcde-fghij,",
             "  author       = {Nielsen, Lars Holm},",
             "  title        = {InvenioRDM},",
             "  month        = mar,",
@@ -128,8 +132,8 @@ def test_misc_types(running_app, updated_minimal_record, resource_type):
 
     expected_data = "\n".join(
         [
-            "@misc{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@misc{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  month        = mar,",
@@ -163,8 +167,8 @@ def test_serialize_publication_conferencepaper(running_app, updated_minimal_reco
 
     expected_data = "\n".join(
         [
-            "@inproceedings{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@inproceedings{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  booktitle    = {book title},",
@@ -183,8 +187,8 @@ def test_serialize_publication_conferencepaper(running_app, updated_minimal_reco
 
     expected_data = "\n".join(
         [
-            "@proceedings{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@proceedings{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  year         = 2023,",
@@ -210,8 +214,8 @@ def test_serialize_publication_book(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@book{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@book{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  publisher    = {Acme Inc},",
@@ -229,9 +233,9 @@ def test_serialize_publication_book(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@booklet{brown_2023_abcde-fghij,",
+            "@booklet{brown_troy_2023_abcde-fghij,",
             "  title        = {A Romans story},",
-            "  author       = {Name and",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  month        = mar,",
             "  year         = 2023,",
@@ -257,8 +261,8 @@ def test_serialize_publication_article(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@article{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@article{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  journal      = {journal title},",
@@ -291,8 +295,8 @@ def test_serialize_publication_preprint(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@unpublished{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@unpublished{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  note         = {a description},",
@@ -321,8 +325,8 @@ def test_serialize_publication_thesis(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@phdthesis{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@phdthesis{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  school       = {A university},",
@@ -349,9 +353,9 @@ def test_serialize_publication_technicalnote(running_app, updated_minimal_record
 
     expected_data = "\n".join(
         [
-            "@manual{brown_2023_abcde-fghij,",
+            "@manual{brown_troy_2023_abcde-fghij,",
             "  title        = {A Romans story},",
-            "  author       = {Name and",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  month        = mar,",
             "  year         = 2023,",
@@ -384,8 +388,8 @@ def test_serialize_publication_workingpaper(running_app, updated_minimal_record)
 
     expected_data = "\n".join(
         [
-            "@unpublished{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@unpublished{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  note         = {a description},",
@@ -410,8 +414,8 @@ def test_serialize_software(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@software{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@software{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  month        = mar,",
@@ -436,8 +440,8 @@ def test_serialize_dataset(running_app, updated_minimal_record):
 
     expected_data = "\n".join(
         [
-            "@dataset{brown_2023_abcde-fghij,",
-            "  author       = {Name and",
+            "@dataset{brown_troy_2023_abcde-fghij,",
+            "  author       = {Brown, Troy and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
             "  month        = mar,",


### PR DESCRIPTION
Records created by GitHub release don't have `creator.given_name` field. `creator.name` is a computed field (`family_name` + `given_name`)
* closes https://github.com/zenodo/rdm-project/issues/403
