### PR TITLE
deposit: fixed creatibutors affiliations select for duplicated entries.

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
@@ -19,10 +19,9 @@ export class AffiliationsField extends Component {
       text: affiliation.acronym
         ? `${affiliation.name} (${affiliation.acronym})`
         : affiliation.name,
-      value: affiliation.name,
-      key: affiliation.name,
-      ...(affiliation.id ? { id: affiliation.id } : {}),
-      name: affiliation.name,
+      value: affiliation.id,
+      key: affiliation.id,
+      id: affiliation.id,
     }));
 
   render() {
@@ -58,8 +57,10 @@ export class AffiliationsField extends Component {
                   selectedSuggestions
                 );
               }}
-              value={getIn(values, fieldPath, []).map((val) => val.name)}
+              value={getIn(values, fieldPath, []).map((val) => val.id)}
               ref={selectRef}
+              // Disable UI-side filtering of search results
+              search={(options) => options}
             />
           );
         }}


### PR DESCRIPTION
closes https://github.com/zenodo/rdm-project/issues/456

**NOTE** : this only closes the issue partially. The UI still has many inconsistencies that deteriorate the user experience. However, this fix at least allows the user to see both affiliations listed in the UI.

There other issues like rendering the affiliations accordion, which aggregates affiliations by name instead of ID