### PR TITLE
schemaorg: added fields to schema to improve fair score.

### DIFF
--- a/tests/resources/serializers/test_schemaorg_serializer.py
+++ b/tests/resources/serializers/test_schemaorg_serializer.py
@@ -109,6 +109,7 @@ def test_schemaorg_serializer_full_record(running_app, full_record):
         "name": "InvenioRDM",
         "publisher": {"@type": "Organization", "name": "InvenioRDM"},
         "version": "v1.0",
+        "temporal": ["1939/1945"],
         # "spatialCoverage": [
         #     {
         #         "geoLocationPoint": {


### PR DESCRIPTION
closes https://github.com/zenodo/rdm-project/issues/507

Notes:

1 - there are fields specific to some work types (e.g. `Dataset`) that we haven't implemented yet. We had them in [legacy](https://github.com/zenodo/zenodo/blob/2dbd8ca0ddf9f9ee8b73a7d8e91e6157ce187fab/zenodo/modules/records/serializers/schemas/schemaorg.py#L279) (example for Dataset). 
2 - I did not implement `access_details` as the user requested in the ticket. I could not find the definition except [this](https://f-uji.net/vocab/metadata/property/access_level). I was trying to look at their [source code](https://github.com/pangaea-data-publisher/fuji/tree/master) to see how they parse it. On this one, I also found these [docs](https://www.fairsfair.eu/fairsfair-data-object-assessment-metrics-request-comments) 