### PR TITLE
email templates: fix access request submit templates

### DIFF
--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submit.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submit.jinja
@@ -15,16 +15,19 @@
 %}
 
 {%- block subject -%}
-    {{ _("❗️Access request for '{record_title}' requires action").format(record_title=record_title) }}
+    {{ _("📥 New access request for your record '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}
     <table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
         <tr>
-            <td>{{ _("Please verify the email address in order to submit the access request")}}</td>
+            <td>{{ _("An access request was submitted for your record '{record_title}'.").format(record_title=record_title) }}</td>
         </tr>
         <tr>
-            <td><a href="{{ request_link }}" class="button">{{ _("Verify email")}}</a></td>
+            <td>{{ _("The requestor's e-mail address: {email}").format(email=creator_email) }}</td>
+        </tr>
+        <tr>
+            <td><a href="{{ request_link }}" class="button">{{ _("See request details")}}</a></td>
         </tr>
         <tr>
             <td><strong>_</strong></td>
@@ -36,18 +39,18 @@
 {%- endblock html_body -%}
 
 {%- block plain_body -%}
-{{ _("Please verify the email address in order to submit the access request")}}
+{{ _("An access request was submitted for your record.") }}
 
-[{{ _("Verify email") }}]({{ request_link }}) 
+[{{ _("See request details") }}]({{ request_link }})
 
 {{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
 {%- endblock plain_body -%}
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("Please verify the email address in order to submit the access request")}}
+{{ _("An access request was submitted for your record.") }}
 
-[{{ _("Verify email") }}]({{ request_link }})  
+[{{ _("See request details") }}]({{ request_link }})
 
 {{ _("This is an auto-generated message. To manage notifications, visit your account settings")}}
 {%- endblock md_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.submit.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.submit.jinja
@@ -39,7 +39,7 @@
 {%- endblock html_body -%}
 
 {%- block plain_body -%}
-{{ _("Your access request was submitted successfully.") }}
+{{ _("An access request was submitted for your record.") }}
 
 [{{ _("See request details") }}]({{ request_link }})
 
@@ -48,7 +48,7 @@
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("Your access request was submitted successfully.") }}
+{{ _("An access request was submitted for your record.") }}
 
 [{{ _("See request details") }}]({{ request_link }})
 


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/513

During templates refactor [here](https://github.com/anikachurilova/invenio-rdm-records/commit/bc2feedbc399ea4bb24a85d04440477268cb2469?diff=split#diff-798f923640e33256f397f36ab6728df5791072e68e9295a538c3123566b160bbR17) the text of the email was changed 

Preview:
<img width="854" alt="Screenshot 2023-11-03 at 16 42 33" src="https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/b4f93bef-2510-4d89-863b-8cf9bb4c9ff8">
