### PR TITLE
serializers: don't strip html for dc and marcxml

### DIFF
--- a/invenio_rdm_records/resources/serializers/dublincore/schema.py
+++ b/invenio_rdm_records/resources/serializers/dublincore/schema.py
@@ -183,8 +183,6 @@ class DublinCoreSchema(BaseSerializerSchema, CommonFieldsMixin):
         descriptions = [
             bleach.clean(
                 desc,
-                strip=True,
-                strip_comments=True,
                 tags=[],
                 attributes=[],
             )

--- a/invenio_rdm_records/resources/serializers/marcxml/schema.py
+++ b/invenio_rdm_records/resources/serializers/marcxml/schema.py
@@ -402,8 +402,6 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
             return {
                 "a": bleach.clean(
                     description,
-                    strip=True,
-                    strip_comments=True,
                     tags=[],
                     attributes=[],
                 )

--- a/tests/resources/serializers/test_dublincore_serializer.py
+++ b/tests/resources/serializers/test_dublincore_serializer.py
@@ -46,7 +46,10 @@ def test_dublincorejson_serializer(running_app, updated_full_record):
             "https://doi.org/10.1234/foo.bar",
             "https://doi.org/10.1234/inveniordm.1234.parent",
         ],
-        "descriptions": ["A description \nwith HTML tags", "Bla bla bla"],
+        "descriptions": [
+            "&lt;h1&gt;A description&lt;/h1&gt; &lt;p&gt;with HTML tags&lt;/p&gt;",
+            "Bla bla bla",
+        ],
         "publishers": ["InvenioRDM"],
         "languages": ["dan", "eng"],
         "locations": [
@@ -109,7 +112,7 @@ def test_dublincorexml_serializer(running_app, updated_full_record):
         "<dc:creator>Nielsen, Lars Holm</dc:creator>",
         "<dc:date>2018/2020-09</dc:date>",
         "<dc:date>info:eu-repo/date/embargoEnd/2131-01-01</dc:date>",
-        "<dc:description>A description \nwith HTML tags</dc:description>",
+        "<dc:description>&amp;lt;h1&amp;gt;A description&amp;lt;/h1&amp;gt; &amp;lt;p&amp;gt;with HTML tags&amp;lt;/p&amp;gt;</dc:description>",
         "<dc:description>Bla bla bla</dc:description>",
         "<dc:format>application/pdf</dc:format>",
         "<dc:identifier>https://doi.org/10.1234/inveniordm.1234</dc:identifier>",
@@ -130,7 +133,6 @@ def test_dublincorexml_serializer(running_app, updated_full_record):
 
     serializer = DublinCoreXMLSerializer()
     serialized_record = serializer.serialize_object(updated_full_record)
-
     for ed in expected_data:
         assert ed in serialized_record
 
@@ -161,7 +163,7 @@ def test_dublincorexml_serializer_list(
         "<dc:creator>Nielsen, Lars Holm</dc:creator>",
         "<dc:date>2018/2020-09</dc:date>",
         "<dc:date>info:eu-repo/date/embargoEnd/2131-01-01</dc:date>",
-        "<dc:description>A description \nwith HTML tags</dc:description>",
+        "<dc:description>&amp;lt;h1&amp;gt;A description&amp;lt;/h1&amp;gt; &amp;lt;p&amp;gt;with HTML tags&amp;lt;/p&amp;gt;</dc:description>",
         "<dc:description>Bla bla bla</dc:description>",
         "<dc:format>application/pdf</dc:format>",
         "<dc:identifier>https://doi.org/10.1234/inveniordm.1234</dc:identifier>",

--- a/tests/resources/serializers/test_marcxml_serializer.py
+++ b/tests/resources/serializers/test_marcxml_serializer.py
@@ -260,8 +260,7 @@ def test_marcxml_serializer_full_record(
                 <subfield code="a">custom</subfield>
             </datafield>
             <datafield tag="520" ind1=" " ind2=" ">
-                <subfield code="a">A description
-            with HTML tags</subfield>
+                <subfield code="a">&amp;lt;h1&amp;gt;Adescription&amp;lt;/h1&amp;gt;&amp;lt;p&amp;gt;withHTMLtags&amp;lt;/p&amp;gt;</subfield>
             </datafield>
             <datafield tag="520" ind1=" " ind2=" ">
                 <subfield code="a">Bla bla bla</subfield>


### PR DESCRIPTION
Fixes https://github.com/zenodo/rdm-project/issues/569