### PR TITLE
mapping: add a text subfield for award acronyms

### DIFF
--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -537,7 +537,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v6.0.0.json
@@ -494,7 +494,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"
@@ -1046,6 +1049,7 @@
       "metadata.description",
       "metadata.formats",
       "metadata.funding.award.identifiers.identifier",
+      "metadata.funding.award.acronym.text",
       "metadata.funding.award.funder.name",
       "metadata.identifiers.identifier",
       "metadata.location.place",

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -537,7 +537,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v6.0.0.json
@@ -494,7 +494,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"
@@ -1046,6 +1049,7 @@
       "metadata.description",
       "metadata.formats",
       "metadata.funding.award.identifiers.identifier",
+      "metadata.funding.award.acronym.text",
       "metadata.funding.award.funder.name",
       "metadata.identifiers.identifier",
       "metadata.location.place",

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
@@ -537,7 +537,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v6.0.0.json
@@ -494,7 +494,10 @@
                     "type": "text"
                   },
                   "acronym": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "fields": {
+                      "text": { "type": "text"}
+                    }
                   },
                   "program": {
                     "type": "keyword"
@@ -1046,6 +1049,7 @@
       "metadata.description",
       "metadata.formats",
       "metadata.funding.award.identifiers.identifier",
+      "metadata.funding.award.acronym.text",
       "metadata.funding.award.funder.name",
       "metadata.identifiers.identifier",
       "metadata.location.place",


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/519

Case-insensitive global search by awards + default search:
![global search](https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/1dda90dd-1ac4-418a-884b-a990dce943a7)
