### PR TITLE
Passing optional client-side validation props into the formik config

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositBootstrap.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositBootstrap.js
@@ -115,7 +115,7 @@ class DepositBootstrapComponent extends Component {
   };
 
   render() {
-    const { errors, record, children } = this.props;
+    const { errors, record, children, validate, validationSchema } = this.props;
     return (
       <DepositFormSubmitContext.Provider
         value={{ setSubmitContext: this.setSubmitContext }}
@@ -131,6 +131,11 @@ class DepositBootstrapComponent extends Component {
             // is requested on each action, generating countless drafts
             enableReinitialize: true,
             initialValues: record,
+            // validate and validationSchema allow a function or schema to be
+            // passed in to enable formik's client-side form validation. If no
+            // values are passed in, no client-side validation is performed.
+            validate: validate,
+            validationSchema: validationSchema,
             // errors need to be repopulated after form is reinitialised
             ...(errors && { initialErrors: errors }),
           }}
@@ -154,12 +159,16 @@ DepositBootstrapComponent.propTypes = {
   reservePIDAction: PropTypes.func.isRequired,
   discardPIDAction: PropTypes.func.isRequired,
   fileUploadOngoing: PropTypes.bool,
+  validate: PropTypes.func,
+  validationSchema: PropTypes.object,
 };
 
 DepositBootstrapComponent.defaultProps = {
   errors: undefined,
   children: undefined,
   fileUploadOngoing: false,
+  validate: undefined,
+  validationSchema: undefined,
 };
 
 const mapStateToProps = (state) => {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormApp.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormApp.js
@@ -82,12 +82,14 @@ export class DepositFormApp extends Component {
   }
 
   render() {
-    const { children } = this.props;
+    const { children, validate, validationSchema } = this.props;
 
     return (
       <Provider store={this.store}>
         <I18nextProvider i18n={i18next}>
-          <DepositBootstrap>{children}</DepositBootstrap>
+          <DepositBootstrap validate={validate} validationSchema={validationSchema}>
+            {children}
+          </DepositBootstrap>
         </I18nextProvider>
       </Provider>
     );
@@ -106,6 +108,8 @@ DepositFormApp.propTypes = {
   filesService: PropTypes.instanceOf(DepositFilesService),
   recordSerializer: PropTypes.instanceOf(DepositRecordSerializer),
   children: PropTypes.node,
+  validate: PropTypes.func,
+  validationSchema: PropTypes.object,
 };
 
 DepositFormApp.defaultProps = {
@@ -118,4 +122,6 @@ DepositFormApp.defaultProps = {
   recordSerializer: undefined,
   files: undefined,
   children: undefined,
+  validate: undefined,
+  validationSchema: undefined,
 };


### PR DESCRIPTION
### Description

Allows custom deposit forms the option of using formik's client-side validation, while changing nothing about the form's server-side validation.

Formik's client-side validation capabilities are currently not accessible to anyone who is building a custom deposit form (i.e., overriding the RDMDepositForm component). There is no way to pass the client-side validation props from RDMDepositForm through to formik. This commit makes client-side validation accessible by passing two props ("validate" and "validationSchema") into formik config via DepositFormApp and DepositBoostrap. This way developers can choose either to pass through a validation function or to pass through a yup schema which formik understands.

These two props default to undefined in which case they are ignored. They do not interfere at all with the current server-side validation. So there's no risk or negative side-effect to passing them through.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
