### PR TITLE
New version button disabled: add UI feedback

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
@@ -31,20 +31,23 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
       content={i18next.t("You don't have permissions to create a new version.")}
       disabled={!disabled}
       trigger={
-        <Button
-          type="button"
-          positive
-          size="mini"
-          onClick={handleClick}
-          loading={loading}
-          icon
-          labelPosition="left"
-          disabled={disabled}
-          {...uiProps}
-        >
-          <Icon name="tag" />
-          {i18next.t("New version")}
-        </Button>
+        // Extra span needed since disabled buttons do not trigger hover events
+        <span>
+          <Button
+            type="button"
+            positive
+            size="mini"
+            onClick={handleClick}
+            loading={loading}
+            icon
+            labelPosition="left"
+            disabled={disabled}
+            {...uiProps}
+          >
+            <Icon name="tag" />
+            {i18next.t("New version")}
+          </Button>
+        </span>
       }
     />
   );

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
@@ -29,6 +29,7 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
   return (
     <Popup
       content={i18next.t("You don't have permissions to create a new version.")}
+      position="top center"
       disabled={!disabled}
       trigger={
         // Extra span needed since disabled buttons do not trigger hover events


### PR DESCRIPTION
Closes https://github.com/zenodo/ops/issues/336

:heart: Thank you for your contribution!

### Description

* The popup tooltip on the disabled "New version" button was not shown since disabled buttons do not trigger hover events.
    * -> **Fixed by adding an extra `<span>` element around the button.**
    * _Remark: the span is always included, even when the button is enabled._

![new-version](https://github.com/inveniosoftware/invenio-rdm-records/assets/2046893/7a8225a1-d29f-4946-bbb6-e534c94ac752)

Extra changes:
1. **Centered the tooltip** instead of the default left positioning.

![new-version-centered](https://github.com/inveniosoftware/invenio-rdm-records/assets/2046893/6cce9e21-f1bb-42b4-9655-7d2398b3fe89)

2. ~~**Reworded the tooltip** to explain more in details the reason for the new versions to be disabled (as suggested in https://github.com/zenodo/ops/issues/336)~~
    * ~~_Remark: I did not include a final dot `.` in the sentence (it seems that we sometimes do and sometimes don't)._~~
    * ~~_Remark: The [JavaScript translations have not been updated for 2 years](https://github.com/inveniosoftware/invenio-rdm-records/tree/master/invenio_rdm_records/assets/semantic-ui/translations/invenio_rdm_records), and running `npm run extract_messages` generates many differences, so I did not update the translations, even though [the previous wording had some existing translations in another repository](https://github.com/search?q=org%3Ainveniosoftware++%22have+permissions+to+create+a+new+version%22&type=code)._~~

~~![new-version-centered-reword](https://github.com/inveniosoftware/invenio-rdm-records/assets/2046893/ff2ef08e-3971-44ba-b6e3-1bdbbc0ca9df)~~

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
