### PR TITLE
alembic: fix wrongly assigned down revision

### DIFF
--- a/invenio_rdm_records/alembic/ff860d48fb4b_create_media_files_table.py
+++ b/invenio_rdm_records/alembic/ff860d48fb4b_create_media_files_table.py
@@ -14,7 +14,7 @@ from sqlalchemy_utils import JSONType, UUIDType
 
 # revision identifiers, used by Alembic.
 revision = "ff860d48fb4b"
-down_revision = "cfcb8cb78708"
+down_revision = "4a15e8671f4d"
 branch_labels = ()
 depends_on = None
 


### PR DESCRIPTION
The `down_revision` should be pointed to [4a15e8671f4d](https://github.com/zzacharo/invenio-rdm-records/blob/e14199ca860f7ec19747d04f02050b8ef61a999a/invenio_rdm_records/alembic/4a15e8671f4d_create_rdm_records_tables.py#L17) which creates the draft/record metadata/files. The existing value i.e `cfcb8cb78708` causes an error to run alembic upgrade `Requested revision ff860d48fb4b overlaps with other requested revisions cfcb8cb78708`.