### PR TITLE
models: drop unique user constraint for record quotas

### DIFF
--- a/invenio_rdm_records/alembic/82e1b238acca_drop_unique_user_record_quota.py
+++ b/invenio_rdm_records/alembic/82e1b238acca_drop_unique_user_record_quota.py
@@ -1,0 +1,30 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2024 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Remove user unique constraint from record quotas."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "82e1b238acca"
+down_revision = "ff9bec971d30"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.drop_constraint(
+        "uq_rdm_records_quota_user_id", "rdm_records_quota", type_="unique"
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.create_unique_constraint(
+        "uq_rdm_records_quota_user_id", "rdm_records_quota", ["user_id"]
+    )

--- a/invenio_rdm_records/records/models.py
+++ b/invenio_rdm_records/records/models.py
@@ -168,7 +168,7 @@ class RDMRecordQuota(db.Model, Timestamp):
 
     """Parent record id."""
 
-    user_id = db.Column(db.Integer, unique=True)
+    user_id = db.Column(db.Integer)
     """User associated with the parent record via parent.access.owned_by."""
 
     quota_size = db.Column(


### PR DESCRIPTION
It doesn't make sense to have a unique constraint on the user ID when performing individual record quota increases. You can exceptionally increase the quota of multiple records from a user.