### PR TITLE
serializers: DataCite to DCAT-AP: fix missing prov namespace for contributors project roles

### DIFF
--- a/invenio_rdm_records/resources/serializers/dcat/datacite-to-dcat-ap.xsl
+++ b/invenio_rdm_records/resources/serializers/dcat/datacite-to-dcat-ap.xsl
@@ -162,6 +162,7 @@
   <xsl:param name="skos">http://www.w3.org/2004/02/skos/core#</xsl:param>
   <xsl:param name="bibo">http://purl.org/ontology/bibo/</xsl:param>
   <xsl:param name="citedcat">https://w3id.org/citedcat-ap/</xsl:param>
+  <xsl:param name="prov">http://www.w3.org/ns/prov#</xsl:param>
 
 <!-- MDR NALs and other code lists -->
 

--- a/invenio_rdm_records/resources/serializers/dcat/datacite-to-dcat-ap.xsl
+++ b/invenio_rdm_records/resources/serializers/dcat/datacite-to-dcat-ap.xsl
@@ -19,6 +19,8 @@
   Authors:      European Commission, Joint Research Centre (JRC)
                 Andrea Perego (https://github.com/andrea-perego)
 
+  Source code:  https://github.com/ec-jrc/datacite-to-dcat-ap
+
 -->
 
 <!--
@@ -26,10 +28,21 @@
   PURPOSE AND USAGE
 
   This XSLT is a proof of concept for the implementation of the specification
-  concerning the DataCite profile of DCAT-AP (CiteDCAT-AP)
+  concerning the DataCite profile of DCAT-AP (CiteDCAT-AP):
+
+    https://w3id.org/citedcat-ap/
 
   As such, this XSLT must be considered as unstable, and can be updated any
   time based on the revisions to the CiteDCAT-AP specification.
+
+  The official distributions of this XSLT are published in the dedicated GitHub
+  repository:
+
+    https://github.com/ec-jrc/datacite-to-dcat-ap
+
+  Comments and inquiries should be sent via the corresponding issue tracker:
+
+    https://github.com/ec-jrc/datacite-to-dcat-ap/issues
 
 -->
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -686,7 +686,7 @@ def enhanced_full_record(users):
                         ],
                     },
                     "role": {
-                        "id": "other",
+                        "id": "datamanager",
                         "title": {
                             "de": "DatenmanagerIn",
                             "en": "Data manager",
@@ -702,10 +702,10 @@ def enhanced_full_record(users):
                         "type": "personal",
                     },
                     "role": {
-                        "id": "other",
+                        "id": "projectmanager",
                         "title": {
-                            "de": "VerteilerIn",
-                            "en": "Other",
+                            "de": "ProjektmanagerIn",
+                            "en": "Project manager",
                         },
                     },
                 },
@@ -1361,6 +1361,26 @@ def contributors_role_type(app):
 @pytest.fixture(scope="module")
 def contributors_role_v(app, contributors_role_type):
     """Contributor role vocabulary record."""
+    vocabulary_service.create(
+        system_identity,
+        {
+            "id": "datamanager",
+            "props": {"datacite": "DataManager"},
+            "title": {"en": "Data manager"},
+            "type": "contributorsroles",
+        },
+    )
+
+    vocabulary_service.create(
+        system_identity,
+        {
+            "id": "projectmanager",
+            "props": {"datacite": "ProjectManager"},
+            "title": {"en": "Project manager"},
+            "type": "contributorsroles",
+        },
+    )
+
     vocab = vocabulary_service.create(
         system_identity,
         {

--- a/tests/resources/serializers/test_dcat_serializer.py
+++ b/tests/resources/serializers/test_dcat_serializer.py
@@ -63,7 +63,7 @@ def test_dcat_serializer(running_app, enhanced_full_record):
         "      </foaf:Project>",
         "    </citedcat:isFundedBy>",
         '    <citedcat:funder rdf:resource="https://ror.org/00k4n6c32"/>',  # noqa
-        "    <dct:contributor>",
+        "    <citedcat:dataManager>",
         '      <rdf:Description rdf:about="https://orcid.org/0000-0001-8135-3489">',  # noqa
         '        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>',  # noqa
         "        <foaf:name>Nielsen, Lars Holm</foaf:name>",
@@ -81,7 +81,7 @@ def test_dcat_serializer(running_app, enhanced_full_record):
         "          </foaf:Organization>",
         "        </org:memberOf>",
         "      </rdf:Description>",
-        "    </dct:contributor>",
+        "    </citedcat:dataManager>",
         "    <dct:contributor>",
         "      <rdf:Description>",
         '        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>',  # noqa
@@ -90,6 +90,19 @@ def test_dcat_serializer(running_app, enhanced_full_record):
         "        <foaf:familyName>Dirk</foaf:familyName>",
         "      </rdf:Description>",
         "    </dct:contributor>",
+        "    <prov:wasGeneratedBy>",
+        "      <foaf:Project>",
+        '        <rdf:type rdf:resource="http://www.w3.org/ns/prov#Activity"/>',
+        "        <citedcat:projectManager>",
+        "          <rdf:Description>",
+        '            <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>',
+        "            <foaf:name>Dirk, Dirkin</foaf:name>",
+        "            <foaf:givenName>Dirkin</foaf:givenName>",
+        "            <foaf:familyName>Dirk</foaf:familyName>",
+        "          </rdf:Description>",
+        "        </citedcat:projectManager>",
+        "      </foaf:Project>",
+        "    </prov:wasGeneratedBy>",
         '    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2018/2020-09</dct:issued>',  # noqa
         '    <dct:date rdf:datatype="http://www.w3.org/2001/XMLSchema#date">1939/1945</dct:date>',  # noqa
         '    <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DAN"/>',  # noqa


### PR DESCRIPTION
:heart: Thank you for your contribution!

Fixes https://github.com/zenodo/ops/issues/356

### Description

How to reproduce the problem:
* Create a record with a contributor having one of the roles: Project Leader, Project Manager, Project Member
* Try to export the report to DCAT
* You will get the error `XSLTApplyError: Undefined variable` in [`invenio_rdm_records/resources/serializers/dcat/__init__.py`](https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/resources/serializers/dcat/__init__.py#L100)

This pull request fixes this bug.

FYI, I created a pull request upstream with the same fix: https://github.com/ec-jrc/datacite-to-dcat-ap/pull/8

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] _I've NOT included third-party code (copy/pasted source code or new dependencies)._
_-> I did copy the code from https://github.com/ec-jrc/datacite-to-dcat-ap/blob/master/datacite-to-dcat-ap.xsl_

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
