### PR TITLE
Fix ESLint problems on oaipmh/details/LinksTable.js

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/LinksTable.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/LinksTable.js
@@ -39,6 +39,10 @@ class LinksTable extends Component {
     };
   }
 
+  componentDidMount() {
+    this.fetchFormats();
+  }
+
   fetchFormats = async () => {
     const cancellableFetchFormats = withCancel(http.get("/api/oaipmh/formats"));
 
@@ -70,10 +74,6 @@ class LinksTable extends Component {
       });
     }
   };
-
-  componentDidMount() {
-    this.fetchFormats();
-  }
 
   /**
    * Replaces the metadata prefix in the link.

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/LinksTable.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/oaipmh/details/LinksTable.js
@@ -123,7 +123,7 @@ class LinksTable extends Component {
 
     if (formats.some((obj) => obj.key === newFormat)) {
       const newLinks = {};
-      Object.keys(links).map((key) => {
+      Object.keys(links).forEach((key) => {
         const link = links[key];
         newLinks[key] = this.replaceLinkPrefix(link, newFormat);
       });


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Every pull request in this repository shows inline ESLint annotations for these two problems:
* fetchFormats should be placed after componentDidMount
* Array.prototype.map() expects a return value from arrow function

This pull requests solves these 2 issues.

:warning: **DISCLAIMER: I did not do any manual testing, but I feel like the changes are harmless.** :warning: 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
