### PR TITLE
serializers: marcxml: fix copyright status (542) wrong key and value

### DIFF
--- a/invenio_rdm_records/resources/serializers/marcxml/schema.py
+++ b/invenio_rdm_records/resources/serializers/marcxml/schema.py
@@ -121,7 +121,7 @@ class MARCXMLSchema(BaseSerializerSchema, CommonFieldsMixin):
 
     def get_access(self, obj):
         """Get access rights."""
-        access = {"a": obj["access"]["record"]}
+        access = {"l": obj["access"]["status"]}
         return access
 
     def get_files(self, obj):

--- a/tests/resources/serializers/test_marcxml_serializer.py
+++ b/tests/resources/serializers/test_marcxml_serializer.py
@@ -122,7 +122,7 @@ def test_marcxml_serializer_minimal_record(running_app, minimal_record, parent):
   </datafield>
   <controlfield tag="005">{parse(record["updated"]).strftime("%Y%m%d%H%M%S.0")}</controlfield>
   <datafield tag="542" ind1=" " ind2=" ">
-    <subfield code="a">public</subfield>
+    <subfield code="l">metadata-only</subfield>
   </datafield>
   <datafield tag="773" ind1=" " ind2=" ">
     <subfield code="a">10.1234/{record.data["parent"]["id"]}</subfield>
@@ -308,7 +308,7 @@ def test_marcxml_serializer_full_record(
     <subfield code="u">https://127.0.0.1:5000/records/{recid}/files/test.pdf</subfield>
   </datafield>
   <datafield tag="542" ind1=" " ind2=" ">
-    <subfield code="a">public</subfield>
+    <subfield code="l">embargoed</subfield>
   </datafield>
   <datafield tag="773" ind1=" " ind2=" ">
     <subfield code="a">10.1234/foo.bar</subfield>


### PR DESCRIPTION
:heart: Thank you for your contribution!

Fixes https://github.com/zenodo/ops/issues/395

### Description

* Wrong subfield code:
    * According to the [MARC 21 documentation for 542](https://www.loc.gov/marc/bibliographic/bd542.html), the subfield `$a` currently used is for "Personal creator".
    * We used to put the information is the subfield `$l` in the old Zenodo and it seems to be more correct.
    * This pull request puts back this information in the correct subfield.
* Wrong value:
    * The value for this tag used to be `open` in the old Zenodo.
    * The value is now `public`.
    * This pull request takes the information from `access.status` instead of `access.record` to get the right value.
    * However, in the [old Zenodo we used to get this information from metadata.access_right](https://github.com/zenodo/zenodo/blob/master/zenodo/modules/records/serializers/schemas/marc21.py#L44), but it seems to be some Zenodo-only metadata.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
