### PR TITLE
test: add journal:journal custom field to full record test

### DIFF
--- a/tests/resources/serializers/test_marcxml_serializer.py
+++ b/tests/resources/serializers/test_marcxml_serializer.py
@@ -199,8 +199,16 @@ def test_marcxml_serializer_full_record(
 
     # We are setting explicitly the order of the communities as it's required to match the expected data
     record.data["parent"]["communities"]["ids"] = [community.id, community2.id]
+    record.data["custom_fields"] = {}
     # TODO: This is cheating, try to set this in the `updated_full_record` method above
-    record.data["custom_fields"] = {"thesis:university": "A university"}
+    record.data["custom_fields"]["thesis:university"] = "A university"
+
+    record.data["custom_fields"]["journal:journal"] = {
+        "title": "Journal Title",
+        "pages": "100",
+        "volume": "5",
+        "issue": "10",
+    }
     serialized_record = serializer.serialize_object(record.data)
 
     expected_data = f"""\
@@ -310,6 +318,13 @@ def test_marcxml_serializer_full_record(
     <subfield code="a">10.1234/{record["parent"]["id"]}</subfield>
     <subfield code="i">isVersionOf</subfield>
     <subfield code="n">doi</subfield>
+  </datafield>
+  <datafield tag="909" ind1="C" ind2="4">
+    <subfield code="p">Journal Title</subfield>
+    <subfield code="v">5</subfield>
+    <subfield code="n">10</subfield>
+    <subfield code="c">100</subfield>
+    <subfield code="y">2018/2020-09</subfield>
   </datafield>
 </record>
 """


### PR DESCRIPTION
:heart: Thank you for your contribution!

Close https://github.com/zenodo/ops/issues/417

### Description

> Please describe briefly your pull request.

Add test.

Note: this journal field is handled via https://github.com/inveniosoftware/invenio-rdm-records/blob/74216f996fc68f146fdca4f00c519250efb286ba/invenio_rdm_records/contrib/journal/processors.py#L91-L124

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
