### PR TITLE
permissions: records always in community feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,5 +75,6 @@ Pipfile.lock
 # pip wheel
 pip-wheel-metadata/
 
-# node_modules
+# node modules
+**/*/node_modules
 node_modules

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2021-2023 Graz University of Technology.
 # Copyright (C) 2023 TU Wien.
+# Copyright (C) 2023 KTH Royal Institute of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -130,6 +131,12 @@ RDM_DEFAULT_FILES_ENABLED = True
 #
 RDM_ALLOW_RESTRICTED_RECORDS = True
 """Allow users to set restricted/private records."""
+
+#
+# Record communities
+#
+RDM_RECORD_ALWAYS_IN_COMMUNITY = False
+"""Enforces at least one community per record on remove community function."""
 
 #
 # Search configuration

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2023 KTH Royal Institute of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -125,6 +126,17 @@ class IfNewRecord(ConditionalGenerator):
     def _condition(self, record=None, **kwargs):
         """Check if there is a record."""
         return record is None
+
+
+class IfOneCommunity(ConditionalGenerator):
+    """Conditional generator for records always in communities case."""
+
+    def _condition(self, record=None, **kwargs):
+        """Check if the record is associated with more than one community."""
+        if record is None:
+            return True
+        rec_communities = record.parent.communities.ids
+        return len(rec_communities) == 1
 
 
 class IfExternalDOIRecord(ConditionalGenerator):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes inveniosoftware/product-rdm#183

This PR adds an option to prevent deleting all communities in a record except for the last one, as our org requires at least one community per record. This feature is off by default and can be activated in your instance by adding:
```python
RDM_ENSURE_RECORD_COMMUNITY_EXISTS = True
```
Then you will still be able to remove communities, but not the last one.
![modal-err-msg-fix](https://user-images.githubusercontent.com/36583694/234033417-26dd8c77-b283-44a9-bc53-f91cf984994d.gif)


This PR is connected to [this package](https://pypi.org/project/invenio-config-kth/) we create, it prevents submitting any record without selecting a community from the API level. and prevents users from creating communities unless they have certain privileges that we set for the theme programmatically. 
Future plans are to implement this as well with the master branch.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
