### PR TITLE
tests: fixture records with reference text and identifier

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -548,7 +548,9 @@ def full_record(users):
             ],
             "references": [
                 {
-                    "reference": "0000 0001 1456 7559",
+                    "reference": "Nielsen et al,..",
+                    "identifier": "0000 0001 1456 7559",
+                    "scheme": "isni",
                 }
             ],
         },

--- a/tests/resources/serializers/conftest.py
+++ b/tests/resources/serializers/conftest.py
@@ -325,7 +325,9 @@ def full_record_to_dict():
             "publisher": "InvenioRDM",
             "references": [
                 {
-                    "reference": "0000 0001 1456 7559",
+                    "reference": "Nielsen et al,..",
+                    "identifier": "0000 0001 1456 7559",
+                    "scheme": "isni",
                 },
             ],
             "related_identifiers": [

--- a/tests/resources/serializers/test_marcxml_serializer.py
+++ b/tests/resources/serializers/test_marcxml_serializer.py
@@ -276,7 +276,7 @@ def test_marcxml_serializer_full_record(db, running_app, updated_full_record):
     <subfield code="a">eng</subfield>
   </datafield>
   <datafield tag="999" ind1="C" ind2="5">
-    <subfield code="x">0000 0001 1456 7559</subfield>
+    <subfield code="x">Nielsen et al,..</subfield>
   </datafield>
   <datafield tag="260" ind1=" " ind2=" ">
     <subfield code="b">InvenioRDM</subfield>


### PR DESCRIPTION
:heart: Thank you for your contribution!

Fixes https://github.com/zenodo/ops/issues/415

### Description

The test in `test_marcxml_serializer.py` has an assertion on `999C5$x` which make it look as if the reference identifier was serialized instead of the reference text.
This is due to the fact that the fake test data did not follow the real format (with a reference text, an identifier and a scheme).

This pull request makes the test data for references match with the reality and modifies affected assertions.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
