### PR TITLE
fix restricted dois problem

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Run eslint test
-        run: ./run-js-linter.sh -i
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -70,14 +62,21 @@ jobs:
         run: |
           pip install ".[$EXTRAS]"
           pip freeze
-          docker --version
-          docker-compose --version
+          docker version
+
+      - name: Run backend tests
+        run: ./run-tests.sh
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run eslint test
+        run: ./run-js-linter.sh -i
 
       - name: Run translations test
         run: ./run-i18n-tests.sh
-
-      - name: Run tests
-        run: ./run-tests.sh
 
       - name: Install deps for frontend tests
         working-directory: ./invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,8 +11,11 @@
 Changes
 =======
 
-Version 10.5.0 (released 2024-05-21)
+Version 10.6.0 (released 2024-05-22)
+- pids: prevent creating pids for restricted records
+- pids: restrict updating permission levels for records based on a grace period
 
+Version 10.5.0 (released 2024-05-21)
 - iiif: add PyVIPS support for PDF thumnbail rendering
 
 Version 10.4.3 (released 2024-05-17)

--- a/invenio_rdm_records/__init__.py
+++ b/invenio_rdm_records/__init__.py
@@ -10,6 +10,6 @@
 
 from .ext import InvenioRDMRecords
 
-__version__ = "10.5.0"
+__version__ = "10.6.0"
 
 __all__ = ("__version__", "InvenioRDMRecords")

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/AccessRightField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/AccessRightField.js
@@ -31,6 +31,9 @@ export class AccessRightFieldCmp extends Component {
       labelIcon,
       showMetadataAccess,
       community,
+      record,
+      recordRestrictionGracePeriod,
+      allowRecordRestriction,
     } = this.props;
 
     const isGhostCommunity = community?.is_ghost === true;
@@ -52,6 +55,9 @@ export class AccessRightFieldCmp extends Component {
                 <MetadataAccess
                   recordAccess={formik.field.value.record}
                   communityAccess={communityAccess}
+                  record={record}
+                  recordRestrictionGracePeriod={recordRestrictionGracePeriod}
+                  allowRecordRestriction={allowRecordRestriction}
                 />
                 <Divider hidden />
               </>
@@ -97,6 +103,9 @@ AccessRightFieldCmp.propTypes = {
   labelIcon: PropTypes.string.isRequired,
   showMetadataAccess: PropTypes.bool,
   community: PropTypes.object,
+  record: PropTypes.object.isRequired,
+  recordRestrictionGracePeriod: PropTypes.object.isRequired,
+  allowRecordRestriction: PropTypes.bool.isRequired,
 };
 
 AccessRightFieldCmp.defaultProps = {
@@ -130,6 +139,9 @@ AccessRightField.propTypes = {
   label: PropTypes.string.isRequired,
   labelIcon: PropTypes.string,
   isMetadataOnly: PropTypes.bool,
+  record: PropTypes.object.isRequired,
+  recordRestrictionGracePeriod: PropTypes.object.isRequired,
+  allowRecordRestriction: PropTypes.bool.isRequired,
 };
 
 AccessRightField.defaultProps = {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/MetadataAccess.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/MetadataAccess.js
@@ -10,17 +10,45 @@ import PropTypes from "prop-types";
 import { ProtectionButtons } from "./ProtectionButtons";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import Overridable from "react-overridable";
+import { DateTime } from "luxon";
 
 export const MetadataAccess = (props) => {
-  const { recordAccess, communityAccess } = props;
+  const {
+    recordAccess,
+    communityAccess,
+    record,
+    recordRestrictionGracePeriod,
+    allowRecordRestriction,
+  } = props;
   const publicMetadata = recordAccess === "public";
   const publicCommunity = communityAccess === "public";
+
+  const isGracePeriodOver = () => {
+    const createdDate = DateTime.fromISO(record.created);
+    const endOfGracePeriod = createdDate.plus({ days: recordRestrictionGracePeriod });
+
+    return endOfGracePeriod < DateTime.now();
+  };
+
+  const canRestrictRecord = () => {
+    if (
+      !allowRecordRestriction &&
+      record?.created &&
+      record?.access?.record !== "restricted" &&
+      record.is_published
+    ) {
+      return !isGracePeriodOver();
+    }
+    return true;
+  };
 
   return (
     <Overridable id="ReactInvenioDeposit.MetadataAccess.layout" {...props}>
       <>
         {i18next.t("Full record")}
         <ProtectionButtons
+          canRestrictRecord={canRestrictRecord()}
+          record={record}
           active={publicMetadata && publicCommunity}
           disabled={!publicCommunity}
           fieldPath="access.record"
@@ -33,4 +61,7 @@ export const MetadataAccess = (props) => {
 MetadataAccess.propTypes = {
   recordAccess: PropTypes.string.isRequired,
   communityAccess: PropTypes.string.isRequired,
+  record: PropTypes.object.isRequired,
+  recordRestrictionGracePeriod: PropTypes.object.isRequired,
+  allowRecordRestriction: PropTypes.bool.isRequired,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/ProtectionButtons.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/ProtectionButtons.js
@@ -7,7 +7,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React, { Component } from "react";
-import { Button } from "semantic-ui-react";
+import { Button, Popup, Icon } from "semantic-ui-react";
 import { FastField } from "formik";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import PropTypes from "prop-types";
@@ -39,36 +39,49 @@ class ProtectionButtonsComponent extends Component {
   };
 
   render() {
-    const { active, disabled } = this.props;
+    const { active, disabled, canRestrictRecord } = this.props;
 
     const publicColor = active ? "positive" : "";
     const restrictedColor = !active ? "negative" : "";
 
     return (
-      <Button.Group widths="2">
-        <Button
-          className={publicColor}
-          data-testid="protection-buttons-component-public"
-          disabled={disabled}
-          onClick={this.handlePublicButtonClick}
-          active={active}
-        >
-          {i18next.t("Public")}
-        </Button>
-        <Button
-          className={restrictedColor}
-          data-testid="protection-buttons-component-restricted"
-          active={!active}
-          onClick={this.handleRestrictionButtonClick}
-        >
-          {i18next.t("Restricted")}
-        </Button>
-      </Button.Group>
+      <>
+        {!canRestrictRecord && (
+          <Popup
+            trigger={<Icon className="right-floated" name="question circle outline" />}
+            content={i18next.t(
+              "Record visibility can not be changed to restricted anymore. Please contact support if you still need to make these changes."
+            )}
+          />
+        )}
+        <Button.Group widths="2">
+          <Button
+            className={publicColor}
+            data-testid="protection-buttons-component-public"
+            disabled={disabled}
+            onClick={this.handlePublicButtonClick}
+            active={active}
+          >
+            {i18next.t("Public")}
+          </Button>
+
+          <Button
+            disabled={!canRestrictRecord}
+            className={restrictedColor}
+            data-testid="protection-buttons-component-restricted"
+            active={!active}
+            onClick={this.handleRestrictionButtonClick}
+          >
+            {i18next.t("Restricted")}
+          </Button>
+        </Button.Group>
+      </>
     );
   }
 }
 
 ProtectionButtonsComponent.propTypes = {
+  canRestrictRecord: PropTypes.bool,
   fieldPath: PropTypes.string.isRequired,
   formik: PropTypes.object.isRequired,
   active: PropTypes.bool,
@@ -78,6 +91,7 @@ ProtectionButtonsComponent.propTypes = {
 ProtectionButtonsComponent.defaultProps = {
   active: true,
   disabled: false,
+  canRestrictRecord: true,
 };
 
 export class ProtectionButtons extends Component {
@@ -96,5 +110,6 @@ export class ProtectionButtons extends Component {
 }
 
 ProtectionButtons.propTypes = {
+  canRestrictRecord: PropTypes.bool.isRequired,
   fieldPath: PropTypes.string.isRequired,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField.js
@@ -391,6 +391,7 @@ class CustomPIDField extends Component {
       unmanagedHelpText,
       pidType,
       field,
+      record,
     } = this.props;
 
     const value = field.value || {};
@@ -412,6 +413,9 @@ class CustomPIDField extends Component {
         ? hasManagedIdentifier || currentProvider === "" // i.e pids: {}
         : isManagedSelected;
 
+    const doi = record?.pids?.doi?.identifier || "";
+    const hasDoi = doi !== "";
+    const isDoiCreated = currentIdentifier !== "";
     const fieldError = getFieldErrors(form, fieldPath);
     return (
       <>
@@ -421,7 +425,10 @@ class CustomPIDField extends Component {
 
         {this.canBeManagedAndUnmanaged && (
           <ManagedUnmanagedSwitch
-            disabled={isEditingPublishedRecord || hasManagedIdentifier}
+            disabled={
+              (isEditingPublishedRecord || hasManagedIdentifier) &&
+              (hasDoi || isDoiCreated)
+            }
             isManagedSelected={_isManagedSelected}
             onManagedUnmanagedChange={(userSelectedManaged) => {
               if (userSelectedManaged) {
@@ -439,7 +446,7 @@ class CustomPIDField extends Component {
 
         {canBeManaged && _isManagedSelected && (
           <ManagedIdentifierCmp
-            disabled={isEditingPublishedRecord}
+            disabled={hasDoi && isEditingPublishedRecord}
             btnLabelDiscardPID={btnLabelDiscardPID}
             btnLabelGetPID={btnLabelGetPID}
             form={form}
@@ -485,6 +492,7 @@ CustomPIDField.propTypes = {
   pidType: PropTypes.string.isRequired,
   required: PropTypes.bool.isRequired,
   unmanagedHelpText: PropTypes.string,
+  record: PropTypes.object.isRequired,
 };
 
 CustomPIDField.defaultProps = {
@@ -533,6 +541,7 @@ PIDField.propTypes = {
   pidType: PropTypes.string.isRequired,
   required: PropTypes.bool,
   unmanagedHelpText: PropTypes.string,
+  record: PropTypes.object.isRequired,
 };
 
 PIDField.defaultProps = {

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -596,3 +596,9 @@ Relative paths are resolved against the application instance path.
 
 IIIF_TILES_CONVERTER_PARAMS = {}
 """Parameters to be passed to the tiles converter."""
+
+RDM_RECORDS_RESTRICTION_GRACE_PERIOD = timedelta(days=30)
+"""Grace period for changing record access to restricted."""
+
+RDM_RECORDS_ALLOW_RESTRICTION_AFTER_GRACE_PERIOD = False
+"""Whether record access restriction is allowed after the grace period or not."""

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -100,8 +100,8 @@ def is_record_and_has_doi(record, ctx):
 
 def is_record_or_draft_and_has_parent_doi(record, ctx):
     """Determine if draft or record has parent doi."""
-    return (
-        is_record(record, ctx) or is_draft(record, ctx) and has_doi(record.parent, ctx)
+    return (is_record(record, ctx) or is_draft(record, ctx)) and has_doi(
+        record.parent, ctx
     )
 
 

--- a/invenio_rdm_records/services/pids/manager.py
+++ b/invenio_rdm_records/services/pids/manager.py
@@ -24,7 +24,7 @@ class PIDManager:
     def __init__(self, providers, required_schemes=None):
         """Constructor for RecordService."""
         self._providers = providers
-        self._required_schemes = required_schemes
+        self._required_schemes = required_schemes if required_schemes else []
 
     def _get_provider(self, scheme, provider_name=None):
         """Get a provider."""
@@ -35,6 +35,21 @@ class PIDManager:
             return providers[provider_name]
         except KeyError:
             raise ProviderNotSupportedError(provider_name, scheme)
+
+    def _get_providers(self, pids):
+        """Get all providers."""
+        schemes = set(pids.keys()) | set(self._required_schemes)
+        scheme_provider_names = [
+            # provider_name for an absent-but-required pid will be None which will
+            # in turn select the default provider below
+            (scheme, pids.get(scheme, {}).get("provider"))
+            for scheme in schemes
+        ]
+        provider_pid_dicts = [
+            (self._get_provider(scheme, provider_name), pids.get(scheme, {}))
+            for scheme, provider_name in scheme_provider_names
+        ]
+        return provider_pid_dicts
 
     def _validate_pids_schemes(self, pids):
         """Validate the pid schemes that are supported by the service.
@@ -96,17 +111,7 @@ class PIDManager:
         # Validate according to the schemes that the draft has and the schemes that
         # the draft would be given. _required_schemes are schemes that would be given
         # (if not already on the draft).
-        schemes = set(pids.keys()) | set(self._required_schemes)
-        scheme_provider_names = [
-            # provider_name for an absent-but-required pid will be None which will
-            # in turn select the default provider below
-            (scheme, pids.get(scheme, {}).get("provider"))
-            for scheme in schemes
-        ]
-        provider_pid_dicts = [
-            (self._get_provider(scheme, provider_name), pids.get(scheme, {}))
-            for scheme, provider_name in scheme_provider_names
-        ]
+        provider_pid_dicts = self._get_providers(pids)
 
         for provider, pid_dict in provider_pid_dicts:
             success, provider_errors = provider.validate(record=record, **pid_dict)
@@ -279,9 +284,26 @@ class PIDManager:
             try:
                 self.discard(
                     scheme,
-                    pid_attrs["identifier"],
-                    pid_attrs["provider"],
+                    pid_attrs.get("identifier"),
+                    pid_attrs.get("provider"),
                     soft_delete=soft_delete,
                 )
             except PIDDoesNotExistError:
                 pass  # might not have been saved to DB yet
+
+    def validate_restriction_level(self, record, **kwargs):
+        """Validates that the record has correct restriction levels to crate the PIDs."""
+        pids = record.get("pids", {})
+        provider_pid_dicts = self._get_providers(pids)
+
+        for provider, pid_dict in provider_pid_dicts:
+            provider.validate_restriction_level(
+                record, identifier=pid_dict.get("identifier")
+            )
+
+    def create_and_reserve(self, record, **kwargs):
+        """Create and reserve a PID for the given record, and update the record with the reserved PID."""
+        pids = record.get("pids", {})
+        provider_pid_dicts = self._get_providers(pids)
+        for provider, _ in provider_pid_dicts:
+            provider.create_and_reserve(record)

--- a/invenio_rdm_records/services/pids/providers/base.py
+++ b/invenio_rdm_records/services/pids/providers/base.py
@@ -203,3 +203,11 @@ class PIDProvider:
             error["messages"].extend(error_msg)
         else:
             error["messages"].append(error_msg)
+
+    def validate_restriction_level(self, record, identifier, **kwargs):
+        """Validates that the record has correct restriction levels to crate the PID."""
+        pass
+
+    def create_and_reserve(self, record, **kwargs):
+        """Create and reserve a PID for a record."""
+        pass

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2023 Northwestern University.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2024 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -26,6 +26,7 @@ from invenio_i18n import lazy_gettext as _
 from invenio_pidstore.models import PIDStatus
 
 from ....resources.serializers import DataCite43JSONSerializer
+from ....utils import ChainObject
 from .base import PIDProvider
 
 
@@ -153,6 +154,12 @@ class DataCitePIDProvider(PIDProvider):
         :param record: the record metadata for the DOI.
         :returns: `True` if is registered successfully.
         """
+        if isinstance(record, ChainObject):
+            if record._child["access"]["record"] == "restricted":
+                return False
+        elif record["access"]["record"] == "restricted":
+            return False
+
         local_success = super().register(pid)
         if not local_success:
             return False
@@ -178,10 +185,22 @@ class DataCitePIDProvider(PIDProvider):
         :param record: the record metadata for the DOI.
         :returns: `True` if is updated successfully.
         """
+        hide = False
+        if isinstance(record, ChainObject):
+            if record._child["access"]["record"] == "restricted":
+                hide = True
+        elif record["access"]["record"] == "restricted":
+            hide = True
+
         try:
-            # Set metadata
-            doc = self.serializer.dump_obj(record)
-            self.client.api.update_doi(metadata=doc, doi=pid.pid_value, url=url)
+            if hide:
+                self.client.api.hide_doi(doi=pid.pid_value)
+            else:
+                doc = self.serializer.dump_obj(record)
+                doc["event"] = (
+                    "publish"  # Required for DataCite to make the DOI findable in the case it was hidden before. See https://support.datacite.org/docs/how-do-i-make-a-findable-doi-with-the-rest-api
+                )
+                self.client.api.update_doi(metadata=doc, doi=pid.pid_value, url=url)
         except DataCiteError as e:
             current_app.logger.warning(
                 f"DataCite provider error when updating DOI for {pid.pid_value}"
@@ -260,3 +279,21 @@ class DataCitePIDProvider(PIDProvider):
             )
 
         return not bool(errors), errors
+
+    def validate_restriction_level(self, record, identifier=None, **kwargs):
+        """Remove the DOI if the record is restricted."""
+        if identifier and record["access"]["record"] == "restricted":
+            pid = self.get(identifier)
+            if pid.status in [PIDStatus.NEW]:
+                self.delete(pid)
+                del record["pids"][self.pid_type]
+
+    def create_and_reserve(self, record, **kwargs):
+        """Create and reserve a DOI for the given record, and update the record with the reserved DOI."""
+        if "doi" not in record.pids:
+            pid = self.create(record)
+            self.reserve(pid, record=record)
+            pid_attrs = {"identifier": pid.pid_value, "provider": self.name}
+            if self.client:
+                pid_attrs["client"] = self.client.name
+            record.pids["doi"] = pid_attrs

--- a/invenio_rdm_records/services/pids/service.py
+++ b/invenio_rdm_records/services/pids/service.py
@@ -57,7 +57,9 @@ class PIDsService(RecordService):
     @property
     def parent_pid_manager(self):
         """Parent PID Manager."""
-        return self.manager_cls(self.config.parent_pids_providers)
+        return self.manager_cls(
+            self.config.parent_pids_providers, self.config.parent_pids_required
+        )
 
     def resolve(self, identity, id_, scheme, expand=False):
         """Resolve PID to a record (not draft)."""

--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -11,23 +11,29 @@
 
 """RDM Record Service."""
 
+from datetime import datetime
 
 import arrow
+from flask import current_app
 from invenio_accounts.models import User
 from invenio_db import db
 from invenio_drafts_resources.services.records import RecordService
+from invenio_drafts_resources.services.records.uow import ParentRecordCommitOp
 from invenio_records_resources.services import LinksTemplate, ServiceSchemaWrapper
 from invenio_records_resources.services.uow import (
     RecordCommitOp,
     RecordIndexDeleteOp,
     RecordIndexOp,
+    TaskOp,
     unit_of_work,
 )
 from invenio_requests.services.results import EntityResolverExpandableField
 from invenio_search.engine import dsl
+from marshmallow import ValidationError
 from sqlalchemy.exc import NoResultFound
 
 from invenio_rdm_records.records.models import RDMRecordQuota, RDMUserQuota
+from invenio_rdm_records.services.pids.tasks import register_or_update_pid
 
 from ..records.systemfields.deletion_status import RecordDeletionStatusEnum
 from .errors import (
@@ -132,8 +138,20 @@ class RDMRecordService(RecordService):
             "lift_embargo", identity, draft=draft, record=record, uow=uow
         )
 
-        # Commit and reindex record
+        self._pids.pid_manager.create_and_reserve(record)
         uow.register(RecordCommitOp(record, indexer=self.indexer))
+        uow.register(TaskOp(register_or_update_pid, record["id"], "doi", parent=False))
+        # If the record was previously public it will still keep the parent PID
+        if not record.parent.pids:
+            self._pids.parent_pid_manager.create_and_reserve(record.parent)
+            uow.register(
+                ParentRecordCommitOp(
+                    record.parent,
+                )
+            )
+            uow.register(
+                TaskOp(register_or_update_pid, record["id"], "doi", parent=True)
+            )
 
     def scan_expired_embargos(self, identity):
         """Scan for records with an expired embargo."""
@@ -556,6 +574,48 @@ class RDMRecordService(RecordService):
                 raise RecordDeletedException(record, result_item=result)
 
         return result
+
+    @unit_of_work()
+    def update_draft(
+        self, identity, id_, data, revision_id=None, uow=None, expand=False
+    ):
+        """Replace a draft."""
+        draft = self.draft_cls.pid.resolve(id_, registered_only=False)
+
+        # can not make record restricted after grace period
+        current_draft_is_public = (
+            draft.get("access", {}).get("record", None) == "public"
+        )
+        is_update_to_restricted = (
+            data.get("access", {}).get("record", None) == "restricted"
+        )
+        allow_restriction = current_app.config[
+            "RDM_RECORDS_ALLOW_RESTRICTION_AFTER_GRACE_PERIOD"
+        ]
+
+        if (
+            not allow_restriction
+            and current_draft_is_public
+            and is_update_to_restricted
+        ):
+            end_of_grace_period = (
+                draft.created
+                + current_app.config["RDM_RECORDS_RESTRICTION_GRACE_PERIOD"]
+            )
+            if end_of_grace_period <= datetime.now():
+                raise ValidationError(
+                    "Record visibility can not be changed to restricted "
+                    "anymore. Please contact support if you still need to make these changes."
+                )
+
+        return super().update_draft(
+            identity,
+            id_,
+            data,
+            revision_id=revision_id,
+            uow=uow,
+            expand=expand,
+        )
 
     #
     # Record file quota handling

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ except AttributeError:
 
 from collections import namedtuple
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import BytesIO
 from unittest import mock
 
@@ -1704,6 +1704,33 @@ def admin_role_need(db):
 
 
 @pytest.fixture()
+def embargoed_files_record(running_app, minimal_record, superuser_identity):
+    """Embargoed files record."""
+    service = current_rdm_records_service
+    today = arrow.utcnow().date().isoformat()
+
+    # Add embargo to record
+    with mock.patch("arrow.utcnow") as mock_arrow:
+        minimal_record["access"]["files"] = "restricted"
+        minimal_record["access"]["status"] = "embargoed"
+        minimal_record["access"]["embargo"] = dict(
+            active=True, until=today, reason=None
+        )
+
+        # We need to set the current date in the past to pass the validations
+        mock_arrow.return_value = arrow.get(datetime(1954, 9, 29), tz.gettz("UTC"))
+        draft = service.create(superuser_identity, minimal_record)
+        record = service.publish(id_=draft.id, identity=superuser_identity)
+
+        RDMRecord.index.refresh()
+
+        # Recover current date
+        mock_arrow.return_value = arrow.get(datetime.utcnow())
+
+    return record
+
+
+@pytest.fixture()
 def embargoed_record(running_app, minimal_record, superuser_identity):
     """Embargoed record."""
     service = current_rdm_records_service
@@ -1711,7 +1738,7 @@ def embargoed_record(running_app, minimal_record, superuser_identity):
 
     # Add embargo to record
     with mock.patch("arrow.utcnow") as mock_arrow:
-        minimal_record["access"]["files"] = "restricted"
+        minimal_record["access"]["record"] = "restricted"
         minimal_record["access"]["status"] = "embargoed"
         minimal_record["access"]["embargo"] = dict(
             active=True, until=today, reason=None

--- a/tests/secret_links/test_sharing.py
+++ b/tests/secret_links/test_sharing.py
@@ -15,7 +15,10 @@ import pytest
 from flask_principal import AnonymousIdentity, Identity, UserNeed
 from invenio_access.permissions import any_user, authenticated_user
 from invenio_db import db
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.errors import (
+    PermissionDeniedError,
+    RecordPermissionDeniedError,
+)
 from marshmallow.exceptions import ValidationError
 
 from invenio_rdm_records.proxies import current_rdm_records
@@ -85,7 +88,7 @@ def test_permission_levels(service, restricted_record, identity_simple, client):
     anon.provides.add(any_user)
 
     # Deny anonymous to read restricted record and draft
-    pytest.raises(PermissionDeniedError, service.read, anon, id_)
+    pytest.raises(RecordPermissionDeniedError, service.read, anon, id_)
     pytest.raises(PermissionDeniedError, service.files.list_files, anon, id_)
     pytest.raises(PermissionDeniedError, service.read_draft, anon, id_)
     with pytest.raises(PermissionDeniedError):

--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -45,11 +45,77 @@ def test_draft_w_languages_creation(running_app, search_clear, minimal_record):
     ]
 
 
+# Test restricted record with doi creation
+
+
+def test_publish_public_record_with_default_doi(
+    running_app, search_clear, minimal_record
+):
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+    draft = service.create(superuser_identity, minimal_record)
+    record = service.publish(id_=draft.id, identity=superuser_identity)
+    assert "doi" in record._record.pids
+
+
+def test_publish_restricted_record_without_default_doi(
+    running_app, search_clear, minimal_restricted_record
+):
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+    draft = service.create(superuser_identity, minimal_restricted_record)
+    record = service.publish(id_=draft.id, identity=superuser_identity)
+    assert (
+        "doi" not in record._record.pids
+    )  # Restricted records do not create by default a doi
+
+
+def test_publish_restricted_record_with_external_doi(
+    running_app, search_clear, minimal_restricted_record
+):
+    superuser_identity = running_app.superuser_identity
+    minimal_restricted_record["pids"]["doi"] = {
+        "identifier": "10.1235/rdm.5678",
+        "provider": "external",
+    }
+    service = current_rdm_records.records_service
+    draft = service.create(superuser_identity, minimal_restricted_record)
+    record = service.publish(id_=draft.id, identity=superuser_identity)
+    assert "doi" in record._record.pids
+    assert record._record.pids["doi"]["identifier"] == "10.1235/rdm.5678"
+    assert record._record.pids["doi"]["provider"] == "external"
+
+
+def test_embargo_lift_creates_doi(running_app, search_clear, embargoed_record):
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+    assert "doi" not in embargoed_record._record.pids
+    service.lift_embargo(_id=embargoed_record["id"], identity=superuser_identity)
+    record_lifted = service.record_cls.pid.resolve(embargoed_record["id"])
+    assert "doi" in record_lifted.pids
+
+
+def test_public_record_to_restricted_keeps_doi(
+    running_app, search_clear, minimal_record
+):
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+    draft = service.create(superuser_identity, minimal_record)
+    record = service.publish(id_=draft.id, identity=superuser_identity)
+    assert "doi" in record._record.pids
+
+    draft = service.edit(superuser_identity, record.id)
+    draft["access"]["record"] = "restricted"
+    draft = service.update_draft(superuser_identity, draft.id, draft.data)
+    record = service.publish(superuser_identity, draft.id)
+    assert "doi" in record._record.pids
+
+
 #
 # Embargo lift
 #
-def test_embargo_lift_without_draft(embargoed_record, running_app, search_clear):
-    record = embargoed_record
+def test_embargo_lift_without_draft(embargoed_files_record, running_app, search_clear):
+    record = embargoed_files_record
     service = current_rdm_records.records_service
 
     service.lift_embargo(_id=record["id"], identity=running_app.superuser_identity)
@@ -61,8 +127,10 @@ def test_embargo_lift_without_draft(embargoed_record, running_app, search_clear)
     assert record_lifted.access.status.value == "metadata-only"
 
 
-def test_embargo_lift_with_draft(embargoed_record, search_clear, superuser_identity):
-    record = embargoed_record
+def test_embargo_lift_with_draft(
+    embargoed_files_record, search_clear, superuser_identity
+):
+    record = embargoed_files_record
     service = current_rdm_records.records_service
 
     # Edit a draft
@@ -82,9 +150,9 @@ def test_embargo_lift_with_draft(embargoed_record, search_clear, superuser_ident
 
 
 def test_embargo_lift_with_updated_draft(
-    embargoed_record, superuser_identity, search_clear
+    embargoed_files_record, superuser_identity, search_clear
 ):
-    record = embargoed_record
+    record = embargoed_files_record
     service = current_rdm_records.records_service
 
     # This draft simulates an existing one while lifting the record

--- a/tests/services/test_service_tasks.py
+++ b/tests/services/test_service_tasks.py
@@ -14,19 +14,21 @@ from invenio_rdm_records.records.api import RDMDraft
 from invenio_rdm_records.services.tasks import update_expired_embargos
 
 
-def test_embargo_lift_without_draft(embargoed_record, running_app, search_clear):
+def test_embargo_lift_without_draft(embargoed_files_record, running_app, search_clear):
     update_expired_embargos()
 
     service = current_rdm_records.records_service
-    record_lifted = service.record_cls.pid.resolve(embargoed_record["id"])
+    record_lifted = service.record_cls.pid.resolve(embargoed_files_record["id"])
     assert record_lifted.access.embargo.active is False
     assert record_lifted.access.protection.files == "public"
     assert record_lifted.access.protection.record == "public"
     assert record_lifted.access.status.value == "metadata-only"
 
 
-def test_embargo_lift_with_draft(embargoed_record, search_clear, superuser_identity):
-    record = embargoed_record
+def test_embargo_lift_with_draft(
+    embargoed_files_record, search_clear, superuser_identity
+):
+    record = embargoed_files_record
     service = current_rdm_records.records_service
 
     # Edit a draft
@@ -48,9 +50,9 @@ def test_embargo_lift_with_draft(embargoed_record, search_clear, superuser_ident
 
 
 def test_embargo_lift_with_updated_draft(
-    embargoed_record, superuser_identity, search_clear
+    embargoed_files_record, superuser_identity, search_clear
 ):
-    record = embargoed_record
+    record = embargoed_files_record
     service = current_rdm_records.records_service
 
     # This draft simulates an existing one while lifting the record


### PR DESCRIPTION
- test: update test workflows
- fix: don't mint doi's on restricted

this PR will close https://github.com/inveniosoftware/product-rdm/issues/178

still open Problem:
- ~~the DOI is shown on the landing page, because the PID exists in the database~~
- ~~the DOI widget in the frontend has to be grayed out if the access is set to restricted~~
- is it really necessary to gray it out? it complicates the code. it has to be done independent of DOI but for all other pids too, to be generic in that way. The problem is, that the DOI could be already there (entry in pidstore_pid), in the InvenioRDM instance, because the record is set to restricted in the end of the drafting process. there would be a lot of work to do to make that consistent.

ATTENTION:
- to make it clear for the user, a message should be added to the landing page too. this has to be done on invenio-app-rdm

NOTE:
- with this solution it is easy to change from `restricted` to `public` and mint the DOI with this step. No further implementation or work from the user would be necessary

UI:
after grace period of a public record ended, the restriction button is disabled + the popup message
![Screenshot 2024-05-21 at 09 54 57](https://github.com/inveniosoftware/invenio-rdm-records/assets/61321254/1c645d09-7d53-4361-84cc-9795283e9f06)


