### PR TITLE
serializers: access values only if set

### DIFF
--- a/invenio_rdm_records/resources/serializers/csl/schema.py
+++ b/invenio_rdm_records/resources/serializers/csl/schema.py
@@ -13,6 +13,7 @@ from edtf.parser.parser_classes import Date, Interval
 from flask_resources.serializers import BaseSerializerSchema
 from marshmallow import Schema, fields, missing, pre_dump
 from marshmallow_utils.fields import SanitizedUnicode, StrippedHTML
+from pydash import py_
 
 from ..schemas import CommonFieldsMixin
 from ..utils import get_vocabulary_props
@@ -62,19 +63,27 @@ class CSLJSONSchema(BaseSerializerSchema, CommonFieldsMixin):
 
     def get_type(self, obj):
         """Get resource type."""
+        resource_type_id = py_.get(obj, "metadata.resource_type.id")
+        if not resource_type_id:
+            return missing
+
         props = get_vocabulary_props(
             "resourcetypes",
             [
                 "props.csl",
             ],
-            obj["metadata"]["resource_type"]["id"],
+            resource_type_id,
         )
         return props.get("csl", "article")  # article is CSL "Other"
 
     def get_issued(self, obj):
         """Get issued dates."""
+        publication_date = py_.get(obj, "metadata.publication_date")
+        if not publication_date:
+            return missing
+
         try:
-            parsed = parse_edtf(obj["metadata"].get("publication_date"))
+            parsed = parse_edtf(publication_date)
         except EDTFParseException:
             return missing
 

--- a/invenio_rdm_records/resources/serializers/schemaorg/schema.py
+++ b/invenio_rdm_records/resources/serializers/schemaorg/schema.py
@@ -207,10 +207,14 @@ class SchemaorgSchema(BaseSerializerSchema, CommonFieldsMixin):
 
     def get_type(self, obj):
         """Get type. Use the vocabulary service to get the schema.org type."""
+        resource_type_id = py_.get(obj, "metadata.resource_type.id")
+        if not resource_type_id:
+            return missing
+
         props = get_vocabulary_props(
             "resourcetypes",
             ["props.schema.org"],
-            py_.get(obj, "metadata.resource_type.id"),
+            resource_type_id,
         )
         ret = props.get("schema.org", "https://schema.org/CreativeWork")
         return ret
@@ -230,8 +234,12 @@ class SchemaorgSchema(BaseSerializerSchema, CommonFieldsMixin):
 
     def get_publication_date(self, obj):
         """Get publication date."""
+        publication_date = py_.get(obj, "metadata.publication_date")
+        if not publication_date:
+            return missing
+
         try:
-            parsed_date = parse_edtf(py_.get(obj, "metadata.publication_date"))
+            parsed_date = parse_edtf(publication_date)
         except ParseException:
             return missing
 

--- a/invenio_rdm_records/resources/serializers/schemas.py
+++ b/invenio_rdm_records/resources/serializers/schemas.py
@@ -8,6 +8,7 @@
 """Base parsing functions for the various serializers."""
 
 from marshmallow import missing
+from pydash import py_
 
 
 class CommonFieldsMixin:
@@ -55,7 +56,8 @@ class CommonFieldsMixin:
 
     def get_titles(self, obj):
         """Get titles."""
-        return [obj["metadata"]["title"]]
+        title = py_.get(obj, "metadata.title")
+        return [title] if title else missing
 
     def get_identifiers(self, obj):
         """Get identifiers."""
@@ -67,7 +69,9 @@ class CommonFieldsMixin:
 
     def get_creators(self, obj):
         """Get creators."""
-        return [c["person_or_org"]["name"] for c in obj["metadata"].get("creators", [])]
+        return [
+            c["person_or_org"]["name"] for c in obj["metadata"].get("creators", [])
+        ] or missing
 
     def get_publishers(self, obj):
         """Get publishers."""

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 from functools import partial
 
 from babel_edtf import parse_edtf
+from edtf.parser.grammar import ParseException
 from flask import current_app, g
 from flask_resources import BaseObjectSchema
 from invenio_communities.communities.resources.ui_schema import (
@@ -30,6 +31,7 @@ from marshmallow_utils.fields import FormatDate as FormatDate_
 from marshmallow_utils.fields import FormatEDTF as FormatEDTF_
 from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode, StrippedHTML
 from marshmallow_utils.fields.babel import gettext_from_dict
+from pyparsing import ParseException
 
 from .fields import AccessStatusField
 
@@ -218,12 +220,18 @@ def compute_publishing_information(obj, dummyctx):
         journal_issue = journal.get("issue")
         journal_volume = journal.get("volume")
         journal_pages = journal.get("pages")
-        publication_date_edtf = (
-            parse_edtf(publication_date).lower_strict() if publication_date else None
-        )
-        publication_date_formatted = (
-            f"{publication_date_edtf.tm_year}" if publication_date_edtf else None
-        )
+
+        try:
+            publication_date_edtf = (
+                parse_edtf(publication_date).lower_strict()
+                if publication_date
+                else None
+            )
+            publication_date_formatted = (
+                f"{publication_date_edtf.tm_year}" if publication_date_edtf else None
+            )
+        except ParseException:
+            publication_date_formatted = None
 
         title = f"{journal_title}" if journal_title else None
         vol_issue = f"{journal_volume}" if journal_volume else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -916,6 +916,19 @@ def minimal_record():
 
 
 @pytest.fixture()
+def empty_record():
+    """Almost empty record data as dict coming from the external world."""
+    return {
+        "pids": {},
+        "access": {},
+        "files": {
+            "enabled": False,  # Most tests don't care about files
+        },
+        "metadata": {},
+    }
+
+
+@pytest.fixture()
 def minimal_restricted_record(minimal_record):
     """Data for restricted record."""
     record = deepcopy(minimal_record)

--- a/tests/resources/serializers/test_csl_serializer.py
+++ b/tests/resources/serializers/test_csl_serializer.py
@@ -148,3 +148,14 @@ def test_citation_string_serializer_record(
             # in case of error, the response is JSON
             assert response.headers["content-type"] == "application/json"
             assert f"Citation string style not found." in body
+
+
+def test_citation_string_serializer_empty_record(running_app, empty_record):
+    """Test Citation String Serializer for an empty record."""
+
+    expected_data = {}
+
+    serializer = CSLJSONSchema()
+    serialized_record = serializer.dump(empty_record)
+
+    assert serialized_record == expected_data

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -513,3 +513,14 @@ def test_datacite43_serializer_updated_date(running_app, full_modified_date_reco
 
     assert expected_dates == serialized_record["dates"]
     assert len(serialized_record["dates"]) == 3
+
+
+def test_datacite43_serializer_empty_record(running_app, empty_record):
+    """Test if the DataCite 4.3 JSON serializer handles an empty record."""
+
+    expected_data = {"schemaVersion": "http://datacite.org/schema/kernel-4"}
+
+    serializer = DataCite43JSONSerializer()
+    serialized_record = serializer.dump_obj(empty_record)
+
+    assert serialized_record == expected_data

--- a/tests/resources/serializers/test_dublincore_serializer.py
+++ b/tests/resources/serializers/test_dublincore_serializer.py
@@ -90,6 +90,17 @@ def test_dublincorejson_serializer_minimal(running_app, updated_minimal_record):
     assert serialized_record == expected_data
 
 
+def test_dublincorejson_serializer_empty_record(running_app, empty_record):
+    """Test serializer to Dublin Core JSON with an empty record"""
+
+    expected_data = {}
+
+    serializer = DublinCoreJSONSerializer()
+    serialized_record = serializer.dump_obj(empty_record)
+
+    assert serialized_record == expected_data
+
+
 def test_vocabulary_type_error(running_app, updated_minimal_record):
     """Test error thrown on missing resource type."""
     updated_minimal_record["metadata"]["resource_type"]["id"] = "invalid"

--- a/tests/resources/serializers/test_schemaorg_serializer.py
+++ b/tests/resources/serializers/test_schemaorg_serializer.py
@@ -176,3 +176,16 @@ def test_schemaorg_serializer_minimal_record(running_app, minimal_record):
     serialized_record = serializer.dump_obj(minimal_record)
 
     assert serialized_record == expected_data
+
+
+def test_schemaorg_serializer_empty_record(running_app, empty_record):
+    """Test Schemaorg JSON-LD serializer with minimal record."""
+
+    expected_data = {
+        "@context": "http://schema.org",
+    }
+
+    serializer = SchemaorgJSONLDSerializer()
+    serialized_record = serializer.dump_obj(empty_record)
+
+    assert serialized_record == expected_data


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Perform resource type vocabulary lookup only if resource type is set.
Parse dates only if they are set

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/) (for relevant code).
- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).

**Third-party code**

If you've added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
