### PR TITLE
parent-doi: add configuration

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2019-2024 CERN.
 # Copyright (C) 2019 Northwestern University.
-# Copyright (C) 2021-2023 Graz University of Technology.
+# Copyright (C) 2021-2024 Graz University of Technology.
 # Copyright (C) 2023 TU Wien.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
@@ -360,11 +360,13 @@ RDM_PERSISTENT_IDENTIFIERS = {
         "label": _("DOI"),
         "validator": idutils.is_doi,
         "normalizer": idutils.normalize_doi,
+        "is_enabled": providers.DataCitePIDProvider.is_enabled,
     },
     "oai": {
         "providers": ["oai"],
         "required": True,
         "label": _("OAI"),
+        "is_enabled": providers.OAIPIDProvider.is_enabled,
     },
 }
 """The configured persistent identifiers for records.
@@ -396,6 +398,7 @@ RDM_PARENT_PERSISTENT_IDENTIFIERS = {
         "label": _("Concept DOI"),
         "validator": idutils.is_doi,
         "normalizer": idutils.normalize_doi,
+        "is_enabled": providers.DataCitePIDProvider.is_enabled,
     },
 }
 """Persistent identifiers for parent record."""

--- a/invenio_rdm_records/services/customizations.py
+++ b/invenio_rdm_records/services/customizations.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021-2023 CERN.
 # Copyright (C) 2022 Northwestern University.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -38,12 +39,10 @@ class FromConfigPIDsProviders:
 
         pids = obj._app.config.get(self.pids_key, {})
         providers = {p.name: p for p in obj._app.config.get(self.providers_key, [])}
-        doi_enabled = obj._app.config.get("DATACITE_ENABLED", False)
-
         return {
             scheme: get_provider_dict(conf, providers)
             for scheme, conf in pids.items()
-            if scheme != "doi" or doi_enabled
+            if conf["is_enabled"](obj._app)
         }
 
 
@@ -57,15 +56,8 @@ class FromConfigRequiredPIDs:
     def __get__(self, obj, objtype=None):
         """Return required pids (descriptor protocol)."""
         pids = obj._app.config.get(self.pids_key, {})
-        doi_enabled = obj._app.config.get("DATACITE_ENABLED", False)
-
-        pids = {
-            scheme: conf
-            for (scheme, conf) in pids.items()
-            if scheme != "doi" or doi_enabled
-        }
         return [
-            scheme for (scheme, conf) in pids.items() if conf.get("required", False)
+            scheme for (scheme, conf) in pids.items() if conf["is_enabled"](obj._app)
         ]
 
 

--- a/invenio_rdm_records/services/pids/providers/base.py
+++ b/invenio_rdm_records/services/pids/providers/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 CERN.
-# Copyright (C) 2021-2023 Graz University of Technology.
+# Copyright (C) 2021-2024 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -37,6 +37,11 @@ class PIDProvider:
 
     def generate_id(self, record, **kwargs):
         """Generates an identifier value."""
+        raise NotImplementedError
+
+    @classmethod
+    def is_enabled(cls):
+        """Determine if the pid is enabled or not."""
         raise NotImplementedError
 
     def is_managed(self):

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -143,6 +143,11 @@ class DataCitePIDProvider(PIDProvider):
         # Delegate to client
         return self.client.generate_doi(record)
 
+    @classmethod
+    def is_enabled(cls, app):
+        """Determine if datacite is enabled or not."""
+        return app.config.get("DATACITE_ENABLED", False)
+
     def can_modify(self, pid, **kwargs):
         """Checks if the PID can be modified."""
         return not pid.is_registered() and not pid.is_reserved()

--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2021 CERN.
 # Copyright (C) 2023 Northwestern University.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2024 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -60,6 +60,13 @@ class ExternalPIDProvider(PIDProvider):
         """Constructor."""
         super().__init__(name, pid_type=pid_type, managed=False, **kwargs)
         self._validators = validators or []
+
+    @classmethod
+    def is_enabled(cls, app):
+        """Determine if datacite is enabled or not."""
+        # TODO: not used at the moment, but this should be implemented when the
+        # ui distinguish between datacite and external doi's
+        return NotImplementedError
 
     def validate(self, record, identifier=None, provider=None, client=None, **kwargs):
         """Validate the pid attributes and record.

--- a/invenio_rdm_records/services/pids/providers/oai.py
+++ b/invenio_rdm_records/services/pids/providers/oai.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 CERN.
-# Copyright (C) 2021-2023 Graz University of Technology.
+# Copyright (C) 2021-2024 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -34,6 +34,11 @@ class OAIPIDProvider(PIDProvider):
         # http://www.openarchives.org/OAI/2.0/guidelines-oai-identifier.htm
         prefix = current_app.config.get("OAISERVER_ID_PREFIX", "")
         return f"oai:{prefix}:{record.pid.pid_value}"
+
+    @classmethod
+    def is_enabled(cls, app):
+        """Determine if datacite is enabled or not."""
+        return True
 
     def reserve(self, pid, record, **kwargs):
         """Constant True.


### PR DESCRIPTION
should fix https://github.com/inveniosoftware/invenio-rdm-records/issues/1652


QUESTIONS:
- is this a valid approach?
- should the default be:
   - yes create parent dois
   - no parent doi should be created
- the PR implements it as DATACITE_ENABLE, where it has to be explicitly turned on
   the problem with that is, that it is not backwards compatible to the actual code, BUT it would be backwards compatible to v11
- i added a check to the migration script, to only create parent DOI's if datacite is enabled ([PR](https://github.com/inveniosoftware/invenio-app-rdm/blob/027a3ad02c0c6617a91a88bff72b2a539fa82556/invenio_app_rdm/upgrade_scripts/migrate_11_0_to_12_0.py#L54)). if the `PARENT_DOI_ENABLE` config will be merged this should be added to the migration script too