### PR TITLE
deposit-ui: show detailed backend error messages if present

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedback.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedback.js
@@ -1,5 +1,5 @@
 // This file is part of Invenio-RDM-Records
-// Copyright (C) 2020-2023 CERN.
+// Copyright (C) 2020-2024 CERN.
 // Copyright (C) 2020-2022 Northwestern University.
 // Copyright (C) 2021 Graz University of Technology.
 //
@@ -266,8 +266,20 @@ class DisconnectedFormFeedback extends Component {
       </Message.Item>
     ));
 
-    // errors not related to validation, following a different format {status:.., message:..}
-    const backendErrorMessage = errors.message;
+    // errors not related to validation, following a different format {status:..., message:..., errors: {field: ..., messages: [...]}}
+    let backendErrorMessage = errors.message;
+
+    // add extra backend error messages related to fields if present
+    if (backendErrorMessage && errors.errors) {
+      backendErrorMessage +=
+        " " +
+        errors.errors
+          .map((error) => {
+            // Not including `error.field` since it's often redundant with the messages
+            return error.messages?.join(" ");
+          })
+          .join(" ");
+    }
 
     return (
       <Message


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This pull request proposes to include more error details from the backend, if present, when an error occurs during record publishing.

This is for instance the case in Zenodo when trying to publish a record with a pending file uploads. This can be either if the file upload failed halfway (can be reproduced with EOS and by reloading the page in the middle of an upload), or if the file is taking a long time to upload (can be reproduced by throttling the network).

In such cases:
1. The `PUT` on `/api/records/1234/draft?expand=1` succeeds
2. The `POST` on `/api/records/1234/draft/actions/publish?expand=1` fails with the following response:
```json
{
  "status": 400,
  "message": "A validation error occurred.",
  "errors": [
    {
      "field": "files",
      "messages": [
        "One or more files have not completed their transfer, please wait."
      ]
    }
  ]
}
```

We are currently only showing `message`:
![current message](https://github.com/inveniosoftware/invenio-rdm-records/assets/2046893/bd8281ce-fa84-4f5b-87ce-45eb14167540)

The proposal of adding the info present in the `errors` array looks like this:
![proposed message](https://github.com/inveniosoftware/invenio-rdm-records/assets/2046893/b54f3035-06ee-45fb-87e7-3995bf7072bd)



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
