### PR TITLE
Add PyVIPS support

### DIFF
--- a/invenio_rdm_records/services/iiif/service.py
+++ b/invenio_rdm_records/services/iiif/service.py
@@ -9,6 +9,7 @@
 
 """IIIF Service."""
 
+import io
 import tempfile
 
 import importlib_metadata as metadata
@@ -23,6 +24,17 @@ try:
 except (metadata.PackageNotFoundError, ImportError):
     # ImageMagick notinstalled
     HAS_IMAGEMAGICK = False
+
+try:
+    import pyvips
+
+    HAS_VIPS = True
+except ModuleNotFoundError:
+    # Python module pyvips not installed
+    HAS_VIPS = False
+except OSError:
+    # Underlying library libvips not installed
+    HAS_VIPS = False
 
 
 class IIIFService(Service):
@@ -72,15 +84,35 @@ class IIIFService(Service):
 
     def _open_image(self, file_):
         fp = file_.get_stream("rb")
-        # If ImageMagick with Wand is installed, extract first page
-        # for PDF/text.
-        pages_mimetypes = {"application/pdf", "text/plain"}
-        if HAS_IMAGEMAGICK and file_.data["mimetype"] in pages_mimetypes:
+        # If the file is not a PDF or text, return the file
+        if file_.data["mimetype"] not in {"application/pdf", "text/plain"}:
+            return fp
+
+        # If Wand (ImageMagick) or PyVIPS is installed, extract the first page
+        if HAS_VIPS:  # prefer PyVIPS since it doesn't load the whole file in memory
+
+            def _seek_handler(offset, whence):
+                fp.seek(offset, whence)
+                return fp.tell()
+
+            source = pyvips.SourceCustom()
+            source.on_read(fp.read)
+            source.on_seek(_seek_handler)
+
+            # PyVIPS returns by default the first page of the PDF
+            first_page = pyvips.Image.new_from_source(source, "", access="sequential")
+            # Convert to memory to be able to return a file-like object
+            first_page_buf = io.BytesIO(first_page.write_to_memory())
+            fp.close()
+            return first_page_buf
+        elif HAS_IMAGEMAGICK:
             first_page = Image(blob=fp)
-            tempfile_ = tempfile.TemporaryFile()
+            first_page_buf = io.BytesIO()
             with first_page.convert(format="png") as converted:
-                converted.save(file=tempfile_)
-            return tempfile_
+                converted.save(file=first_page_buf)
+            first_page_buf.seek(0)
+            fp.close()
+            return first_page_buf
 
         return fp
 

--- a/tests/resources/conftest.py
+++ b/tests/resources/conftest.py
@@ -35,18 +35,14 @@ def link(url):
 @pytest.fixture(scope="function")
 def app_with_allowed_edits(running_app):
     """Allow editing of published records."""
-    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = (
-        lambda service, identity, record=None: False
-    )
+    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = lambda *_, **__: False
     return running_app
 
 
 @pytest.fixture(scope="function")
 def app_with_deny_edits(running_app):
     """Deny editing of published records."""
-    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = (
-        lambda service, identity, record=None: True
-    )
+    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = lambda *_, **__: True
 
 
 def init_file(client, recid, key, headers):

--- a/tests/services/files/conftest.py
+++ b/tests/services/files/conftest.py
@@ -47,9 +47,7 @@ def app_with_allowed_edits(running_app):
     sessions as we want to test sqlalchemy-continuum and the latter misbehaves when the
     default `pytest_invenio.db` fixture is used. Thus,
     """
-    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = (
-        lambda service, identity, record=None: False
-    )
+    running_app.app.config["RDM_LOCK_EDIT_PUBLISHED_FILES"] = lambda *_, **__: False
     return running_app
 
 


### PR DESCRIPTION
- **tests: fix broken files lock fixtures**
- **iiif: add PyVIPS support for PDF thumnbail rendering**
  - If PyVIPS is available, it will be used by default to generate PDF thumbnails.
  - PyVIPS uses significantly less memory to do so, since it doesn't load the entire image/PDF in memory. See also https://github.com/inveniosoftware/invenio-records-resources/pull/576 for explanation.
