### PR TITLE
github: read previous version also from deleted records.

### DIFF
--- a/invenio_rdm_records/services/github/release.py
+++ b/invenio_rdm_records/services/github/release.py
@@ -152,7 +152,7 @@ class RDMGithubRelease(GitHubRelease):
 
                     # Use the previous record's owner as the new version owner
                     last_record = current_rdm_records_service.read(
-                        system_identity, recid.pid_value
+                        system_identity, recid.pid_value, include_deleted=True
                     )
                     owner = last_record._record.parent.access.owner.resolve()
 


### PR DESCRIPTION
We have the following scenario:

- Create version 1 of a release
- Create version 2 of a release
- Delete version 2 (e.g on support)
- A new release comes in and it fails because version 2 was deleted

The error is on the `read` call (`RecordDeletedException`)