### PR TITLE
tiles: don't process images <= tile dimensions

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -597,7 +597,12 @@ IIIF_TILES_STORAGE_BASE_PATH = "images/"
 Relative paths are resolved against the application instance path.
 """
 
-IIIF_TILES_CONVERTER_PARAMS = {}
+IIIF_TILES_CONVERTER_PARAMS = {
+    "compression": "jpeg",
+    "Q": 90,
+    "tile_width": 256,
+    "tile_height": 256,
+}
 """Parameters to be passed to the tiles converter."""
 
 RDM_RECORDS_RESTRICTION_GRACE_PERIOD = timedelta(days=30)

--- a/invenio_rdm_records/records/processors/tiles.py
+++ b/invenio_rdm_records/records/processors/tiles.py
@@ -43,7 +43,18 @@ class TilesProcessor(RecordFilesProcessor):
 
     def _can_process_file(self, file_record, draft, record) -> bool:
         """Checks to determine if to process the record."""
-        return file_record.file.ext in self.valid_exts
+        if file_record.file.ext not in self.valid_exts:
+            return False
+
+        iiif_config = current_app.config.get("IIIF_TILES_CONVERTER_PARAMS")
+        metadata = file_record.metadata or {}
+
+        if (metadata.get("height", 0) <= iiif_config.get("tile_width")) or (
+            metadata.get("width", 0) <= iiif_config.get("tile_height")
+        ):
+            return False
+
+        return True
 
     @contextmanager
     def unlocked_bucket(self, files):


### PR DESCRIPTION
Currently we are processing images less than the tile size into pyramidal tiffs, which leads to corrupt files ptif. We would want to skip the processing for those images.

The config design is not the best and I would probably change how we load the default args here:
https://github.com/inveniosoftware/invenio-rdm-records/blob/c387d843127f9bab3c78550afe57e3ccbeb7725e/invenio_rdm_records/services/iiif/converter.py#L36-L40

Probably, completely removing default_args.
