### PR TITLE
iiif: schema: only return images within size limit in manifest

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -597,7 +597,12 @@ IIIF_TILES_STORAGE_BASE_PATH = "images/"
 Relative paths are resolved against the application instance path.
 """
 
-IIIF_TILES_CONVERTER_PARAMS = {}
+IIIF_TILES_CONVERTER_PARAMS = {
+    "compression": "jpeg",
+    "Q": 90,
+    "tile_width": 256,
+    "tile_height": 256,
+}
 """Parameters to be passed to the tiles converter."""
 
 RDM_RECORDS_RESTRICTION_GRACE_PERIOD = timedelta(days=30)

--- a/invenio_rdm_records/resources/serializers/iiif/schema.py
+++ b/invenio_rdm_records/resources/serializers/iiif/schema.py
@@ -132,10 +132,18 @@ class ListIIIFFilesAttribute(fields.List):
 
     def get_value(self, obj, *args, **kwargs):
         """Return the value for a given key from an object attribute."""
+        iiif_config = current_app.config.get("IIIF_TILES_CONVERTER_PARAMS")
+        valid_metadata = (
+            lambda x: x
+            and x["height"] > iiif_config["tile_height"]
+            and x["width"] > iiif_config["tile_width"]
+        )
+
         return [
             f
             for f in obj["files"].get("entries", {}).values()
             if f["ext"] in current_app.config["RDM_IIIF_MANIFEST_FORMATS"]
+            and valid_metadata(f["metadata"])
         ]
 
 


### PR DESCRIPTION
IIIF Manifest should only serve images within minimum size constraints.