### PR TITLE
pids: fix required behavior

### DIFF
--- a/invenio_rdm_records/services/customizations.py
+++ b/invenio_rdm_records/services/customizations.py
@@ -57,7 +57,9 @@ class FromConfigRequiredPIDs:
         """Return required pids (descriptor protocol)."""
         pids = obj._app.config.get(self.pids_key, {})
         return [
-            scheme for (scheme, conf) in pids.items() if conf["is_enabled"](obj._app)
+            scheme
+            for (scheme, conf) in pids.items()
+            if (conf["is_enabled"](obj._app) and conf.get("required", False))
         ]
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The fix for the parent doi configuration https://github.com/inveniosoftware/invenio-rdm-records/pull/1740 broke the "required" parameter for the pid provider. Previously you could have a pid provider that was active (shows up in the deposit form), but not required (pid would only be minted if something was entered). Because the check for "required" was removed, this stopped working.

This PR adds back in the check for "required". I added added a test in https://github.com/inveniosoftware/invenio-rdm-records/pull/1765, but I need some help to get all of pytest working.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
