### PR TITLE
Fix pid required feature

### DIFF
--- a/invenio_rdm_records/services/customizations.py
+++ b/invenio_rdm_records/services/customizations.py
@@ -57,7 +57,9 @@ class FromConfigRequiredPIDs:
         """Return required pids (descriptor protocol)."""
         pids = obj._app.config.get(self.pids_key, {})
         return [
-            scheme for (scheme, conf) in pids.items() if conf["is_enabled"](obj._app)
+            scheme
+            for (scheme, conf) in pids.items()
+            if (conf["is_enabled"](obj._app) and conf.get("required", False))
         ]
 
 

--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2024 California Institute of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
@@ -56,6 +57,19 @@ def test_publish_public_record_with_default_doi(
     draft = service.create(superuser_identity, minimal_record)
     record = service.publish(id_=draft.id, identity=superuser_identity)
     assert "doi" in record._record.pids
+
+
+def test_publish_public_record_with_optional_doi(
+    running_app, search_clear, minimal_record
+):
+    running_app.app.config["RDM_PERSISTENT_IDENTIFIERS"]["doi"]["required"] = False
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+    draft = service.create(superuser_identity, minimal_record)
+    record = service.publish(id_=draft.id, identity=superuser_identity)
+    assert "doi" not in record._record.pids
+    # Reset the running_app config for next tests
+    running_app.app.config["RDM_PERSISTENT_IDENTIFIERS"]["doi"]["required"] = True
 
 
 def test_publish_restricted_record_without_default_doi(


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The fix for the parent doi configuration https://github.com/inveniosoftware/invenio-rdm-records/pull/1740 broke the "required" parameter for the pid provider. Previously you could have a pid provider that was active (shows up in the deposit form), but not required (pid would only be minted if something was entered). Because the check for "required" was removed, this stopped working. A test is also included.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
