### PR TITLE
deposit: check permission and set disable tooltip for publish button

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
@@ -1,6 +1,7 @@
 // This file is part of Invenio-RDM-Records
 // Copyright (C) 2020-2023 CERN.
 // Copyright (C) 2020-2022 Northwestern University.
+// Copyright (C)      2024 Graz University of Technology.
 //
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -12,7 +13,7 @@ import _omit from "lodash/omit";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { connect } from "react-redux";
-import { Button, Icon, Message, Modal } from "semantic-ui-react";
+import { Button, Icon, Message, Modal, Popup } from "semantic-ui-react";
 import {
   DepositFormSubmitActions,
   DepositFormSubmitContext,
@@ -40,8 +41,8 @@ class PublishButtonComponent extends Component {
     this.closeConfirmModal();
   };
 
-  isDisabled = (values, isSubmitting, filesState) => {
-    if (isSubmitting) {
+  isDisabled = (values, isSubmitting, filesState, hasPublishPermission) => {
+    if (isSubmitting || !hasPublishPermission) {
       return true;
     }
 
@@ -59,6 +60,19 @@ class PublishButtonComponent extends Component {
     return !allCompleted;
   };
 
+  hasPermission = (permissions) => {
+    return permissions.can_publish;
+  };
+
+  getDisabledButtonPopupText = (hasPublishPermission) => {
+    let text = i18next.t("Required fields are missing");
+
+    if (!hasPublishPermission) {
+      text = i18next.t("You don't have permission to publish");
+    }
+    return text;
+  };
+
   render() {
     const {
       actionState,
@@ -67,6 +81,7 @@ class PublishButtonComponent extends Component {
       publishWithoutCommunity,
       formik,
       publishModalExtraContent,
+      permissions,
       ...ui
     } = this.props;
     const { isConfirmModalOpen } = this.state;
@@ -74,19 +89,38 @@ class PublishButtonComponent extends Component {
 
     const uiProps = _omit(ui, ["dispatch"]);
 
+    const hasPublishPermission = this.hasPermission(permissions);
+    const publishDisabled = this.isDisabled(
+      values,
+      isSubmitting,
+      filesState,
+      hasPublishPermission
+    );
+
+    // only used when button is disabled
+    const popupText = this.getDisabledButtonPopupText(hasPublishPermission);
+
     return (
       <>
-        <Button
-          disabled={this.isDisabled(values, isSubmitting, filesState)}
-          name="publish"
-          onClick={this.openConfirmModal}
-          positive
-          icon="upload"
-          loading={isSubmitting && actionState === DRAFT_PUBLISH_STARTED}
-          labelPosition="left"
-          content={buttonLabel}
-          {...uiProps}
-          type="button" // needed so the formik form doesn't handle it as submit button i.e enable HTML validation on required input fields
+        <Popup
+          disabled={!publishDisabled}
+          content={popupText}
+          trigger={
+            <span>
+              <Button
+                disabled={publishDisabled}
+                name="publish"
+                onClick={this.openConfirmModal}
+                positive
+                icon="upload"
+                loading={isSubmitting && actionState === DRAFT_PUBLISH_STARTED}
+                labelPosition="left"
+                content={buttonLabel}
+                {...uiProps}
+                type="button" // needed so the formik form doesn't handle it as submit button i.e enable HTML validation on required input fields
+              />
+            </span>
+          }
         />
         {isConfirmModalOpen && (
           <Modal
@@ -139,6 +173,7 @@ PublishButtonComponent.propTypes = {
   formik: PropTypes.object.isRequired,
   publishModalExtraContent: PropTypes.string,
   filesState: PropTypes.object,
+  permissions: PropTypes.object.isRequired,
 };
 
 PublishButtonComponent.defaultProps = {
@@ -153,6 +188,7 @@ const mapStateToProps = (state) => ({
   actionState: state.deposit.actionState,
   publishModalExtraContent: state.deposit.config.publish_modal_extra,
   filesState: state.files,
+  permissions: state.deposit.permissions,
 });
 
 export const PublishButton = connect(

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewOrPublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewOrPublishButton.js
@@ -29,6 +29,7 @@ class SubmitReviewOrPublishComponent extends Component {
       showDirectPublishButton,
       showSubmitForReviewButton,
       record,
+      permissions,
       ...ui
     } = this.props;
     const { modalOpen } = this.state;
@@ -61,13 +62,14 @@ class SubmitReviewOrPublishComponent extends Component {
           />
           <PublishButton
             buttonLabel={i18next.t("Publish without community")}
+            permissions={permissions}
             publishWithoutCommunity
             {...ui}
           />
         </>
       );
     } else {
-      result = <PublishButton {...ui} />;
+      result = <PublishButton permissions={permissions} {...ui} />;
     }
     return result;
   }
@@ -80,6 +82,7 @@ SubmitReviewOrPublishComponent.propTypes = {
   showDirectPublishButton: PropTypes.bool.isRequired,
   showSubmitForReviewButton: PropTypes.bool.isRequired,
   record: PropTypes.object.isRequired,
+  permissions: PropTypes.object.isRequired,
 };
 
 SubmitReviewOrPublishComponent.defaultProps = {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Check the `can_publish` permission to determine the rendering of the publish button on the front end.
A tool tip will be shown on hover, when the publish button is disabled.

No permission:
![Screenshot from 2024-07-10 13-00-41](https://github.com/inveniosoftware/invenio-rdm-records/assets/72449192/d931a570-abef-457d-b245-9e009eff9eb4)

Missing fields:
![Screenshot from 2024-07-10 13-07-16](https://github.com/inveniosoftware/invenio-rdm-records/assets/72449192/1e2a0fac-d2ba-4543-80c3-180970da8484)




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
