### PR TITLE
record inclusion: use system identity to accept inclusion request when can_include_directly

### DIFF
--- a/invenio_rdm_records/services/community_inclusion/service.py
+++ b/invenio_rdm_records/services/community_inclusion/service.py
@@ -8,15 +8,14 @@
 """Community Inclusion Service."""
 
 from flask import current_app
+from invenio_access.permissions import system_identity
 from invenio_communities import current_communities
-from invenio_requests import current_requests_service
+from invenio_i18n import gettext as _
+from invenio_requests import current_events_service, current_requests_service
+from invenio_requests.customizations.event_types import CommentEventType
 
-from ...requests.community_inclusion import (
-    CommunityInclusion,
-    is_access_restriction_valid,
-)
+from ...requests.community_inclusion import CommunityInclusion
 from ...requests.community_submission import CommunitySubmission
-from ..errors import InvalidAccessRestrictions
 
 
 class CommunityInclusionService:
@@ -64,7 +63,24 @@ class CommunityInclusionService:
 
         if can_include_directly:
             request_item = current_requests_service.execute_action(
-                identity, request.id, "accept", data=None, uow=uow
+                system_identity, request.id, "accept", data=None, uow=uow
+            )
+
+            data = {
+                "payload": {
+                    "content": _(
+                        "This request has been automatically accepted, as the uploader can submit to "
+                        "community directly without review."
+                    ),
+                }
+            }
+            current_events_service.create(
+                system_identity,
+                request_item.id,
+                data,
+                CommentEventType,
+                uow=uow,
+                notify=False,
             )
         else:
             request_item = current_requests_service.read(identity, request.id)


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/176

Request gets auto-submitted by system user
![Screenshot 2024-07-26 at 10 18 23](https://github.com/user-attachments/assets/8323e5c8-8570-40cf-a708-cb409326bbb4)
