### PR TITLE
services: added record extension registry

### DIFF
--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -86,6 +86,7 @@ from .search_params import (
     StatusParam,
 )
 from .sort import VerifiedRecordsSortParam
+from werkzeug.utils import cached_property
 
 
 def is_draft_and_has_review(record, ctx):
@@ -277,8 +278,20 @@ class RDMFileRecordServiceConfig(FileServiceConfig, ConfiguratorMixin):
 class RDMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     """RDM record draft service config."""
 
-    # Record and draft classes
-    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
+    @cached_property
+    def record_cls(self):
+        """Record class."""
+        cfg_cls = self._app.config.get("RDM_RECORD_CLS", RDMRecord)
+        exts = getattr(
+            self._app.extensions["invenio-rdm-records"], "record_service_registry", {}
+        )
+        new_cls = cfg_cls
+        for name, _ext in exts.items():
+            tmp = _ext(self._app, new_cls)
+            assert type(tmp) == type(cfg_cls), f"Invalid record type. Expected: {type(cfg_cls)}, got: {type(tmp)}"
+            new_cls = tmp
+        return new_cls
+
     draft_cls = FromConfig("RDM_DRAFT_CLS", default=RDMDraft)
 
     # Schemas


### PR DESCRIPTION
This PR introduces a new mechanism to extend the configured record class.

The idea is that some modules might want to add a single field (or method) to the record class, without polluting the core's RDM namespace. 

The interface of these "extensions" is a callback that returns a valid Record class. 

The extension point right now uses entry points since they can be loaded before all the extensions are initialised.

One example of a registration could be the following:

```python
class SWHExtension(object):
    swhid = SystemField("swhid")


def add_swh_extension(app, record_cls):
    # generate a new class with the field and return it
    if current_swh_ext.is_enabled(app) and current_swh_ext.is_configured(app):
        return type(record_cls.__name__, (record_cls, SWHExtension), {})
    return record_cls
```

There are still unanswered questions to move forward:

- The field can't be stored in DB or ES, if both mappings are set to `strict`
- Dumpers are not extensible at the moment
- Serializer's schemas are not extensible from config, instead, they are extensible on object initialisation. Therefore, we can't extend it from other modules than `invenio-rdm-records` (without subclassing the serializer entirely)

