### PR TITLE
Fix parent DOI link generation

### DIFF
--- a/invenio_rdm_records/services/pids/service.py
+++ b/invenio_rdm_records/services/pids/service.py
@@ -199,9 +199,14 @@ class PIDsService(RecordService):
         # Determine landing page (use scheme specific if available)
         links = self.links_item_tpl.expand(identity, record)
         link_prefix = "parent" if parent else "self"
-        url = links[f"{link_prefix}_html"]
-        if f"{link_prefix}_{scheme}" in links:
-            url = links[f"{link_prefix}_{scheme}"]
+        link_choices = [
+            f"{link_prefix}_{scheme}_html",
+            f"{link_prefix}_html",
+        ]
+        for link_id in link_choices:
+            if link_id in links:
+                url = links[link_id]
+                break
 
         # NOTE: This is not the best place to do this, since we shouldn't be aware of
         #       the fact that the record has a `RelationsField``. However, without

--- a/tests/resources/test_serialized_links.py
+++ b/tests/resources/test_serialized_links.py
@@ -94,16 +94,18 @@ def test_record_links(client, published_json, headers):
     expected_links = {
         "self": f"https://127.0.0.1:5000/api/records/{pid_value}",
         "self_html": f"https://127.0.0.1:5000/records/{pid_value}",
-        "self_doi": f"https://127.0.0.1:5000/doi/{doi_value}",
         "doi": f"https://handle.stage.datacite.org/{doi_value}",
+        "self_doi": f"https://handle.stage.datacite.org/{doi_value}",
+        "self_doi_html": f"https://127.0.0.1:5000/doi/{doi_value}",
         "draft": f"https://127.0.0.1:5000/api/records/{pid_value}/draft",
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/files",
         "media_files": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files",
         "archive": f"https://127.0.0.1:5000/api/records/{pid_value}/files-archive",
         "archive_media": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files-archive",
         "parent": f"https://127.0.0.1:5000/api/records/{parent_pid_value}",
-        "parent_doi": f"https://127.0.0.1:5000/doi/{parent_doi_value}",
         "parent_html": f"https://127.0.0.1:5000/records/{parent_pid_value}",
+        "parent_doi": f"https://handle.stage.datacite.org/{parent_doi_value}",
+        "parent_doi_html": f"https://127.0.0.1:5000/doi/{parent_doi_value}",
         "versions": f"https://127.0.0.1:5000/api/records/{pid_value}/versions",
         "latest": f"https://127.0.0.1:5000/api/records/{pid_value}/versions/latest",  # noqa
         "latest_html": f"https://127.0.0.1:5000/records/{pid_value}/latest",  # noqa


### PR DESCRIPTION
- Closes https://github.com/zenodo/zenodo-rdm/issues/523
- **ci: use reusable workflows**
- **pids: fix parent DOI link generation**
- Adds a new `{self/parent}_doi_html` link, pointing to `{ui}/doi/{doi}`

Note that this PR is somewhat of a breaking change since it changes how `links.parent_doi` is generated:

- Before this PR: `https://my-site.com/doi/{parent_doi}`
- After this PR: `https://doi.org/{parent_doi}`

I think this was a bug/mistake to begin with since it doesn't make sense to render in the UI a link to `/doi/{doi}` for reuse/sharing purposes. The `/doi/{doi}` URL, though, is useful when registering the DOI with DataCite.
