### PR TITLE
Fix JS tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,66 +26,11 @@ on:
         default: "Manual trigger"
 
 jobs:
-  Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.9, 3.12]
-        db-service: [postgresql14]
-        search-service: [opensearch2]
-        node-version: [18.x, 20.x]
-        include:
-          - db-service: postgresql14
-            DB_EXTRAS: "postgresql"
+  Python:
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
 
-          - search-service: opensearch2
-            SEARCH_EXTRAS: "opensearch2"
-
-    env:
-      DB: ${{ matrix.db-service }}
-      SEARCH: ${{ matrix.search-service }}
-      EXTRAS: tests,${{ matrix.SEARCH_EXTRAS }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: setup.cfg
-
-      - name: Install dependencies
-        run: |
-          pip install ".[$EXTRAS]"
-          pip freeze
-          docker version
-
-      - name: Run backend tests
-        run: ./run-tests.sh
-
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-
-      - name: Run eslint test
-        run: ./run-js-linter.sh -i
-
-      - name: Run translations test
-        run: ./run-i18n-tests.sh
-
-      - name: Install deps for frontend tests
-        working-directory: ./invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records
-        run: npm install
-
-      - name: Install deps for frontend tests - translations
-        working-directory: ./invenio_rdm_records/assets/semantic-ui/translations/invenio_rdm_records
-        run: npm install
-
-      - name: Run frontend tests
-        working-directory: ./invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records
-        run: npm test
+  JS:
+    uses: inveniosoftware/workflows/.github/workflows/tests-js.yml@master
+    with:
+      js-working-directory: ./invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records
+      translations-working-directory: ./invenio_rdm_records/assets/semantic-ui/translations/invenio_rdm_records

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/package.json
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/package.json
@@ -24,7 +24,6 @@
     "coveralls": "^3.0.0",
     "enzyme": "^3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
-    "enzyme-to-json": "^3.4.0",
     "expect": "^26.0.0",
     "formik": "^2.1.0",
     "i18next": "^20.3.0",
@@ -59,10 +58,5 @@
     "tinymce": "^6.7.2",
     "typescript": "^4.9.5",
     "yup": "^0.32.11"
-  },
-  "jest": {
-    "snapshotSerializers": [
-      "enzyme-to-json/serializer"
-    ]
   }
 }


### PR DESCRIPTION
- **ci: use reusable workflows**
- **js: fix jest missing globals**

It looks like the `enzyme-to-json` module was installing some weird mix of dependencies that didn't play well with how `react-scripts`/`jest` runs the tests. From what I understand, we're not doing snapshot testing, in which case I don't think we need this dependency at all.