### PR TITLE
config: added links for thumbnails

### DIFF
--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -156,7 +156,7 @@ def lock_edit_published_files(service, identity, record=None, draft=None):
 
 def record_thumbnail_sizes():
     """Return configured sizes for thumbnails."""
-    return current_app.config.get("APP_RDM_RECORD_THUMBNAIL_SIZES",[])
+    return current_app.config.get("APP_RDM_RECORD_THUMBNAIL_SIZES", [])
 
 
 def record_thumbnail(size, record=None, **kwargs):
@@ -180,7 +180,7 @@ def record_thumbnail(size, record=None, **kwargs):
             None,
         )
         if file_key:
-            return f"{file_key}/full/{size},/0/default.png"
+            return f"{file_key}/full/^{size},/0/default.png"
 
     raise NotFound("Thumbnail not found")
 

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -11,7 +11,10 @@
 
 """RDM Record Service."""
 
+import itertools
+from copy import deepcopy
 from os.path import splitext
+from pathlib import Path
 
 from flask import current_app
 from invenio_communities.communities.records.api import Community
@@ -41,11 +44,19 @@ from invenio_records_resources.services.base.config import (
     SearchOptionsMixin,
     ServiceConfig,
 )
-from invenio_records_resources.services.base.links import Link, NestedLinks
+from invenio_records_resources.services.base.links import (
+    Link,
+    NestedLinks,
+    preprocess_vars,
+)
 from invenio_records_resources.services.files.links import FileLink
 from invenio_records_resources.services.files.schema import FileSchema
 from invenio_records_resources.services.records.config import (
     RecordServiceConfig as BaseRecordServiceConfig,
+)
+from invenio_records_resources.services.records.links import (
+    RecordLink,
+    pagination_links,
 )
 from invenio_records_resources.services.records.params import (
     FacetsParam,
@@ -55,6 +66,7 @@ from invenio_records_resources.services.records.params import (
 from invenio_requests.services.requests import RequestItem, RequestList
 from invenio_requests.services.requests.config import RequestSearchOptions
 from requests import Request
+from werkzeug.exceptions import NotFound
 
 from invenio_rdm_records.records.processors.tiles import TilesProcessor
 
@@ -140,6 +152,37 @@ def lock_edit_published_files(service, identity, record=None, draft=None):
     Return False to allow editing of published files or True otherwise.
     """
     return True
+
+
+def record_thumbnail_sizes():
+    """Return configured sizes for thumbnails."""
+    return current_app.config.get("APP_RDM_RECORD_THUMBNAIL_SIZES",[])
+
+
+def record_thumbnail(size, record=None, **kwargs):
+    """Generate the URL for a record's thumbnail."""
+    # Verify against allowed thumbnail sizes
+    if size not in current_app.config["APP_RDM_RECORD_THUMBNAIL_SIZES"]:
+        raise NotFound("Thumbnail size not allowed")
+
+    files = record.files
+    default_preview = files.get("default_preview")
+    file_entries = files.entries
+    image_extensions = current_app.config["IIIF_FORMATS"]
+    if file_entries:
+        # Verify file has allowed extension and selects default preview file if present else the first valid file
+        file_key = next(
+            (
+                key
+                for key in itertools.chain([default_preview], file_entries)
+                if key and Path(key).suffix[1:] in image_extensions
+            ),
+            None,
+        )
+        if file_key:
+            return f"{file_key}/full/{size},/0/default.png"
+
+    raise NotFound("Thumbnail not found")
 
 
 class RecordPIDLink(Link):
@@ -293,6 +336,36 @@ class RDMFileRecordServiceConfig(FileServiceConfig, ConfiguratorMixin):
     }
 
     file_schema = FileSchema
+
+
+class RDMThumbnailLink(RecordLink):
+    """RDM thumbnail links dictionary."""
+
+    def __init__(self, *args, sizes=None, **kwargs):
+        """Constructor."""
+        self._sizes = sizes
+        super().__init__(*args, **kwargs)
+
+    def expand(self, obj, context):
+        """Expand the thumbs size dictionary of URIs."""
+        vars = {}
+        vars.update(deepcopy(context))
+        self.vars(obj, vars)
+        if self._vars_func:
+            self._vars_func(obj, vars)
+        vars = preprocess_vars(vars)
+
+        thumbnail_links = {}
+        for size in self._sizes():
+            try:
+                thumbnail_url = record_thumbnail(size, record=obj)
+                thumbnail_links[str(size)] = (
+                    self._uritemplate.expand(**vars) + thumbnail_url
+                )
+            except NotFound:
+                # Handle the case where the thumbnail does not exist
+                thumbnail_links[str(size)] = None
+        return thumbnail_links
 
 
 # Helper link definitions
@@ -454,6 +527,10 @@ class RDMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
             cond=is_record,
             if_=RecordLink("{+api}/records/{id}/media-files"),
             else_=RecordLink("{+api}/records/{id}/draft/media-files"),
+        ),
+        "thumbnails": RDMThumbnailLink(
+            "{+api}/iiif/record:{id}:",
+            sizes=record_thumbnail_sizes,
         ),
         "archive": ConditionalLink(
             cond=is_record,

--- a/tests/resources/test_serialized_links.py
+++ b/tests/resources/test_serialized_links.py
@@ -64,7 +64,6 @@ def test_draft_links(client, draft_json, minimal_record, headers):
         "access_links": f"https://127.0.0.1:5000/api/records/{pid_value}/access/links",  # noqa
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/files",
         "media_files": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/media-files",
-        "thumbnails": {},
         "archive": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/files-archive",  # noqa
         "archive_media": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/media-files-archive",  # noqa
         "reserve_doi": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/pids/doi",  # noqa
@@ -102,7 +101,6 @@ def test_record_links(client, published_json, headers):
         "draft": f"https://127.0.0.1:5000/api/records/{pid_value}/draft",
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/files",
         "media_files": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files",
-        "thumbnails": {},
         "archive": f"https://127.0.0.1:5000/api/records/{pid_value}/files-archive",
         "archive_media": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files-archive",
         "parent": f"https://127.0.0.1:5000/api/records/{parent_pid_value}",

--- a/tests/resources/test_serialized_links.py
+++ b/tests/resources/test_serialized_links.py
@@ -64,6 +64,7 @@ def test_draft_links(client, draft_json, minimal_record, headers):
         "access_links": f"https://127.0.0.1:5000/api/records/{pid_value}/access/links",  # noqa
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/files",
         "media_files": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/media-files",
+        "thumbnails": {},
         "archive": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/files-archive",  # noqa
         "archive_media": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/media-files-archive",  # noqa
         "reserve_doi": f"https://127.0.0.1:5000/api/records/{pid_value}/draft/pids/doi",  # noqa
@@ -78,6 +79,7 @@ def test_draft_links(client, draft_json, minimal_record, headers):
         "access_users": f"https://127.0.0.1:5000/api/records/{pid_value}/access/users",
         "access_groups": f"https://127.0.0.1:5000/api/records/{pid_value}/access/groups",
     }
+
     assert expected_links == created_draft_links == read_draft_links
 
 
@@ -100,6 +102,7 @@ def test_record_links(client, published_json, headers):
         "draft": f"https://127.0.0.1:5000/api/records/{pid_value}/draft",
         "files": f"https://127.0.0.1:5000/api/records/{pid_value}/files",
         "media_files": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files",
+        "thumbnails": {},
         "archive": f"https://127.0.0.1:5000/api/records/{pid_value}/files-archive",
         "archive_media": f"https://127.0.0.1:5000/api/records/{pid_value}/media-files-archive",
         "parent": f"https://127.0.0.1:5000/api/records/{parent_pid_value}",
@@ -122,6 +125,7 @@ def test_record_links(client, published_json, headers):
         "access_users": f"https://127.0.0.1:5000/api/records/{pid_value}/access/users",
         "access_groups": f"https://127.0.0.1:5000/api/records/{pid_value}/access/groups",
     }
+
     assert expected_links == published_record_links == read_record_links
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Added links for thumbnails in RDMRecordServiceConfig

_/api/records/228_
```json
"thumbnails": {
    "10": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^10,/0/default.png",
    "50": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^50,/0/default.png",
    "100": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^100,/0/default.png",
    "250": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^250,/0/default.png",
    "750": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^750,/0/default.png",
    "1200": "https://127.0.0.1:5000/api/iiif/record:228:Screenshot 2024-08-15 at 17.24.39.png/full/^1200,/0/default.png"
},
```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
