### PR TITLE
UI: Handle Empty File Uploads in FileUploader

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploader.js
@@ -3,6 +3,7 @@
 // Copyright (C) 2020-2022 Northwestern University.
 // Copyright (C)      2022 Graz University of Technology.
 // Copyright (C)      2022 TU Wien.
+// Copyright (C)      2024 KTH Royal Institute of Technology.
 //
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -40,6 +41,7 @@ export const FileUploaderComponent = ({
   isFileImportInProgress,
   decimalSizeDisplay,
   filesLocked,
+  allowEmptyFiles,
   ...uiProps
 }) => {
   // We extract the working copy of the draft stored as `values` in formik
@@ -80,9 +82,27 @@ export const FileUploaderComponent = ({
       const maxFileStorageReached = filesSize + acceptedFilesSize > quota.maxStorage;
 
       const filesNames = _map(filesList, "name");
-      const duplicateFiles = acceptedFiles.filter((acceptedFile) =>
-        filesNames.includes(acceptedFile.name)
+      const filesNamesSet = new Set(filesNames);
+
+      const { duplicateFiles, emptyFiles, nonEmptyFiles } = acceptedFiles.reduce(
+        (accumulators, file) => {
+          if (filesNamesSet.has(file.name)) {
+            accumulators.duplicateFiles.push(file);
+          }
+
+          if (file.size === 0) {
+            accumulators.emptyFiles.push(file);
+          } else {
+            accumulators.nonEmptyFiles.push(file);
+          }
+
+          return accumulators;
+        },
+        { duplicateFiles: [], emptyFiles: [], nonEmptyFiles: [] }
       );
+
+      const hasEmptyFiles = !_isEmpty(emptyFiles);
+      const hasNonEmptyFiles = !_isEmpty(nonEmptyFiles);
 
       if (maxFileNumberReached) {
         setWarningMsg(
@@ -130,7 +150,24 @@ export const FileUploaderComponent = ({
           </div>
         );
       } else {
-        uploadFiles(formikDraft, acceptedFiles);
+        if (!allowEmptyFiles && hasEmptyFiles) {
+          setWarningMsg(
+            <div className="content">
+              <Message
+                warning
+                icon="warning circle"
+                header={i18next.t("Could not upload all files.")}
+                content={i18next.t("Empty files were skipped.")}
+                list={_map(emptyFiles, "name")}
+              />
+            </div>
+          );
+        }
+
+        // Proceed with uploading the non-empty files or all files if empty files are allowed
+        if (allowEmptyFiles || hasNonEmptyFiles) {
+          uploadFiles(formikDraft, allowEmptyFiles ? acceptedFiles : nonEmptyFiles);
+        }
       }
     },
     multiple: true,
@@ -348,6 +385,7 @@ FileUploaderComponent.propTypes = {
   decimalSizeDisplay: PropTypes.bool,
   filesLocked: PropTypes.bool,
   permissions: PropTypes.object,
+  allowEmptyFiles: PropTypes.bool,
 };
 
 FileUploaderComponent.defaultProps = {
@@ -369,4 +407,5 @@ FileUploaderComponent.defaultProps = {
   importButtonText: i18next.t("Import files"),
   decimalSizeDisplay: true,
   filesLocked: false,
+  allowEmptyFiles: true,
 };


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/2804
* Depends on https://github.com/inveniosoftware/invenio-app-rdm/pull/2815
* Display a warning for empty files, indicating they won't be included.
* Show a list of removed file names in the warning.
* This feature is controlled by `records-resources-allow-empty-files` config value.
* Continue uploading other files while showing the warning message.

![upload-empty-files](https://github.com/user-attachments/assets/58005efb-0664-477e-9b68-9b8736cf5618)


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
