### PR TITLE
(UI) Publish buttons: refactored isDisabled function

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
@@ -54,7 +54,7 @@ class PublishButtonComponent extends Component {
     }
 
     // All files must be finished uploading
-    const allCompleted = filesArray.every(file => file.status === "finished")
+    const allCompleted = filesArray.every((file) => file.status === "finished");
 
     return !allCompleted;
   };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
@@ -40,16 +40,29 @@ class PublishButtonComponent extends Component {
     this.closeConfirmModal();
   };
 
-  isDisabled = (values, isSubmitting, numberOfFiles) => {
+  isDisabled = (values, isSubmitting, filesState) => {
+    if (isSubmitting) {
+      return true;
+    }
+
     const filesEnabled = _get(values, "files.enabled", false);
-    const filesMissing = filesEnabled && !numberOfFiles;
-    return isSubmitting || filesMissing;
+    const filesArray = Object.values(filesState.entries ?? {});
+    const filesMissing = filesEnabled && filesArray.length === 0;
+
+    if (filesMissing) {
+      return true;
+    }
+
+    // All files must be finished uploading
+    const allCompleted = filesArray.every(file => file.status === "finished")
+
+    return !allCompleted;
   };
 
   render() {
     const {
       actionState,
-      numberOfFiles,
+      filesState,
       buttonLabel,
       publishWithoutCommunity,
       formik,
@@ -64,7 +77,7 @@ class PublishButtonComponent extends Component {
     return (
       <>
         <Button
-          disabled={this.isDisabled(values, isSubmitting, numberOfFiles)}
+          disabled={this.isDisabled(values, isSubmitting, filesState)}
           name="publish"
           onClick={this.openConfirmModal}
           positive
@@ -123,9 +136,9 @@ PublishButtonComponent.propTypes = {
   buttonLabel: PropTypes.string,
   publishWithoutCommunity: PropTypes.bool,
   actionState: PropTypes.string,
-  numberOfFiles: PropTypes.number.isRequired,
   formik: PropTypes.object.isRequired,
   publishModalExtraContent: PropTypes.string,
+  filesState: PropTypes.object,
 };
 
 PublishButtonComponent.defaultProps = {
@@ -133,12 +146,13 @@ PublishButtonComponent.defaultProps = {
   publishWithoutCommunity: false,
   actionState: undefined,
   publishModalExtraContent: undefined,
+  filesState: undefined,
 };
 
 const mapStateToProps = (state) => ({
   actionState: state.deposit.actionState,
-  numberOfFiles: Object.values(state.files.entries).length,
   publishModalExtraContent: state.deposit.config.publish_modal_extra,
+  filesState: state.files,
 });
 
 export const PublishButton = connect(

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewButton.js
@@ -58,7 +58,7 @@ class SubmitReviewButtonComponent extends Component {
     }
 
     // All files must be finished uploading
-    const allCompleted = filesArray.every(file => file.status === "finished")
+    const allCompleted = filesArray.every((file) => file.status === "finished");
 
     return !allCompleted;
   };
@@ -138,7 +138,7 @@ SubmitReviewButtonComponent.defaultProps = {
   disableSubmitForReviewButton: undefined,
   publishModalExtraContent: undefined,
   directPublish: false,
-  filesState: undefined
+  filesState: undefined,
 };
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
**Issue**

On Zenodo, we have seen multiple inclusion requests being created for records that have "Pending" files. When the receiver tries to accept the request - and publish the record - it fails and does not show any useful information for the user. 

**How to replicate**

1. Create a draft
2. Fill in the required metadata
3. Select a community
4. Add a file but don't let it finish (e.g. use network throttling or simply reload the page)
5. Validate that the button "Submit" is enabled

**Changes**

* Refactored isDisabled function in PublishButton and SubmitReviewButton components to check if all files are finished uploading before enabling the button.
* Passed filesState instead of just the number of files to the function.
* Added a check for non-finished files.
* Added early returns to avoid unnecessary checks on possible large objects / arrays.