### PR TITLE
deposit: change creatributor and license item button order

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
@@ -81,6 +81,9 @@ export const CreatibutorsFieldItem = ({
         className={hidden ? "deposit-drag-listitem hidden" : "deposit-drag-listitem"}
       >
         <List.Content floated="right">
+          <Button size="mini" type="button" onClick={() => removeCreatibutor(index)}>
+            {i18next.t("Remove")}
+          </Button>
           <CreatibutorsModal
             addLabel={addLabel}
             editLabel={editLabel}
@@ -101,9 +104,6 @@ export const CreatibutorsFieldItem = ({
             serializeCreatibutor={serializeCreatibutor}
             deserializeCreatibutor={deserializeCreatibutor}
           />
-          <Button size="mini" type="button" onClick={() => removeCreatibutor(index)}>
-            {i18next.t("Remove")}
-          </Button>
         </List.Content>
         <Ref innerRef={drag}>
           <List.Icon name="bars" className="drag-anchor" />

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/License/LicenseFieldItem.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/License/LicenseFieldItem.js
@@ -60,6 +60,15 @@ export const LicenseFieldItem = ({
         className={hidden ? "deposit-drag-listitem hidden" : "deposit-drag-listitem"}
       >
         <List.Content floated="right">
+          <Button
+            size="mini"
+            type="button"
+            onClick={() => {
+              removeLicense(license.index);
+            }}
+          >
+            {i18next.t("Remove")}
+          </Button>
           <LicenseModal
             searchConfig={searchConfig}
             onLicenseChange={(selectedLicense) => {
@@ -75,15 +84,6 @@ export const LicenseFieldItem = ({
             }
             serializeLicenses={serializeLicenses}
           />
-          <Button
-            size="mini"
-            type="button"
-            onClick={() => {
-              removeLicense(license.index);
-            }}
-          >
-            {i18next.t("Remove")}
-          </Button>
         </List.Content>
         <Ref innerRef={drag}>
           <List.Icon name="bars" className="drag-anchor" />


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR reverts https://github.com/inveniosoftware/invenio-rdm-records/pull/1784 and re-implements https://github.com/inveniosoftware/invenio-rdm-records/pull/1389 with the addition of the license field.

The current button order with Remove on the far right makes it too easy to accidentally delete a creatributor when editing a record.  It also isn't consistent with the button order guidelines https://inveniordm.docs.cern.ch/develop/best-practices/ui/#button-colors-and-order

Change in this PR:
![Screenshot 2024-09-05 at 2 42 55 PM](https://github.com/user-attachments/assets/91558fa8-5c33-4e6c-b69a-5b25fc753fbf)



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
