### PR TITLE
mappings: disable doc_values for geo_shape fields

### DIFF
--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -1074,7 +1074,8 @@
                     "type": "geo_point"
                   },
                   "geometry": {
-                    "type": "geo_shape"
+                    "type": "geo_shape",
+                    "doc_values": false
                   },
                   "place": {
                     "type": "text"

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -1074,7 +1074,8 @@
                     "type": "geo_point"
                   },
                   "geometry": {
-                    "type": "geo_shape"
+                    "type": "geo_shape",
+                    "doc_values": false
                   },
                   "place": {
                     "type": "text"


### PR DESCRIPTION
* Addresses #1807.
* Fixes that multiple values for ``metadata.locations.features``.

Switching `doc_values` off implies that we cannot perform aggregations on the `metadata.locations.features` field. That is fine since we're anyways not doing this at the moment, but should be addressed properly in the future.