### PR TITLE
deposit: add missing fields to record deserializer

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
@@ -323,6 +323,9 @@ export class RDMDepositRecordSerializer extends DepositRecordSerializer {
       "pids",
       "ui",
       "custom_fields",
+      "created",
+      "updated",
+      "revision_id",
     ]);
 
     // FIXME: move logic in a more sophisticated PIDField that allows empty values

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.test.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.test.js
@@ -368,6 +368,7 @@ describe("RDMDepositRecordSerializer tests", () => {
           files: false,
           metadata: false,
         },
+        created: "2020-10-28 18:35:58.113520",
         expanded: {},
         id: "wk205-00878",
         links: {
@@ -496,9 +497,11 @@ describe("RDMDepositRecordSerializer tests", () => {
           ],
           version: "v2.0.0",
         },
+        revision_id: 1,
         ui: {
           publication_date_l10n: "Sep 28, 2020",
         },
+        updated: "2020-10-28 18:35:58.125222",
       };
       expect(deserializedRecord).toEqual(expectedRecord);
     });


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Add fields present in the response to record deserializer in the UI.
Added fields `created`, `updated`, `revision_id`

Two additional fields are part of the response but not part of the deserializer:
- `is_draft`: since the context is the deposit page, it should be clear we are dealing with a draft.
- `expires_at`: not relevant for a draft
Could still add these two fields just to be complete.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
