### PR TITLE
community: added myCommunitiesEnabled prop to CommunitySelectionSearch & 📦 release: v15.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 Changes
 =======
 
+Version v15.6.0 (released 2024-10-18)
+
+- community: added myCommunitiesEnabled prop to CommunitySelectionSearch
+
 Version v15.5.0 (released 2024-10-18)
 
 - community: added autofocus prop to CommunitySelectionSearch

--- a/invenio_rdm_records/__init__.py
+++ b/invenio_rdm_records/__init__.py
@@ -11,6 +11,6 @@
 
 from .ext import InvenioRDMRecords
 
-__version__ = "15.5.0"
+__version__ = "15.6.0"
 
 __all__ = ("__version__", "InvenioRDMRecords")

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionSearch.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionSearch.js
@@ -50,6 +50,7 @@ export class CommunitySelectionSearch extends Component {
       isInitialSubmission,
       CommunityListItem,
       pagination,
+      myCommunitiesEnabled,
       autofocus,
     } = this.props;
 
@@ -72,55 +73,57 @@ export class CommunitySelectionSearch extends Component {
           defaultSortingOnEmptyQueryString={{ sortBy: "bestmatch" }}
         >
           <>
-            <Modal.Content as={Grid} className="m-0 pb-0">
+            <Modal.Content as={Grid} className="m-0 pb-0 centered">
+              {myCommunitiesEnabled && (
+                <Grid.Column
+                  mobile={16}
+                  tablet={8}
+                  computer={8}
+                  textAlign="left"
+                  floated="left"
+                  className="pt-0 pl-0"
+                >
+                  <Menu role="tablist" className="theme-primary-menu" compact>
+                    <Menu.Item
+                      as="button"
+                      role="tab"
+                      id="all-communities-tab"
+                      aria-selected={selectedAppId === allCommunities.appId}
+                      aria-controls={allCommunities.appId}
+                      name="All"
+                      active={selectedAppId === allCommunities.appId}
+                      onClick={() =>
+                        this.setState({
+                          selectedConfig: allCommunities,
+                        })
+                      }
+                    >
+                      {i18next.t("All")}
+                    </Menu.Item>
+                    <Menu.Item
+                      as="button"
+                      role="tab"
+                      id="my-communities-tab"
+                      aria-selected={selectedAppId === myCommunities.appId}
+                      aria-controls={myCommunities.appId}
+                      name="My communities"
+                      active={selectedAppId === myCommunities.appId}
+                      onClick={() =>
+                        this.setState({
+                          selectedConfig: myCommunities,
+                        })
+                      }
+                    >
+                      {i18next.t("My communities")}
+                    </Menu.Item>
+                  </Menu>
+                </Grid.Column>
+              )}
               <Grid.Column
                 mobile={16}
                 tablet={8}
                 computer={8}
-                textAlign="left"
-                floated="left"
-                className="pt-0 pl-0"
-              >
-                <Menu role="tablist" className="theme-primary-menu" compact>
-                  <Menu.Item
-                    as="button"
-                    role="tab"
-                    id="all-communities-tab"
-                    aria-selected={selectedAppId === allCommunities.appId}
-                    aria-controls={allCommunities.appId}
-                    name="All"
-                    active={selectedAppId === allCommunities.appId}
-                    onClick={() =>
-                      this.setState({
-                        selectedConfig: allCommunities,
-                      })
-                    }
-                  >
-                    {i18next.t("All")}
-                  </Menu.Item>
-                  <Menu.Item
-                    as="button"
-                    role="tab"
-                    id="my-communities-tab"
-                    aria-selected={selectedAppId === myCommunities.appId}
-                    aria-controls={myCommunities.appId}
-                    name="My communities"
-                    active={selectedAppId === myCommunities.appId}
-                    onClick={() =>
-                      this.setState({
-                        selectedConfig: myCommunities,
-                      })
-                    }
-                  >
-                    {i18next.t("My communities")}
-                  </Menu.Item>
-                </Menu>
-              </Grid.Column>
-              <Grid.Column
-                mobile={16}
-                tablet={8}
-                computer={8}
-                floated="right"
+                floated={myCommunitiesEnabled ? "right" : "null"}
                 verticalAlign="middle"
                 className="pt-0 pr-0 pl-0"
               >
@@ -179,12 +182,14 @@ CommunitySelectionSearch.propTypes = {
   isInitialSubmission: PropTypes.bool,
   CommunityListItem: PropTypes.elementType,
   pagination: PropTypes.bool,
+  myCommunitiesEnabled: PropTypes.bool,
   autofocus: PropTypes.bool,
 };
 
 CommunitySelectionSearch.defaultProps = {
   isInitialSubmission: true,
   pagination: true,
+  myCommunitiesEnabled: true,
   autofocus: true,
   CommunityListItem: CommunityListItem,
   apiConfigs: {


### PR DESCRIPTION
:heart: Thank you for your contribution!

Partially fixes inveniosoftware/invenio-communities#1227

### Description

*!! MAKE SURE TO HIDE WHITESPACE !!*
![Hide whitespace settings](https://github.com/user-attachments/assets/dc76ddb5-3f87-4af9-9ae8-915dab51b1b0)


Now that the `CommunitySelectionSearch` is used in the community front page (see linked issue), there might not be an authenticated user and the myCommunities tab might not make sense.
One option could be for the component to fetch an endpoint to determine if a user is authenticated or not, but here we are choosing to delegate this responsibility to the user of the component.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
