### PR TITLE
components: make content moderation configurable

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -15,6 +15,9 @@ from datetime import timedelta
 import idutils
 from invenio_i18n import lazy_gettext as _
 
+import invenio_rdm_records.services.communities.moderation as communities_moderation
+from invenio_rdm_records.services.components.verified import UserModerationHandler
+
 from . import tokens
 from .resources.serializers import DataCite43JSONSerializer
 from .services import facets
@@ -554,6 +557,16 @@ RDM_LOCK_EDIT_PUBLISHED_FILES = lock_edit_published_files
    signature to implement:
    def lock_edit_published_files(service, identity, record=None, draft=None):
 """
+
+RDM_CONTENT_MODERATION_HANDLERS = [
+    UserModerationHandler(),
+]
+"""Records content moderation handlers."""
+
+RDM_COMMUNITY_CONTENT_MODERATION_HANDLERS = [
+    communities_moderation.UserModerationHandler(),
+]
+"""Community content moderation handlers."""
 
 # Feature flag to enable/disable user moderation
 RDM_USER_MODERATION_ENABLED = False

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -135,6 +135,84 @@ record_serializers = {
     "application/linkset+json": ResponseHandler(FAIRSignpostingProfileLvl2Serializer()),
 }
 
+error_handlers = {
+    **ErrorHandlersMixin.error_handlers,
+    DeserializerError: create_error_handler(
+        lambda exc: HTTPJSONException(
+            code=400,
+            description=exc.args[0],
+        )
+    ),
+    StyleNotFoundError: create_error_handler(
+        HTTPJSONException(
+            code=400,
+            description=_("Citation string style not found."),
+        )
+    ),
+    ReviewNotFoundError: create_error_handler(
+        HTTPJSONException(
+            code=404,
+            description=_("Review for draft not found"),
+        )
+    ),
+    ReviewStateError: create_error_handler(
+        lambda e: HTTPJSONException(
+            code=400,
+            description=str(e),
+        )
+    ),
+    ReviewExistsError: create_error_handler(
+        lambda e: HTTPJSONException(
+            code=400,
+            description=str(e),
+        )
+    ),
+    InvalidRelationValue: create_error_handler(
+        lambda exc: HTTPJSONException(
+            code=400,
+            description=exc.args[0],
+        )
+    ),
+    InvalidAccessRestrictions: create_error_handler(
+        lambda exc: HTTPJSONException(
+            code=400,
+            description=exc.args[0],
+        )
+    ),
+    ValidationErrorWithMessageAsList: create_error_handler(
+        lambda e: HTTPJSONValidationWithMessageAsListException(e)
+    ),
+    AccessRequestExistsError: create_error_handler(
+        lambda e: HTTPJSONException(
+            code=400,
+            description=e.description,
+        )
+    ),
+    RecordDeletedException: create_error_handler(
+        lambda e: (
+            HTTPJSONException(code=404, description=_("Record not found"))
+            if not e.record.tombstone.is_visible
+            else HTTPJSONException(
+                code=410,
+                description=_("Record deleted"),
+                tombstone=e.record.tombstone.dump(),
+            )
+        )
+    ),
+    RecordSubmissionClosedCommunityError: create_error_handler(
+        lambda e: HTTPJSONException(
+            code=403,
+            description=e.description,
+        )
+    ),
+    CommunityRequiredError: create_error_handler(
+        HTTPJSONException(
+            code=400,
+            description=_("Cannot publish without selecting a community."),
+        )
+    ),
+}
+
 
 #
 # Records and record versions
@@ -187,83 +265,10 @@ class RDMRecordResourceConfig(RecordResourceConfig, ConfiguratorMixin):
         default=record_serializers,
     )
 
-    error_handlers = {
-        **ErrorHandlersMixin.error_handlers,
-        DeserializerError: create_error_handler(
-            lambda exc: HTTPJSONException(
-                code=400,
-                description=exc.args[0],
-            )
-        ),
-        StyleNotFoundError: create_error_handler(
-            HTTPJSONException(
-                code=400,
-                description=_("Citation string style not found."),
-            )
-        ),
-        ReviewNotFoundError: create_error_handler(
-            HTTPJSONException(
-                code=404,
-                description=_("Review for draft not found"),
-            )
-        ),
-        ReviewStateError: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=400,
-                description=str(e),
-            )
-        ),
-        ReviewExistsError: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=400,
-                description=str(e),
-            )
-        ),
-        InvalidRelationValue: create_error_handler(
-            lambda exc: HTTPJSONException(
-                code=400,
-                description=exc.args[0],
-            )
-        ),
-        InvalidAccessRestrictions: create_error_handler(
-            lambda exc: HTTPJSONException(
-                code=400,
-                description=exc.args[0],
-            )
-        ),
-        ValidationErrorWithMessageAsList: create_error_handler(
-            lambda e: HTTPJSONValidationWithMessageAsListException(e)
-        ),
-        AccessRequestExistsError: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=400,
-                description=e.description,
-            )
-        ),
-        RecordDeletedException: create_error_handler(
-            lambda e: (
-                HTTPJSONException(code=404, description=_("Record not found"))
-                if not e.record.tombstone.is_visible
-                else HTTPJSONException(
-                    code=410,
-                    description=_("Record deleted"),
-                    tombstone=e.record.tombstone.dump(),
-                )
-            )
-        ),
-        RecordSubmissionClosedCommunityError: create_error_handler(
-            lambda e: HTTPJSONException(
-                code=403,
-                description=e.description,
-            )
-        ),
-        CommunityRequiredError: create_error_handler(
-            HTTPJSONException(
-                code=400,
-                description=_("Cannot publish without selecting a community."),
-            )
-        ),
-    }
+    error_handlers = FromConfig(
+        "RDM_RECORDS_ERROR_HANDLERS",
+        default=error_handlers,
+    )
 
 
 #

--- a/invenio_rdm_records/services/communities/components.py
+++ b/invenio_rdm_records/services/communities/components.py
@@ -7,8 +7,6 @@
 
 """Record communities service components."""
 
-from flask import current_app
-from invenio_access.permissions import system_identity
 from invenio_communities.communities.records.systemfields.access import VisibilityEnum
 from invenio_communities.communities.services.components import ChildrenComponent
 from invenio_communities.communities.services.components import (
@@ -24,18 +22,16 @@ from invenio_communities.communities.services.components import (
     OwnershipComponent,
     PIDComponent,
 )
-from invenio_drafts_resources.services.records.components import ServiceComponent
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.components import (
     MetadataComponent,
     RelationsComponent,
 )
-from invenio_records_resources.services.uow import TaskOp
-from invenio_requests.tasks import request_moderation
 from invenio_search.engine import dsl
 
 from ...proxies import current_community_records_service
 from ..errors import InvalidCommunityVisibility
+from .moderation import ContentModerationComponent
 
 
 class CommunityAccessComponent(BaseAccessComponent):
@@ -66,25 +62,6 @@ class CommunityAccessComponent(BaseAccessComponent):
             self._check_visibility(identity, record)
 
 
-class ContentModerationComponent(ServiceComponent):
-    """Service component for content moderation."""
-
-    def create(self, identity, data=None, record=None, **kwargs):
-        """Create a moderation request if the user is not verified."""
-        if current_app.config["RDM_USER_MODERATION_ENABLED"]:
-            # If the publisher is the system process, we don't want to create a moderation request.
-            # Even if the record being published is owned by a user that is not system
-            if identity == system_identity:
-                return
-
-            # resolve current user and check if they are verified
-            is_verified = identity.user.verified_at is not None
-
-            if not is_verified:
-                # Spawn a task to request moderation.
-                self.uow.register(TaskOp(request_moderation, user_id=identity.id))
-
-
 CommunityServiceComponents = [
     MetadataComponent,
     CommunityThemeComponent,
@@ -95,8 +72,8 @@ CommunityServiceComponents = [
     OwnershipComponent,
     FeaturedCommunityComponent,
     OAISetComponent,
-    ContentModerationComponent,
     CommunityDeletionComponent,
     ChildrenComponent,
     CommunityParentComponent,
+    ContentModerationComponent,
 ]

--- a/invenio_rdm_records/services/communities/moderation.py
+++ b/invenio_rdm_records/services/communities/moderation.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 CERN.
+# Copyright (C) 2024 CERN.
 #
-# Invenio-RDM-records is free software; you can redistribute it and/or modify
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
-"""RDM service component for content moderation."""
+
+"""Content moderation for communities."""
 
 from flask import current_app
 from invenio_access.permissions import system_identity
-from invenio_drafts_resources.services.records.components import ServiceComponent
+from invenio_records_resources.services.records.components import ServiceComponent
 from invenio_records_resources.services.uow import TaskOp
 from invenio_requests.tasks import request_moderation
 
@@ -16,34 +17,16 @@ from invenio_requests.tasks import request_moderation
 class BaseHandler:
     """Base class for content moderation handlers."""
 
-    def update_draft(
-        self, identity, data=None, record=None, errors=None, uow=None, **kwargs
-    ):
-        """Update draft handler."""
+    def create(self, identity, record=None, data=None, uow=None, **kwargs):
+        """Create handler."""
         pass
 
-    def delete_draft(
-        self, identity, draft=None, record=None, force=False, uow=None, **kwargs
-    ):
-        """Delete draft handler."""
+    def update(self, identity, record=None, data=None, uow=None, **kwargs):
+        """Update handler."""
         pass
 
-    def edit(self, identity, draft=None, record=None, uow=None, **kwargs):
-        """Edit a record handler."""
-        pass
-
-    def new_version(self, identity, draft=None, record=None, uow=None, **kwargs):
-        """New version handler."""
-        pass
-
-    def publish(self, identity, draft=None, record=None, uow=None, **kwargs):
-        """Publish handler."""
-        pass
-
-    def post_publish(
-        self, identity, record=None, is_published=False, uow=None, **kwargs
-    ):
-        """Post publish handler."""
+    def delete(self, identity, data=None, record=None, uow=None, **kwargs):
+        """Delete handler."""
         pass
 
 
@@ -63,14 +46,18 @@ class UserModerationHandler(BaseHandler):
             if identity == system_identity:
                 return
 
-            is_verified = record.parent.is_verified
+            # resolve current user and check if they are verified
+            is_verified = identity.user.verified_at is not None
             if not is_verified:
                 # Spawn a task to request moderation.
-                user_id = record.parent.access.owner.owner_id
-                uow.register(TaskOp(request_moderation, user_id=user_id))
+                self.uow.register(TaskOp(request_moderation, user_id=identity.id))
 
-    def publish(self, identity, draft=None, record=None, uow=None, **kwargs):
-        """Handle publish."""
+    def create(self, identity, record=None, data=None, uow=None, **kwargs):
+        """Handle create."""
+        self.run(identity, record=record, uow=uow)
+
+    def update(self, identity, record=None, data=None, uow=None, **kwargs):
+        """Handle update."""
         self.run(identity, record=record, uow=uow)
 
 
@@ -81,7 +68,9 @@ class ContentModerationComponent(ServiceComponent):
         """Get the handlers for an action."""
 
         def _handler_method(self, *args, **kwargs):
-            handlers = current_app.config.get("RDM_CONTENT_MODERATION_HANDLERS", [])
+            handlers = current_app.config.get(
+                "RDM_COMMUNITY_CONTENT_MODERATION_HANDLERS", []
+            )
             for handler in handlers:
                 action_method = getattr(handler, action, None)
                 if action_method:
@@ -89,11 +78,8 @@ class ContentModerationComponent(ServiceComponent):
 
         return _handler_method
 
-    update_draft = handler_for("update_draft")
-    delete_draft = handler_for("delete_draft")
-    edit = handler_for("edit")
-    publish = handler_for("publish")
-    post_publish = handler_for("post_publish")
-    new_version = handler_for("new_version")
+    create = handler_for("create")
+    update = handler_for("update")
+    delete = handler_for("delete")
 
     del handler_for

--- a/tests/requests/conftest.py
+++ b/tests/requests/conftest.py
@@ -15,6 +15,8 @@ fixtures are available.
 import pytest
 from invenio_records_permissions.generators import AuthenticatedUser, SystemProcess
 
+import invenio_rdm_records.services.communities.moderation as communities_moderation
+from invenio_rdm_records.services.components.verified import UserModerationHandler
 from invenio_rdm_records.services.permissions import RDMRecordPermissionPolicy
 
 
@@ -35,4 +37,9 @@ def app_config(app_config):
     app_config["RDM_PERMISSION_POLICY"] = CustomRDMRecordPermissionPolicy
     # Enable user moderation
     app_config["RDM_USER_MODERATION_ENABLED"] = True
+    # Enable content moderation handlers
+    app_config["RDM_CONTENT_MODERATION_HANDLERS"] = [UserModerationHandler()]
+    app_config["RDM_COMMUNITY_CONTENT_MODERATION_HANDLERS"] = [
+        communities_moderation.UserModerationHandler(),
+    ]
     return app_config


### PR DESCRIPTION
- Closes #1861.
- Adds a new `RRM_CONTENT_MODERATION_HANDLERS` config variable to allow
  for configuring multiple handlers for the different write actions.
