### PR TITLE
tests: fix EDTF interval with unknown start/end

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     arrow>=0.17.0
-    babel-edtf>=1.1.0
+    babel-edtf>=1.2.0
     citeproc-py-styles>=0.1.2,<1.0.0
     citeproc-py>=0.6.0
     commonmeta-py>=0.8.4,<0.8.7

--- a/tests/services/schemas/test_publication_date.py
+++ b/tests/services/schemas/test_publication_date.py
@@ -62,6 +62,10 @@ def test_asymmetric_interval(app, minimal_record):
     _assert_meta(minimal_record["metadata"], "2020-01/2020-12-01")
 
 
+def test_unknown_bound_interval(app, minimal_record):
+    _assert_meta(minimal_record["metadata"], "/2020-12")
+    _assert_meta(minimal_record["metadata"], "2020-12/")
+
+
 def test_invalid_interval(app, minimal_record):
     _assert_fails(minimal_record["metadata"], "2021-01/2020-12")
-    _assert_fails(minimal_record["metadata"], "/2020-12")


### PR DESCRIPTION
* tests: fix EDTF interval with unknown start/end
    * After the v5.x release of the ``edtf`` package, EDTF intervals with
      unknown start/end are valid.
* installation: bump babel-edtf to >=1.2.0
    * This is to enforce `edtf>=5`, which has a fix for supporting EDTF
      intervals with unknown start/end.
