### PR TITLE
deposit-ui: fix creator affiliations selection display

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
@@ -54,7 +54,7 @@ export class AffiliationsField extends Component {
                 );
               }}
               value={getIn(values, fieldPath, []).map(
-                (val) => val.id || val.text || val.name
+                (val) => val.name || val.text || val.id
               )}
               ref={selectRef}
               // Disable UI-side filtering of search results


### PR DESCRIPTION
* Fixes a bug where the selected affiliations from the dropdown do not
  appear inside the input box.

NOTE: In the deposit form we still display only the first affiliation (which is fine). Also tested that publishing the record keeps the ROR ID relation link, so no problem with the serialization from/to the REST API


https://github.com/user-attachments/assets/e748db12-e22c-43c9-9486-0251c45301ba

