### PR TITLE
search: pass search parameters

### DIFF
--- a/invenio_rdm_records/collections/services/service.py
+++ b/invenio_rdm_records/collections/services/service.py
@@ -203,6 +203,7 @@ class CollectionsService(Service):
                 identity,
                 community_id=collection.community.id,
                 extra_filter=collection.query,
+                params=params,
             )
         else:
             raise NotImplementedError(


### PR DESCRIPTION
Search facets and sort options did not work with collections search, the search parameters were not passed to the record search