### PR TITLE
datacite: improve error logging formatting and grouping

### DIFF
--- a/invenio_rdm_records/services/community_records/service.py
+++ b/invenio_rdm_records/services/community_records/service.py
@@ -18,7 +18,7 @@ from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_records_resources.services.uow import unit_of_work
 from invenio_search.engine import dsl
 
-from ...proxies import current_rdm_records, current_record_communities_service
+from ...proxies import current_record_communities_service
 from ...records.systemfields.deletion_status import RecordDeletionStatusEnum
 
 

--- a/invenio_rdm_records/services/pids/providers/datacite.py
+++ b/invenio_rdm_records/services/pids/providers/datacite.py
@@ -120,23 +120,26 @@ class DataCitePIDProvider(PIDProvider):
         # DataCiteError will have the response msg as first arg
         ex_txt = exception.args[0] or ""
         if isinstance(exception, DataCiteNoContentError):
-            current_app.logger.error(f"No content error: {ex_txt}")
+            current_app.logger.error("DataCite no content error", exc_info=exception)
         elif isinstance(exception, DataCiteServerError):
-            current_app.logger.error(f"DataCite internal server error: {ex_txt}")
+            current_app.logger.error(
+                "DataCite internal server error", exc_info=exception
+            )
         else:
             # Client error 4xx status code
             try:
                 ex_json = json.loads(ex_txt)
             except JSONDecodeError:
-                current_app.logger.error(f"Unknown error: {ex_txt}")
+                current_app.logger.error("Unknown DataCite error", exc_info=exception)
                 return
 
             # the `errors` field is only available when a 4xx error happened (not 500)
             for error in ex_json.get("errors", []):
-                reason = error["title"]
-                field = error.get("source")  # set when missing/wrong required field
-                error_prefix = f"Error in `{field}`: " if field else "Error: "
-                current_app.logger.error(f"{error_prefix}{reason}")
+                current_app.logger.error(
+                    "DataCite error (field: %(field)s): %(reason)s",
+                    {"field": error.get("source"), "reason": error.get("title")},
+                    exc_info=exception,
+                )
 
     def generate_id(self, record, **kwargs):
         """Generate a unique DOI."""

--- a/tests/services/pids/providers/test_datacite_pid_provider.py
+++ b/tests/services/pids/providers/test_datacite_pid_provider.py
@@ -245,11 +245,19 @@ def test_datacite_provider_validation(record):
 def test_log_error_msg(app, mocker):
     """Test that error msgs are logged correctly."""
 
-    def _test(mock_fn, err, expected_msg):
+    def _test(mock_fn, err, expected_msg, expected_msg_args=None):
         DataCitePIDProvider._log_errors(err)
         mock_fn.assert_called_once()
-        _, args, _ = mock_fn.mock_calls[0]
-        assert expected_msg in args[0]  # first arg contains the exception msg
+        _, args, kwargs = mock_fn.mock_calls[0]
+        assert expected_msg == args[0]  # first arg is the logged msg
+        if expected_msg_args:  # second arg contains the msg args (if any)
+            assert len(args) == 2
+            assert expected_msg_args == args[1]
+        else:
+            assert len(args) == 1
+
+        # the error is always passed as exc_info
+        assert kwargs["exc_info"] == err
         mock_fn.reset_mock()
 
     _log_fn = (
@@ -259,18 +267,28 @@ def test_log_error_msg(app, mocker):
         _mocked_fn = mocker.patch(_log_fn)
 
         err = DataCiteError.factory(204, "")
-        _test(_mocked_fn, err, "No content error:")
+        _test(_mocked_fn, err, "DataCite no content error")
 
         err = DataCiteError.factory(500, "down")
-        _test(_mocked_fn, err, "DataCite internal server error: down")
+        _test(_mocked_fn, err, "DataCite internal server error")
 
         err = DataCiteError.factory(400, "{[")  # wrong json
-        _test(_mocked_fn, err, "Unknown error:")
+        _test(_mocked_fn, err, "Unknown DataCite error")
 
         err = DataCiteError.factory(
-            400, '{"errors": [{"source": "creator", "title": "reason"}]}'
+            400, '{"errors": [{"source": "creator", "title": "missing"}]}'
         )
-        _test(_mocked_fn, err, "Error in `creator`: reason")
+        _test(
+            _mocked_fn,
+            err,
+            "DataCite error (field: %(field)s): %(reason)s",
+            expected_msg_args={"field": "creator", "reason": "missing"},
+        )
 
         err = DataCiteError.factory(403, '{"errors": [{"title": "Unauthorized"}]}')
-        _test(_mocked_fn, err, "Error: Unauthorized")
+        _test(
+            _mocked_fn,
+            err,
+            "DataCite error (field: %(field)s): %(reason)s",
+            expected_msg_args={"field": None, "reason": "Unauthorized"},
+        )


### PR DESCRIPTION
* Avoids f-strings in logging calls so that entries are easier to be
  grouped.
* Adds exception info to the logged errors.
