### PR TITLE
deposit-ui: fix deposit form infinite recursion

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
@@ -383,7 +383,7 @@ export class RDMDepositRecordSerializer extends DepositRecordSerializer {
    *
    */
   serialize(record) {
-    // NOTE: cloning nows allows us to manipulate the copy with impunity without
+    // NOTE: cloning now allows us to manipulate the copy with impunity without
     //       affecting the original
     let originalRecord = _pick(_cloneDeep(record), [
       "access",
@@ -400,8 +400,7 @@ export class RDMDepositRecordSerializer extends DepositRecordSerializer {
     // Save pids so they are not removed when an empty value is passed
     let savedPIDsFieldValue = originalRecord.pids || {};
 
-    let serializedRecord = this._removeEmptyValues(originalRecord);
-
+    let serializedRecord = originalRecord;
     for (let key in this.depositRecordSchema) {
       serializedRecord = this.depositRecordSchema[key].serialize(
         serializedRecord,

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/serializers/SchemaField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/serializers/SchemaField.js
@@ -57,7 +57,7 @@ export class SchemaField extends Field {
    */
   serialize(deserialized, defaultLocale) {
     const fieldValues = _get(deserialized, this.fieldpath, this.serializedDefault);
-    const serializedElements = fieldValues.map((value) => {
+    const serializedElements = fieldValues?.map((value) => {
       let serializedElement = _pick(value, this.schemaKeys);
       this.schemaKeys.forEach((key) => {
         serializedElement = this.schema[key].serialize(

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
@@ -72,6 +72,7 @@ async function _saveDraft(
   try {
     response = await saveDraftWithUrlUpdate(draft, draftsService, failType);
   } catch (error) {
+    console.error("Error saving draft", error, draft);
     dispatchFn({
       type: failType,
       payload: { errors: error.errors },
@@ -180,6 +181,7 @@ export const publish = (draft, { removeSelectedCommunity = false }) => {
       const recordURL = response.data.links.self_html;
       window.location.replace(recordURL);
     } catch (error) {
+      console.error("Error publishing draft", error, draft);
       dispatch({
         type: DRAFT_PUBLISH_FAILED,
         payload: { errors: error.errors },
@@ -215,6 +217,7 @@ export const submitReview = (draft, { reviewComment, directPublish }) => {
       const nextURL = reqResponse.data.links.next_html;
       window.location.replace(nextURL);
     } catch (error) {
+      console.error("Error submitting review", error, draft);
       dispatch({
         type: DRAFT_SUBMIT_REVIEW_FAILED,
         payload: { errors: error.errors },
@@ -261,6 +264,7 @@ export const delete_ = () => {
       const redirectURL = config.config.dashboard_routes.uploads;
       window.location.replace(redirectURL);
     } catch (error) {
+      console.error("Error deleting draft", error);
       dispatch({
         type: DRAFT_DELETE_FAILED,
         payload: { errors: error.errors },
@@ -291,6 +295,7 @@ export const reservePID = (draft, { pidType }) => {
         payload: { data: response.data },
       });
     } catch (error) {
+      console.error("Error reserving PID", error, draft);
       dispatch({
         type: RESERVE_PID_FAILED,
         payload: { errors: error.errors },
@@ -321,6 +326,7 @@ export const discardPID = (draft, { pidType }) => {
         payload: { data: response.data },
       });
     } catch (error) {
+      console.error("Error discarding PID", error, draft);
       dispatch({
         type: DISCARD_PID_FAILED,
         payload: { errors: error.errors },

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
@@ -33,6 +33,7 @@ export const uploadFiles = (draft, files) => {
         config.service.files.upload(uploadFileUrl, file);
       }
     } catch (error) {
+      console.error("Error uploading files", error, draft, files);
       dispatch({
         type: FILE_UPLOAD_SAVE_DRAFT_FAILED,
         payload: { errors: error.errors },
@@ -64,6 +65,7 @@ export const deleteFile = (file) => {
           },
         });
       } else {
+        console.error("Error deleting file", error, file);
         dispatch({ type: FILE_DELETE_FAILED });
         throw error;
       }
@@ -86,6 +88,7 @@ export const importParentFiles = () => {
         payload: { files: files },
       });
     } catch (error) {
+      console.error("Error importing parent record files", error);
       dispatch({ type: FILE_IMPORT_FAILED });
       throw error;
     }


### PR DESCRIPTION
- **deposit-ui: log errors on all deposit form actions**
  * This can help with debugging unexpected non-network related errors
    that might occur in the logic before/after a REST API requests.
  

- **deposit-ui: skip unecessary removal of empty values in serialization**
  * This initial removal of empty values can be dangerous, since the
    `record` at this point is a UI object representation that could
    potentially include circular references or very deeply nested objects.
    Since `_removeEmptyValues` is recursive this can lead to stack
    overflow errors.
  