### PR TITLE
doi: handle UI for optional DOI feature

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
@@ -103,7 +103,12 @@ export class RDMDepositApiClient extends DepositApiClient {
       );
       return new DepositApiClientResponse(data, errors);
     } catch (error) {
-      const errorData = error.response.data;
+      let errorData = error.response.data;
+      const errors = this.recordSerializer.deserializeErrors(
+        error.response.data.errors || []
+      );
+      // this is to serialize raised error from the backend on publish
+      if (errors) errorData = errors;
       throw new DepositApiClientResponse({}, errorData);
     }
   }

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -391,6 +391,7 @@ RDM_PERSISTENT_IDENTIFIERS = {
         "validator": idutils.is_doi,
         "normalizer": idutils.normalize_doi,
         "is_enabled": providers.DataCitePIDProvider.is_enabled,
+        "ui": {"default_selected": "yes"},  # "yes", "no" or "not_needed"
     },
     "oai": {
         "providers": ["oai"],

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -536,9 +536,39 @@ class RDMRecord(CommonFieldsMixin, Record):
         published yet or all versions are deleted.
         """
         latest_record = cls.get_latest_by_parent(parent)
-        if latest_record.deletion_status != RecordDeletionStatusEnum.PUBLISHED.value:
+        if (
+            latest_record
+            and latest_record.deletion_status
+            != RecordDeletionStatusEnum.PUBLISHED.value
+        ):
             return None
         return latest_record
+
+    @classmethod
+    def get_previous_published_by_parent(cls, parent):
+        """Get the previous of latest published record for the specified parent record.
+
+        It might return None if there is no latest published version i.e not
+        published yet or all versions are deleted or there is only one published record.
+
+        This method is needed instead of `get_latest_published_by_parent` because during
+        publish the version state is updated before the record is actually published.
+        That means, that `get_latest_published_by_parent` returns always the record that
+        is about to be published and thus, we cannot use it in the `component.publish()`
+        method to retrieve the actual last published record.
+
+        Check `services.components.pids.PIDsComponent.publish()` for how it is used.
+        """
+        # We need no_autoflush because the record.versions access triggers automatically
+        # one
+        with db.session.no_autoflush:
+            records = cls.get_records_by_parent(parent)
+            for record in records:
+                latest_version_index = record.versions.latest_index
+                if latest_version_index > 1:
+                    if record.versions.index == latest_version_index - 1:
+                        return record
+            return None
 
 
 RDMFileRecord.record_cls = RDMRecord

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -418,7 +418,7 @@ class DataCite43Schema(BaseSerializerSchema):
                 params={"_source_includes": "pids.doi"},
             )
             for version in record_versions:
-                version_doi = version["pids"]["doi"]
+                version_doi = version.get("pids", {}).get("doi")
                 id_scheme = get_scheme_datacite(
                     "doi",
                     "RDM_RECORDS_IDENTIFIERS_SCHEMES",

--- a/tests/services/components/test_pids_component.py
+++ b/tests/services/components/test_pids_component.py
@@ -123,12 +123,11 @@ class TestServiceConfigRequiredExternalPID(RDMRecordServiceConfig):
 
 
 @pytest.fixture(scope="module")
-def no_pids_cmp():
+def no_pids_cmp(app):
+    service_config = TestServiceConfigNoPIDs.build(app)
     service = RDMRecordService(
-        config=TestServiceConfigNoPIDs,
-        pids_service=PIDsService(
-            config=TestServiceConfigNoPIDs, manager_cls=PIDManager
-        ),
+        config=service_config,
+        pids_service=PIDsService(config=service_config, manager_cls=PIDManager),
     )
     c = PIDsComponent(service=service)
     c.uow = UnitOfWork()
@@ -136,12 +135,11 @@ def no_pids_cmp():
 
 
 @pytest.fixture(scope="module")
-def no_required_pids_service():
+def no_required_pids_service(app):
+    service_config = TestServiceConfigNoRequiredPIDs.build(app)
     return RDMRecordService(
-        config=TestServiceConfigNoRequiredPIDs,
-        pids_service=PIDsService(
-            config=TestServiceConfigNoRequiredPIDs, manager_cls=PIDManager
-        ),
+        config=service_config,
+        pids_service=PIDsService(config=service_config, manager_cls=PIDManager),
     )
 
 
@@ -153,12 +151,11 @@ def no_required_pids_cmp(no_required_pids_service):
 
 
 @pytest.fixture(scope="module")
-def required_managed_pids_cmp():
+def required_managed_pids_cmp(app):
+    service_config = TestServiceConfigRequiredManagedPID.build(app)
     service = RDMRecordService(
-        config=TestServiceConfigRequiredManagedPID,
-        pids_service=PIDsService(
-            config=TestServiceConfigRequiredManagedPID, manager_cls=PIDManager
-        ),
+        config=service_config,
+        pids_service=PIDsService(config=service_config, manager_cls=PIDManager),
     )
     c = PIDsComponent(service=service)
     c.uow = UnitOfWork()
@@ -166,12 +163,11 @@ def required_managed_pids_cmp():
 
 
 @pytest.fixture(scope="module")
-def required_external_pids_cmp():
+def required_external_pids_cmp(app):
+    service_config = TestServiceConfigRequiredExternalPID.build(app)
     service = RDMRecordService(
-        config=TestServiceConfigRequiredExternalPID,
-        pids_service=PIDsService(
-            config=TestServiceConfigRequiredExternalPID, manager_cls=PIDManager
-        ),
+        config=service_config,
+        pids_service=PIDsService(config=service_config, manager_cls=PIDManager),
     )
     c = PIDsComponent(service=service)
     c.uow = UnitOfWork()
@@ -318,6 +314,7 @@ def test_publish_no_pids(no_pids_cmp, minimal_record, identity_simple, location)
     ],
 )
 def test_publish_no_required_pids(
+    app,
     pids,
     no_required_pids_service,
     no_required_pids_cmp,


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/163

If DOI is required: 
<img width="688" alt="Screenshot 2024-12-05 at 12 28 16" src="https://github.com/user-attachments/assets/5ca38539-7e15-42fd-9af9-1f79a6641098">

If DOI is not required:
<img width="848" alt="Screenshot 2024-12-05 at 12 29 07" src="https://github.com/user-attachments/assets/36d42a8c-7717-4c8c-b215-62d35202ac42">

Different options overview:
<img width="849" alt="Screenshot 2024-12-05 at 12 29 36" src="https://github.com/user-attachments/assets/48193d5c-3efb-4d8d-b648-dac751ea910d">
<img width="845" alt="Screenshot 2024-12-05 at 12 29 45" src="https://github.com/user-attachments/assets/cbd74f61-97df-4f34-9253-6981481ef537">
<img width="848" alt="Screenshot 2024-12-05 at 12 30 01" src="https://github.com/user-attachments/assets/ac6c581a-ae1d-49b4-a32b-4b8fdfb0356a">

Errors displaying that DOI was needed, but was not reserved (on publish of the draft):
<img width="1428" alt="Screenshot 2024-12-06 at 10 35 35" src="https://github.com/user-attachments/assets/4a86ee2e-7b34-412f-bf94-b31a28cff4f9">
<img width="877" alt="Screenshot 2024-12-06 at 10 35 44" src="https://github.com/user-attachments/assets/07e3b357-2a79-410f-8d3d-b14036ed46c9">

