### PR TITLE
github: map license NOASSERTION to other

### DIFF
--- a/invenio_rdm_records/services/github/metadata.py
+++ b/invenio_rdm_records/services/github/metadata.py
@@ -80,9 +80,15 @@ class RDMReleaseMetadata(object):
 
     @property
     def repo_license(self):
-        """Get license from repository, if any. Falls back to default."""
+        """Get license from repository, if any."""
         repo_license_obj = self.rdm_release.repository_payload.get("license", {})
-        return repo_license_obj.get("spdx_id") if repo_license_obj else None
+        if not repo_license_obj:
+            return None
+        spdx_id = repo_license_obj.get("spdx_id")
+        # For 'other' type of licenses, Github sets the spdx_id to NOASSERTION
+        if spdx_id == "NOASSERTION":
+            spdx_id = "other"
+        return spdx_id
 
     @property
     def contributors(self):

--- a/invenio_rdm_records/services/github/metadata.py
+++ b/invenio_rdm_records/services/github/metadata.py
@@ -87,7 +87,7 @@ class RDMReleaseMetadata(object):
         spdx_id = repo_license_obj.get("spdx_id")
         # For 'other' type of licenses, Github sets the spdx_id to NOASSERTION
         if spdx_id == "NOASSERTION":
-            spdx_id = "other"
+            return None
         return spdx_id
 
     @property


### PR DESCRIPTION
For `other` type of licenses, Github sends a payload with the SPDX ID set to `NOASSERTION`. 

```python
'license': {
   'key': 'other',
   'name': 'Other',
   'spdx_id': 'NOASSERTION',
   'url': None,
}
```