### PR TITLE
bibtex: add trailing comma in url field

### DIFF
--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -269,7 +269,7 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
         elif field == "month":
             out = "  {0:<12} = {1},\n".format(field, value)
         elif field == "url":
-            out = "  {0:<12} = {{{1}}}\n".format(field, value)
+            out = "  {0:<12} = {{{1}}},\n".format(field, value)
         else:
             if not isinstance(value, list) and value.isdigit():
                 out = "  {0:<12} = {1},\n".format(field, value)

--- a/tests/resources/serializers/test_bibtex_serializer.py
+++ b/tests/resources/serializers/test_bibtex_serializer.py
@@ -74,7 +74,7 @@ def test_bibtex_serializer_full_record(running_app, updated_full_record):
         "  publisher    = {InvenioRDM},\n"
         "  version      = {v1.0},\n"
         "  doi          = {10.1234/12345-abcde},\n"
-        "  url          = {https://doi.org/10.1234/12345-abcde}\n"
+        "  url          = {https://doi.org/10.1234/12345-abcde},\n"
         "}"
     )
 


### PR DESCRIPTION
The output of a bibtex export is wrong right now. Note the field `url` does not have a comma in the end:


```
@software{daniel_hay_guest_2024_14276439,
  author       = {Daniel Hay Guest and
                  Joshua Wyatt Smith and
                  Michela Paganini and
                  Michael Kagan and
                  Marie Lanfermann and
                  Attila Krasznahorkay and
                  Daniel Edison Marley and
                  Aishik Ghosh and
                  Benjamin Huth and
                  Matthew Feickert},
  title        = {lwtnn/lwtnn: v2.14.1},
  month        = dec,
  year         = 2024,
  publisher    = {Zenodo},
  version      = {v2.14.1},
  doi          = {10.5281/zenodo.14276439},
  url          = {https://doi.org/10.5281/zenodo.14276439}
  swhid        = {swh:1:dir:e8e8cd6fad6becd5e8b193c1148f94e023df3bae
                   ;origin=https://doi.org/10.5281/zenodo.597221;visi
                   t=swh:1:snp:fe7e271159192d7ee02e85798322462a200620
                   a1;anchor=swh:1:rel:698f80ceb7827b6d852a1bbf695eaf
                   b0fccc5079;path=/
                  },
}
```