### PR TITLE
mappings: add missing `identifiers` to community orgs

### DIFF
--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -307,6 +307,21 @@
                           },
                           "name": {
                             "type": "text"
+                          },
+                          "identifiers": {
+                            "properties": {
+                              "identifier": {
+                                "type": "text",
+                                "fields": {
+                                  "keyword": {
+                                    "type": "keyword"
+                                  }
+                                }
+                              },
+                              "scheme": {
+                                "type": "keyword"
+                              }
+                            }
                           }
                         }
                       },
@@ -499,6 +514,21 @@
                               },
                               "name": {
                                 "type": "text"
+                              },
+                              "identifiers": {
+                                "properties": {
+                                  "identifier": {
+                                    "type": "text",
+                                    "fields": {
+                                      "keyword": {
+                                        "type": "keyword"
+                                      }
+                                    }
+                                  },
+                                  "scheme": {
+                                    "type": "keyword"
+                                  }
+                                }
                               }
                             }
                           },

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -362,6 +362,21 @@
                           },
                           "name": {
                             "type": "text"
+                          },
+                          "identifiers": {
+                            "properties": {
+                              "identifier": {
+                                "type": "text",
+                                "fields": {
+                                  "keyword": {
+                                    "type": "keyword"
+                                  }
+                                }
+                              },
+                              "scheme": {
+                                "type": "keyword"
+                              }
+                            }
                           }
                         }
                       },
@@ -554,6 +569,21 @@
                               },
                               "name": {
                                 "type": "text"
+                              },
+                              "identifiers": {
+                                "properties": {
+                                  "identifier": {
+                                    "type": "text",
+                                    "fields": {
+                                      "keyword": {
+                                        "type": "keyword"
+                                      }
+                                    }
+                                  },
+                                  "scheme": {
+                                    "type": "keyword"
+                                  }
+                                }
                               }
                             }
                           },

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -307,6 +307,21 @@
                           },
                           "name": {
                             "type": "text"
+                          },
+                          "identifiers": {
+                            "properties": {
+                              "identifier": {
+                                "type": "text",
+                                "fields": {
+                                  "keyword": {
+                                    "type": "keyword"
+                                  }
+                                }
+                              },
+                              "scheme": {
+                                "type": "keyword"
+                              }
+                            }
                           }
                         }
                       },
@@ -499,6 +514,21 @@
                               },
                               "name": {
                                 "type": "text"
+                              },
+                              "identifiers": {
+                                "properties": {
+                                  "identifier": {
+                                    "type": "text",
+                                    "fields": {
+                                      "keyword": {
+                                        "type": "keyword"
+                                      }
+                                    }
+                                  },
+                                  "scheme": {
+                                    "type": "keyword"
+                                  }
+                                }
                               }
                             }
                           },

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -362,6 +362,21 @@
                           },
                           "name": {
                             "type": "text"
+                          },
+                          "identifiers": {
+                            "properties": {
+                              "identifier": {
+                                "type": "text",
+                                "fields": {
+                                  "keyword": {
+                                    "type": "keyword"
+                                  }
+                                }
+                              },
+                              "scheme": {
+                                "type": "keyword"
+                              }
+                            }
                           }
                         }
                       },
@@ -554,6 +569,21 @@
                               },
                               "name": {
                                 "type": "text"
+                              },
+                              "identifiers": {
+                                "properties": {
+                                  "identifier": {
+                                    "type": "text",
+                                    "fields": {
+                                      "keyword": {
+                                        "type": "keyword"
+                                      }
+                                    }
+                                  },
+                                  "scheme": {
+                                    "type": "keyword"
+                                  }
+                                }
                               }
                             }
                           },


### PR DESCRIPTION
* Closes https://github.com/inveniosoftware/invenio-communities/issues/1264
* Adds the missing `identifiers` mapping field to community
  organizations.
