### PR TITLE
serializers: bibtex: Conference proceeding to proceedings

### DIFF
--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -48,6 +48,7 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
             BibTexFormatter.in_proceedings,
             BibTexFormatter.proceedings,
         ],
+        "publication-conferenceproceeding": [BibTexFormatter.proceedings],
         "publication-book": [
             BibTexFormatter.book,
             BibTexFormatter.booklet,

--- a/tests/resources/serializers/test_bibtex_serializer.py
+++ b/tests/resources/serializers/test_bibtex_serializer.py
@@ -87,7 +87,6 @@ def test_bibtex_serializer_full_record(running_app, updated_full_record):
         ("publication"),
         ("publication-annotationcollection"),
         ("publication-section"),
-        ("publication-conferenceproceeding"),
         ("publication-datamanagementplan"),
         ("publication-journal"),
         ("publication-patent"),
@@ -194,6 +193,34 @@ def test_serialize_publication_conferencepaper(running_app, updated_minimal_reco
             "}",
         ]
     )
+
+
+def test_serialize_publication_conferenceproceeding(
+    running_app, updated_minimal_record
+):
+    """Test bibtex formatter for conference proceedings.
+
+    It serializes into 'proceedings'.
+    """
+    updated_minimal_record["metadata"]["resource_type"][
+        "id"
+    ] = "publication-conferenceproceeding"
+
+    serializer = BibtexSerializer()
+    serialized_record = serializer.serialize_object(updated_minimal_record)
+
+    expected_data = "\n".join(
+        [
+            "@proceedings{brown_2023_abcde-fghij,",
+            "  title        = {A Romans story},",
+            "  year         = 2023,",
+            "  publisher    = {Acme Inc},",
+            "  month        = mar,",
+            "}",
+        ]
+    )
+
+    assert serialized_record == expected_data
 
 
 def test_serialize_publication_book(running_app, updated_minimal_record):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #1914 
* See description in linked issue

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
