### PR TITLE
serializers: bibtex: Conference paper not falling back to proceedings

### DIFF
--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -48,10 +48,7 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
 
     entry_mapper = {
         # Publication fields
-        "publication-conferencepaper": [
-            BibTexFormatter.in_proceedings,
-            BibTexFormatter.proceedings,
-        ],
+        "publication-conferencepaper": [BibTexFormatter.in_proceedings],
         "publication-conferenceproceeding": [BibTexFormatter.proceedings],
         "publication-book": [
             BibTexFormatter.book,

--- a/tests/resources/serializers/test_bibtex_serializer.py
+++ b/tests/resources/serializers/test_bibtex_serializer.py
@@ -150,7 +150,7 @@ def test_serialize_publication_conferencepaper(running_app, updated_minimal_reco
     It serializes into the following formats, depending on the data:
 
     - inproceedings
-    - proceedings
+    - misc
     """
     updated_minimal_record["metadata"]["resource_type"][
         "id"
@@ -179,22 +179,24 @@ def test_serialize_publication_conferencepaper(running_app, updated_minimal_reco
 
     assert serialized_record == expected_data
 
-    # Force serialization into 'proceedings'
+    # Force serialization into 'misc'
     del updated_minimal_record["custom_fields"]["imprint:imprint"]
     serialized_record = serializer.serialize_object(updated_minimal_record)
 
     expected_data = "\n".join(
         [
-            "@proceedings{brown_2023_abcde-fghij,",
+            "@misc{brown_2023_abcde-fghij,",
             "  author       = {Name and",
             "                  Troy Inc.},",
             "  title        = {A Romans story},",
+            "  month        = mar,",
             "  year         = 2023,",
             "  publisher    = {Acme Inc},",
-            "  month        = mar,",
             "}",
         ]
     )
+
+    assert serialized_record == expected_data
 
 
 def test_serialize_publication_conferenceproceeding(


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes #1916 
* See description in linked issue


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
