### PR TITLE
deposit-ui: fix affiliation selection input display

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AffiliationsField/AffiliationsField.js
@@ -54,7 +54,7 @@ export class AffiliationsField extends Component {
                 );
               }}
               value={getIn(values, fieldPath, []).map(
-                (val) => val.id || val.name || val.text
+                ({ id, name, text }) => id ?? name ?? text
               )}
               ref={selectRef}
               // Disable UI-side filtering of search results

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
@@ -267,10 +267,10 @@ export class CreatibutorsModal extends Component {
     });
 
     // Update affiliations render
-    const affiliationsState = affiliations.map(({ name }) => ({
+    const affiliationsState = affiliations.map(({ id, name }) => ({
       text: name,
-      value: name,
-      key: name,
+      value: id ?? name,
+      key: id ?? name,
       name,
     }));
     affiliationsRef.current.setState({


### PR DESCRIPTION
* Fixes an bug where names selected from the search box don't get
  their affiliations displayed in the modal (even though the values are
  persisted in the form's data/state).
