### PR TITLE
config: Remove bdist_wheel.universal = 1 from setup.cfg and stray quote

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/AccessMessage.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/AccessField/components/AccessMessage.js
@@ -53,7 +53,7 @@ export const AccessMessage = ({ access, metadataOnly, accessCommunity }) => {
           <Trans i18nKey="access-message">
             On <b>{fmtDate}</b> the record will automatically be made publicly
             accessible. Until then, the record can <b>only</b> be accessed by{" "}
-            <b>users specified</b> in the permissions."
+            <b>users specified</b> in the permissions.
           </Trans>
         </Message.Content>
       </Message>

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,9 +145,6 @@ source-dir = docs/
 build-dir = docs/_build
 all_files = 1
 
-[bdist_wheel]
-universal = 1
-
 [pydocstyle]
 add_ignore = D401,D403
 


### PR DESCRIPTION
### Description

```
[bdist.wheel]
universal = 1
```

is for when the project supports Python 2 and contains no C extensions (see [here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#wheels))
 
but

`python_requires = >=3.7`

the PR also removes a stray flag from a frontend message

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
