### PR TITLE
services: proper escape the fiels key in links generation

### DIFF
--- a/invenio_rdm_records/services/communities/components.py
+++ b/invenio_rdm_records/services/communities/components.py
@@ -8,7 +8,9 @@
 """Record communities service components."""
 
 from invenio_communities.communities.records.systemfields.access import VisibilityEnum
-from invenio_communities.communities.services.components import ChildrenComponent
+from invenio_communities.communities.services.components import (
+    ChildrenComponent,
+)
 from invenio_communities.communities.services.components import (
     CommunityAccessComponent as BaseAccessComponent,
 )

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -324,16 +324,14 @@ class RDMFileRecordServiceConfig(FileServiceConfig, ConfiguratorMixin):
         **FileServiceConfig.file_links_item,
         # FIXME: filename instead
         "iiif_canvas": FileLink(
-            "{+api}/iiif/record:{id}/canvas/{+key}", when=is_iiif_compatible
+            "{+api}/iiif/record:{id}/canvas/{key}", when=is_iiif_compatible
         ),
-        "iiif_base": FileLink(
-            "{+api}/iiif/record:{id}:{+key}", when=is_iiif_compatible
-        ),
+        "iiif_base": FileLink("{+api}/iiif/record:{id}:{key}", when=is_iiif_compatible),
         "iiif_info": FileLink(
-            "{+api}/iiif/record:{id}:{+key}/info.json", when=is_iiif_compatible
+            "{+api}/iiif/record:{id}:{key}/info.json", when=is_iiif_compatible
         ),
         "iiif_api": FileLink(
-            "{+api}/iiif/record:{id}:{+key}/{region=full}"
+            "{+api}/iiif/record:{id}:{key}/{region=full}"
             "/{size=full}/{rotation=0}/{quality=default}.{format=png}",
             when=is_iiif_compatible,
         ),
@@ -695,16 +693,14 @@ class RDMMediaFileRecordServiceConfig(FileServiceConfig, ConfiguratorMixin):
         "self": FileLink("{+api}/records/{id}/media-files/{key}"),
         "content": FileLink("{+api}/records/{id}/media-files/{key}/content"),
         "iiif_canvas": FileLink(
-            "{+api}/iiif/record:{id}/canvas/{+key}", when=is_iiif_compatible
+            "{+api}/iiif/record:{id}/canvas/{key}", when=is_iiif_compatible
         ),
-        "iiif_base": FileLink(
-            "{+api}/iiif/record:{id}:{+key}", when=is_iiif_compatible
-        ),
+        "iiif_base": FileLink("{+api}/iiif/record:{id}:{key}", when=is_iiif_compatible),
         "iiif_info": FileLink(
-            "{+api}/iiif/record:{id}:{+key}/info.json", when=is_iiif_compatible
+            "{+api}/iiif/record:{id}:{key}/info.json", when=is_iiif_compatible
         ),
         "iiif_api": FileLink(
-            "{+api}/iiif/record:{id}:{+key}/{region=full}"
+            "{+api}/iiif/record:{id}:{key}/{region=full}"
             "/{size=full}/{rotation=0}/{quality=default}.{format=png}",
             when=is_iiif_compatible,
         ),
@@ -736,19 +732,19 @@ class RDMFileDraftServiceConfig(FileServiceConfig, ConfiguratorMixin):
     }
 
     file_links_item = {
-        "self": FileLink("{+api}/records/{id}/draft/files/{+key}"),
-        "content": FileLink("{+api}/records/{id}/draft/files/{+key}/content"),
-        "commit": FileLink("{+api}/records/{id}/draft/files/{+key}/commit"),
+        "self": FileLink("{+api}/records/{id}/draft/files/{key}"),
+        "content": FileLink("{+api}/records/{id}/draft/files/{key}/content"),
+        "commit": FileLink("{+api}/records/{id}/draft/files/{key}/commit"),
         # FIXME: filename instead
         "iiif_canvas": FileLink(
-            "{+api}/iiif/draft:{id}/canvas/{+key}", when=is_iiif_compatible
+            "{+api}/iiif/draft:{id}/canvas/{key}", when=is_iiif_compatible
         ),
-        "iiif_base": FileLink("{+api}/iiif/draft:{id}:{+key}", when=is_iiif_compatible),
+        "iiif_base": FileLink("{+api}/iiif/draft:{id}:{key}", when=is_iiif_compatible),
         "iiif_info": FileLink(
-            "{+api}/iiif/draft:{id}:{+key}/info.json", when=is_iiif_compatible
+            "{+api}/iiif/draft:{id}:{key}/info.json", when=is_iiif_compatible
         ),
         "iiif_api": FileLink(
-            "{+api}/iiif/draft:{id}:{+key}/{region=full}"
+            "{+api}/iiif/draft:{id}:{key}/{region=full}"
             "/{size=full}/{rotation=0}/{quality=default}.{format=png}",
             when=is_iiif_compatible,
         ),
@@ -787,14 +783,14 @@ class RDMMediaFileDraftServiceConfig(FileServiceConfig, ConfiguratorMixin):
         "content": FileLink("{+api}/records/{id}/draft/media-files/{key}/content"),
         "commit": FileLink("{+api}/records/{id}/draft/media-files/{key}/commit"),
         "iiif_canvas": FileLink(
-            "{+api}/iiif/draft:{id}/canvas/{+key}", when=is_iiif_compatible
+            "{+api}/iiif/draft:{id}/canvas/{key}", when=is_iiif_compatible
         ),
-        "iiif_base": FileLink("{+api}/iiif/draft:{id}:{+key}", when=is_iiif_compatible),
+        "iiif_base": FileLink("{+api}/iiif/draft:{id}:{key}", when=is_iiif_compatible),
         "iiif_info": FileLink(
-            "{+api}/iiif/draft:{id}:{+key}/info.json", when=is_iiif_compatible
+            "{+api}/iiif/draft:{id}:{key}/info.json", when=is_iiif_compatible
         ),
         "iiif_api": FileLink(
-            "{+api}/iiif/draft:{id}:{+key}/{region=full}"
+            "{+api}/iiif/draft:{id}:{key}/{region=full}"
             "/{size=full}/{rotation=0}/{quality=default}.{format=png}",
             when=is_iiif_compatible,
         ),

--- a/tests/resources/test_iiif_image_api.py
+++ b/tests/resources/test_iiif_image_api.py
@@ -6,6 +6,7 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 
 from io import BytesIO
+from urllib.parse import quote
 
 import dictdiffer
 from PIL import Image
@@ -96,12 +97,13 @@ def test_iiif_base(
     ## Testing with filename with a slash ##
 
     file_id = "test/image.png"
+    encoded_file_id = quote(file_id, safe="")
     recid = publish_record_with_images(client, file_id, minimal_record, headers)
     response = client.get(f"/iiif/record:{recid}:{file_id}")
     assert response.status_code == 301
     assert (
         response.json["location"]
-        == f"https://127.0.0.1:5000/api/iiif/record:{recid}:{file_id}/info.json"
+        == f"https://127.0.0.1:5000/api/iiif/record:{recid}:{encoded_file_id}/info.json"
     )
 
 
@@ -131,6 +133,7 @@ def test_iiif_info(
     ## Testing with filename with a slash ##
 
     file_id = "test/image.png"
+    encoded_file_id = quote(file_id, safe="")
     recid = publish_record_with_images(client, file_id, minimal_record, headers)
     response = client.get(f"/iiif/record:{recid}:{file_id}/info.json")
     assert response.status_code == 200
@@ -138,7 +141,7 @@ def test_iiif_info(
         "@context": "http://iiif.io/api/image/2/context.json",
         "profile": ["http://iiif.io/api/image/2/level2.json"],
         "protocol": "http://iiif.io/api/image",
-        "@id": f"https://127.0.0.1:5000/api/iiif/record:{recid}:{file_id}",
+        "@id": f"https://127.0.0.1:5000/api/iiif/record:{recid}:{encoded_file_id}",
         "tiles": [{"width": 256, "scaleFactors": [1, 2, 4, 8, 16, 32, 64]}],
         "width": 1280,
         "height": 1024,

--- a/tests/services/schemas/test_version.py
+++ b/tests/services/schemas/test_version.py
@@ -13,7 +13,7 @@ from marshmallow import ValidationError
 from invenio_rdm_records.services.schemas.metadata import MetadataSchema
 
 
-@pytest.mark.parametrize("version", [("v1.0.0")])
+@pytest.mark.parametrize("version", ["v1.0.0"])
 def test_valid_version(version, app, minimal_record):
     metadata = minimal_record["metadata"]
     metadata["version"] = version


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/320
* closes https://github.com/inveniosoftware/rfcs/issues/88

 {+key} was keeping special characters unescaped by uritemplate

Tested locally upload of files within a directory, it seems to work fine.