### PR TITLE
IIIF: info request not being proxied

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -321,7 +321,7 @@ class IIIFProxy(ABC):
         """
         return request.endpoint in (
             "iiif.image_api",
-            "iiif.image_info",
+            "iiif.info",
             # TODO: `image_base` would redirect to the info endpoint, but we should make
             #       sure the proxy does this correctly, preserving the original path.
             # "iiif.image_base",


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

I notcied that IIIF info requests are not being proxied, this is due to the wrong value of request.endpoint being checked in should_proxy(). 

Additionally, I don't see any issues in our testing with enabling the (currently commented out) iiif.image_base - which also works when corrected to iiif.base. I will update this PR switching that on if no objections? 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
