### PR TITLE
IfRecordDeleted: a more precise query for deletion status

### DIFF
--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -160,21 +160,21 @@ class IfRecordDeleted(Generator):
 
     def query_filter(self, **kwargs):
         """Filters for current identity."""
-        q_then = dsl.Q("match_all")
-        q_else = dsl.Q(
+        q_record_not_deleted = dsl.Q(
             "term", **{"deletion_status": RecordDeletionStatusEnum.PUBLISHED.value}
         )
+        q_record_deleted = ~q_record_not_deleted
         then_query = self.make_query(self.then_, **kwargs)
         else_query = self.make_query(self.else_, **kwargs)
 
         if then_query and else_query:
-            return (q_then & then_query) | (q_else & else_query)
+            return (q_record_deleted & then_query) | (q_record_not_deleted & else_query)
         elif then_query:
-            return (q_then & then_query) | q_else
+            return (q_record_deleted & then_query) | q_record_not_deleted
         elif else_query:
-            return q_else & else_query
+            return q_record_not_deleted & else_query
         else:
-            return q_else
+            return q_record_not_deleted
 
 
 class RecordOwners(Generator):


### PR DESCRIPTION
### Description

The query_filter of `IfRecordDeleted(then_, else_)` is implemented as:

`(match_all & then_) | (if not deleted & else_)` which simplifies to `then_ | (if not deleted & else_)`

This implementation can be confusing because the `then_` branch is always applied, regardless of the record's deletion status. A more consistent implementation, proposed in this pull request, changes this to:

`(if deleted & then_) | (if not deleted & else_)`

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
