### PR TITLE
added overridable blocks and passing serializing functions as props

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsField.js
@@ -12,10 +12,8 @@ import { getIn, FieldArray } from "formik";
 import { Button, Form, List, Icon } from "semantic-ui-react";
 import _get from "lodash/get";
 import { FeedbackLabel, FieldLabel } from "react-invenio-forms";
-
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { DndProvider } from "react-dnd";
-
 import { CreatibutorsModal } from "./CreatibutorsModal";
 import { CreatibutorsFieldItem } from "./CreatibutorsFieldItem";
 import { CREATIBUTOR_TYPE } from "./type";
@@ -63,6 +61,9 @@ class CreatibutorsFieldForm extends Component {
       modal,
       autocompleteNames,
       addButtonLabel,
+      serializeSuggestions,
+      serializeCreatibutor,
+      deserializeCreatibutor,
     } = this.props;
 
     const creatibutorsList = getIn(values, fieldPath, []);
@@ -123,6 +124,9 @@ class CreatibutorsFieldForm extends Component {
                     addLabel: modal.addLabel,
                     editLabel: modal.editLabel,
                     autocompleteNames: autocompleteNames,
+                    serializeSuggestions: serializeSuggestions,
+                    serializeCreatibutor: serializeCreatibutor,
+                    deserializeCreatibutor: deserializeCreatibutor,
                   }}
                 />
               );
@@ -183,6 +187,9 @@ CreatibutorsFieldForm.propTypes = {
   move: PropTypes.func.isRequired,
   push: PropTypes.func.isRequired,
   name: PropTypes.string.isRequired,
+  serializeSuggestions: PropTypes.func,
+  serializeCreatibutor: PropTypes.func,
+  deserializeCreatibutor: PropTypes.func,
 };
 
 CreatibutorsFieldForm.defaultProps = {
@@ -194,6 +201,9 @@ CreatibutorsFieldForm.defaultProps = {
     editLabel: i18next.t("Edit creator"),
   },
   addButtonLabel: i18next.t("Add creator"),
+  serializeSuggestions: undefined,
+  serializeCreatibutor: undefined,
+  deserializeCreatibutor: undefined,
 };
 
 CreatibutorsField.propTypes = {
@@ -208,6 +218,9 @@ CreatibutorsField.propTypes = {
   label: PropTypes.string,
   labelIcon: PropTypes.string,
   roleOptions: PropTypes.array,
+  serializeSuggestions: PropTypes.func,
+  serializeCreatibutor: PropTypes.func,
+  deserializeCreatibutor: PropTypes.func,
 };
 
 CreatibutorsField.defaultProps = {
@@ -220,4 +233,7 @@ CreatibutorsField.defaultProps = {
     editLabel: i18next.t("Edit creator"),
   },
   addButtonLabel: i18next.t("Add creator"),
+  serializeSuggestions: undefined,
+  serializeCreatibutor: undefined,
+  deserializeCreatibutor: undefined,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsFieldItem.js
@@ -30,6 +30,9 @@ export const CreatibutorsFieldItem = ({
   roleOptions,
   schema,
   autocompleteNames,
+  serializeSuggestions,
+  serializeCreatibutor,
+  deserializeCreatibutor,
 }) => {
   const dropRef = React.useRef(null);
   // eslint-disable-next-line no-unused-vars
@@ -94,6 +97,9 @@ export const CreatibutorsFieldItem = ({
                 {i18next.t("Edit")}
               </Button>
             }
+            serializeSuggestions={serializeSuggestions}
+            serializeCreatibutor={serializeCreatibutor}
+            deserializeCreatibutor={deserializeCreatibutor}
           />
           <Button size="mini" type="button" onClick={() => removeCreatibutor(index)}>
             {i18next.t("Remove")}
@@ -166,6 +172,9 @@ CreatibutorsFieldItem.propTypes = {
   roleOptions: PropTypes.array.isRequired,
   schema: PropTypes.string.isRequired,
   autocompleteNames: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  serializeSuggestions: PropTypes.func,
+  serializeCreatibutor: PropTypes.func,
+  deserializeCreatibutor: PropTypes.func,
 };
 
 CreatibutorsFieldItem.defaultProps = {
@@ -174,4 +183,7 @@ CreatibutorsFieldItem.defaultProps = {
   editLabel: undefined,
   displayName: undefined,
   autocompleteNames: undefined,
+  serializeSuggestions: undefined,
+  serializeCreatibutor: undefined,
+  deserializeCreatibutor: undefined,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsModal.js
@@ -27,6 +27,7 @@ import * as Yup from "yup";
 import { AffiliationsField } from "./../AffiliationsField";
 import { CreatibutorsIdentifiers } from "./CreatibutorsIdentifiers";
 import { CREATIBUTOR_TYPE } from "./type";
+import Overridable from "react-overridable";
 
 const ModalActions = {
   ADD: "add",
@@ -150,7 +151,10 @@ export class CreatibutorsModal extends Component {
    * back to the external format.
    */
   serializeCreatibutor = (submittedCreatibutor) => {
-    const { initialCreatibutor } = this.props;
+    const { initialCreatibutor, serializeCreatibutor } = this.props;
+    if (serializeCreatibutor) {
+      return serializeCreatibutor(submittedCreatibutor, initialCreatibutor);
+    }
     const findField = (arrayField, key, value) => {
       const knownField = _find(arrayField, {
         [key]: value,
@@ -188,6 +192,10 @@ export class CreatibutorsModal extends Component {
    * array of strings as values.
    */
   deserializeCreatibutor = (initialCreatibutor) => {
+    const { deserializeCreatibutor } = this.props;
+    if (deserializeCreatibutor) {
+      return deserializeCreatibutor(initialCreatibutor);
+    }
     const identifiersFieldPath = "person_or_org.identifiers";
 
     return {
@@ -357,8 +365,14 @@ export class CreatibutorsModal extends Component {
   };
 
   render() {
-    const { initialCreatibutor, autocompleteNames, roleOptions, trigger, action } =
-      this.props;
+    const {
+      initialCreatibutor,
+      autocompleteNames,
+      roleOptions,
+      trigger,
+      action,
+      serializeSuggestions,
+    } = this.props;
     const {
       open,
       showPersonForm,
@@ -463,133 +477,203 @@ export class CreatibutorsModal extends Component {
                   {_get(values, typeFieldPath, "") === CREATIBUTOR_TYPE.PERSON ? (
                     <>
                       {autocompleteNames !== NamesAutocompleteOptions.OFF && (
-                        <RemoteSelectField
-                          selectOnBlur={false}
-                          selectOnNavigation={false}
-                          searchInput={{
-                            autoFocus: _isEmpty(initialCreatibutor),
-                          }}
-                          fieldPath="creators"
-                          clearable
-                          multiple={false}
-                          allowAdditions={false}
-                          placeholder={i18next.t(
-                            "Search for persons by name, identifier, or affiliation..."
-                          )}
-                          noQueryMessage={i18next.t(
-                            "Search for persons by name, identifier, or affiliation..."
-                          )}
-                          required={false}
-                          // Disable UI-side filtering of search results
-                          search={(options) => options}
-                          suggestionAPIUrl="/api/names"
-                          serializeSuggestions={this.serializeSuggestions}
+                        <Overridable
+                          id="InvenioRDMRecords.CreatibutorsModal.PersonRemoteSelectField.container"
+                          initialCreatibutor={initialCreatibutor}
+                          serializeSuggestions={
+                            serializeSuggestions || this.serializeSuggestions
+                          }
                           onValueChange={this.onPersonSearchChange}
                           ref={this.namesAutocompleteRef}
-                        />
+                        >
+                          <RemoteSelectField
+                            selectOnBlur={false}
+                            selectOnNavigation={false}
+                            searchInput={{
+                              autoFocus: _isEmpty(initialCreatibutor),
+                            }}
+                            fieldPath="creators"
+                            clearable
+                            multiple={false}
+                            allowAdditions={false}
+                            placeholder={i18next.t(
+                              "Search for persons by name, identifier, or affiliation..."
+                            )}
+                            noQueryMessage={i18next.t(
+                              "Search for persons by name, identifier, or affiliation..."
+                            )}
+                            required={false}
+                            // Disable UI-side filtering of search results
+                            search={(options) => options}
+                            suggestionAPIUrl="/api/names"
+                            serializeSuggestions={
+                              serializeSuggestions || this.serializeSuggestions
+                            }
+                            onValueChange={this.onPersonSearchChange}
+                            ref={this.namesAutocompleteRef}
+                          />
+                        </Overridable>
                       )}
                       {showPersonForm && (
                         <>
-                          <Form.Group widths="equal">
-                            <TextField
-                              label={i18next.t("Family name")}
-                              placeholder={i18next.t("Family name")}
-                              fieldPath={familyNameFieldPath}
-                              required={this.isCreator()}
-                            />
-                            <TextField
-                              label={i18next.t("Given names")}
-                              placeholder={i18next.t("Given names")}
-                              fieldPath={givenNameFieldPath}
-                            />
-                          </Form.Group>
-                          <CreatibutorsIdentifiers
-                            initialOptions={_map(
-                              _get(values, identifiersFieldPath, []),
-                              (identifier) => ({
-                                text: identifier,
-                                value: identifier,
-                                key: identifier,
-                              })
-                            )}
-                            fieldPath={identifiersFieldPath}
+                          <Overridable
+                            id="InvenioRDMRecords.CreatibutorsModal.FullNameField.container"
+                            familyNameFieldPath={familyNameFieldPath}
+                            givenNameFieldPath={givenNameFieldPath}
+                            isCreator={this.isCreator()}
+                          >
+                            <Form.Group widths="equal">
+                              <TextField
+                                label={i18next.t("Family name")}
+                                placeholder={i18next.t("Family name")}
+                                fieldPath={familyNameFieldPath}
+                                required={this.isCreator()}
+                              />
+                              <TextField
+                                label={i18next.t("Given names")}
+                                placeholder={i18next.t("Given names")}
+                                fieldPath={givenNameFieldPath}
+                              />
+                            </Form.Group>
+                          </Overridable>
+                          <Overridable
+                            id="InvenioRDMRecords.CreatibutorsModal.PersonIdentifiersField.container"
                             ref={this.identifiersRef}
-                          />
-                          <AffiliationsField
+                            fieldPath={identifiersFieldPath}
+                            values={values}
+                          >
+                            <CreatibutorsIdentifiers
+                              initialOptions={_map(
+                                _get(values, identifiersFieldPath, []),
+                                (identifier) => ({
+                                  text: identifier,
+                                  value: identifier,
+                                  key: identifier,
+                                })
+                              )}
+                              fieldPath={identifiersFieldPath}
+                              ref={this.identifiersRef}
+                            />
+                          </Overridable>
+                          <Overridable
+                            id="InvenioRDMRecords.CreatibutorsModal.PersonAffiliationsField.container"
+                            ref={this.affiliationsRef}
                             fieldPath={affiliationsFieldPath}
-                            selectRef={this.affiliationsRef}
-                          />
+                          >
+                            <AffiliationsField
+                              fieldPath={affiliationsFieldPath}
+                              selectRef={this.affiliationsRef}
+                            />
+                          </Overridable>
                         </>
                       )}
                     </>
                   ) : (
                     <>
                       {autocompleteNames !== NamesAutocompleteOptions.OFF && (
-                        <RemoteSelectField
-                          selectOnBlur={false}
-                          selectOnNavigation={false}
-                          searchInput={{
-                            autoFocus: _isEmpty(initialCreatibutor),
-                          }}
-                          fieldPath="creators"
-                          clearable
-                          multiple={false}
-                          allowAdditions={false}
-                          placeholder={i18next.t(
-                            "Search for an organization by name, identifier, or affiliation..."
-                          )}
-                          noQueryMessage={i18next.t(
-                            "Search for organization by name, identifier, or affiliation..."
-                          )}
-                          required={false}
-                          // Disable UI-side filtering of search results
-                          search={(options) => options}
-                          suggestionAPIUrl="/api/affiliations"
-                          serializeSuggestions={this.serializeSuggestions}
+                        <Overridable
+                          id="InvenioRDMRecords.CreatibutorsModal.OrganizationRemoteSelectField.container"
+                          initialCreatibutor={initialCreatibutor}
+                          serializeSuggestions={
+                            serializeSuggestions || this.serializeSuggestions
+                          }
                           onValueChange={this.onOrganizationSearchChange}
-                        />
+                        >
+                          <RemoteSelectField
+                            selectOnBlur={false}
+                            selectOnNavigation={false}
+                            searchInput={{
+                              autoFocus: _isEmpty(initialCreatibutor),
+                            }}
+                            fieldPath="creators"
+                            clearable
+                            multiple={false}
+                            allowAdditions={false}
+                            placeholder={i18next.t(
+                              "Search for an organization by name, identifier, or affiliation..."
+                            )}
+                            noQueryMessage={i18next.t(
+                              "Search for organization by name, identifier, or affiliation..."
+                            )}
+                            required={false}
+                            // Disable UI-side filtering of search results
+                            search={(options) => options}
+                            suggestionAPIUrl="/api/affiliations"
+                            serializeSuggestions={
+                              serializeSuggestions || this.serializeSuggestions
+                            }
+                            onValueChange={this.onOrganizationSearchChange}
+                          />
+                        </Overridable>
                       )}
-                      <TextField
-                        label={i18next.t("Name")}
-                        placeholder={i18next.t("Organization name")}
+                      <Overridable
+                        id="InvenioRDMRecords.CreatibutorsModal.OrganizationNameField.container"
                         fieldPath={organizationNameFieldPath}
-                        required={this.isCreator()}
-                        // forward ref to Input component because Form.Input
-                        // doesn't handle it
-                        input={{ ref: this.inputRef }}
-                      />
-                      <CreatibutorsIdentifiers
-                        initialOptions={_map(
-                          _get(values, identifiersFieldPath, []),
-                          (identifier) => ({
-                            text: identifier,
-                            value: identifier,
-                            key: identifier,
-                          })
-                        )}
-                        fieldPath={identifiersFieldPath}
+                        ref={this.inputRef}
+                        isCreator={this.isCreator()}
+                      >
+                        <TextField
+                          label={i18next.t("Name")}
+                          placeholder={i18next.t("Organization name")}
+                          fieldPath={organizationNameFieldPath}
+                          required={this.isCreator()}
+                          // forward ref to Input component because Form.Input
+                          // doesn't handle it
+                          input={{ ref: this.inputRef }}
+                        />
+                      </Overridable>
+                      <Overridable
+                        id="InvenioRDMRecords.CreatibutorsModal.OrganizationIdentifiersField.container"
                         ref={this.identifiersRef}
-                        placeholder={i18next.t("e.g. ROR, ISNI or GND.")}
-                      />
-                      <AffiliationsField
+                        values={values}
+                        fieldPath={identifiersFieldPath}
+                      >
+                        <CreatibutorsIdentifiers
+                          initialOptions={_map(
+                            _get(values, identifiersFieldPath, []),
+                            (identifier) => ({
+                              text: identifier,
+                              value: identifier,
+                              key: identifier,
+                            })
+                          )}
+                          fieldPath={identifiersFieldPath}
+                          ref={this.identifiersRef}
+                          placeholder={i18next.t("e.g. ROR, ISNI or GND.")}
+                        />
+                      </Overridable>
+                      <Overridable
+                        id="InvenioRDMRecords.CreatibutorsModal.OrganizationAffiliationsField.container"
                         fieldPath={affiliationsFieldPath}
-                        selectRef={this.affiliationsRef}
-                      />
+                        ref={this.affiliationsRef}
+                      >
+                        <AffiliationsField
+                          fieldPath={affiliationsFieldPath}
+                          selectRef={this.affiliationsRef}
+                        />
+                      </Overridable>
                     </>
                   )}
                   {(_get(values, typeFieldPath) === CREATIBUTOR_TYPE.ORGANIZATION ||
                     (showPersonForm &&
                       _get(values, typeFieldPath) === CREATIBUTOR_TYPE.PERSON)) && (
-                    <SelectField
+                    <Overridable
+                      id="InvenioRDMRecords.CreatibutorsModal.RoleSelectField.container"
                       fieldPath={roleFieldPath}
-                      label={i18next.t("Role")}
-                      options={roleOptions}
-                      placeholder={i18next.t("Select role")}
-                      {...(this.isCreator() && { clearable: true })}
-                      required={!this.isCreator()}
-                      optimized
-                      scrolling
-                    />
+                      roleOptions={roleOptions}
+                      isCreator={this.isCreator()}
+                    >
+                      <SelectField
+                        fieldPath={roleFieldPath}
+                        label={i18next.t("Role")}
+                        options={roleOptions}
+                        placeholder={i18next.t("Select role")}
+                        {...(this.isCreator() && { clearable: true })}
+                        required={!this.isCreator()}
+                        optimized
+                        scrolling
+                      />
+                    </Overridable>
                   )}
                 </Form>
               </Modal.Content>
@@ -675,10 +759,16 @@ CreatibutorsModal.propTypes = {
   trigger: PropTypes.object.isRequired,
   onCreatibutorChange: PropTypes.func.isRequired,
   roleOptions: PropTypes.array,
+  serializeSuggestions: PropTypes.func,
+  serializeCreatibutor: PropTypes.func,
+  deserializeCreatibutor: PropTypes.func,
 };
 
 CreatibutorsModal.defaultProps = {
   roleOptions: [],
   initialCreatibutor: {},
   autocompleteNames: "search",
+  serializeSuggestions: undefined,
+  serializeCreatibutor: undefined,
+  deserializeCreatibutor: undefined,
 };


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

We would like to use the creatibutor component for our apps as well. Generally, we really like the look/functionality. We only have small issue, because it is not possible to make any, relevant customizations. This PR keeps 100% the current behavior of the app. The only change is:

1. Added overridable blocks (for our case, certain things as affiliations for the Organizational type of creatibutors does not make sense).
2. Passing three functions as props (to serializeSuggestions, and to serialize and deserialize creatibutors). These are by default undefined and the ones already existing are used by default. 
The issue can be for example, we have more types of identifiers and also our static folder might have different structure (for icons and such).

We would really appreciate if you would consider merging this. I think it could be beneficial also for other users/partners of invenio.

Please let us know and thank you!

Dusan Stojanovic (CESNET).




