### PR TITLE
deposit-ui: creatibutors: support general new error format with severity

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CreatibutorsField/CreatibutorsField.js
@@ -9,9 +9,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { getIn, FieldArray } from "formik";
-import { Button, Form, Label, List, Icon } from "semantic-ui-react";
+import { Button, Form, List, Icon } from "semantic-ui-react";
 import _get from "lodash/get";
-import { FieldLabel } from "react-invenio-forms";
+import { FeedbackLabel, FieldLabel } from "react-invenio-forms";
+
 import { HTML5Backend } from "react-dnd-html5-backend";
 import { DndProvider } from "react-dnd";
 
@@ -78,11 +79,18 @@ class CreatibutorsFieldForm extends Component {
         typeof creatibutorsError !== "string" ? creatibutorsError.severity : "error";
     }
 
-    let generalCreatibutorsErrorMessage;
+    // Check if there is a general error (since there can also be errors for specific creatibutors).
+    let generalCreatibutorsError;
     if (typeof creatibutorsError === "string") {
-      generalCreatibutorsErrorMessage = creatibutorsError;
+      // If there is a string at the top level, it means that this is a general error.
+      generalCreatibutorsError = creatibutorsError;
     } else if (typeof creatibutorsError === "object") {
-      generalCreatibutorsErrorMessage = creatibutorsError?.message;
+      // If there is an object at the top level, try to extract the new error format.
+      generalCreatibutorsError = {
+        message: creatibutorsError?.message,
+        severity: creatibutorsError?.severity,
+        description: creatibutorsError?.description,
+      };
     }
 
     return (
@@ -135,10 +143,8 @@ class CreatibutorsFieldForm extends Component {
               </Button>
             }
           />
-          {generalCreatibutorsErrorMessage && (
-            <Label pointing="left" prompt>
-              {generalCreatibutorsErrorMessage}
-            </Label>
+          {generalCreatibutorsError && (
+            <FeedbackLabel errorMessage={generalCreatibutorsError} />
           )}
         </Form.Field>
       </DndProvider>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Fixes inveniosoftware/invenio-rdm-records#1980
* Will be backported to the `maint-17.x` branch

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
