### PR TITLE
Adding service component calls to methods in RecordCommunitiesService

### DIFF
--- a/invenio_rdm_records/services/communities/service.py
+++ b/invenio_rdm_records/services/communities/service.py
@@ -149,6 +149,11 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
         record = self.record_cls.pid.resolve(id_)
         self.require_permission(identity, "add_community", record=record)
 
+        # Run components
+        for component in self.components:
+            if hasattr(component, "add"):
+                component.add(identity, record=record, communities=communities, uow=uow)
+
         processed = []
         for community in communities:
             community_id = community["id"]
@@ -241,6 +246,14 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
             raise_errors=True,
         )
         communities = valid_data["communities"]
+
+        # Run components
+        for component in self.components:
+            if hasattr(component, "remove"):
+                component.remove(
+                    identity, record=record, communities=communities, uow=uow
+                )
+
         processed = []
         for community in communities:
             community_id = community["id"]
@@ -391,6 +404,17 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
         default_community_id = valid_data.get("default", {}).get("id") or None
         record.parent.communities.default = default_community_id
 
+        # Run components
+        for component in self.components:
+            if hasattr(component, "set_default"):
+                component.set_default(
+                    identity,
+                    record=record,
+                    default_community_id=default_community_id,
+                    valid_data=valid_data,
+                    uow=uow,
+                )
+
         uow.register(
             ParentRecordCommitOp(
                 record.parent,
@@ -411,11 +435,25 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
         """
         self.require_permission(identity, "bulk_add")
         errors = []
+
+        # Run components
+        # mutable set_default_flag allows components to modify the set_default value
+        set_default_flag = {"value": set_default}
+        for component in self.components:
+            if hasattr(component, "bulk_add"):
+                component.bulk_add(
+                    identity,
+                    community_id=community_id,
+                    record_ids=record_ids,
+                    set_default=set_default_flag,
+                    uow=uow,
+                )
+
         for record_id in record_ids:
             record = self.record_cls.pid.resolve(record_id)
             community = current_communities.service.record_cls.pid.resolve(community_id)
 
-            set_default = set_default or not record.parent.communities
+            set_default = set_default_flag["value"] or not record.parent.communities
             already_included = community.id in record.parent.communities
             if already_included:
                 errors.append(

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -278,6 +278,11 @@ class RDMRecordCommunitiesConfig(ServiceConfig, ConfiguratorMixin):
     # Max n. communities that can be removed at once
     max_number_of_removals = 10
 
+    components = FromConfig(
+        "RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS",
+        default=[],
+    )
+
 
 class RDMRecordRequestsConfig(ServiceConfig, ConfiguratorMixin):
     """Record community inclusion config."""

--- a/tests/services/test_service_record_communities.py
+++ b/tests/services/test_service_record_communities.py
@@ -7,8 +7,10 @@
 """Test community records service."""
 
 import pytest
+from flask import current_app
 from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.records.components import ServiceComponent
 
 from invenio_rdm_records.proxies import (
     current_rdm_records_service,
@@ -68,3 +70,121 @@ def test_bulk_add_already_in_community(community, uploader, record_factory):
             "message": "Community already included.",
         }
     ]
+
+
+def test_add_component_called(community, uploader, community_owner, record_factory):
+    """The component `add` method is called and modifies the supplied arguments."""
+
+    class MockAddComponent(ServiceComponent):
+        def add(self, identity, record, communities, uow):
+            communities.pop(-1)
+
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = [MockAddComponent]
+
+    record = record_factory.create_record(uploader=community_owner, community=None)
+
+    submitted_communities = [{"id": str(community.id)}, {"id": "dummy_id"}]
+    requests, errors = current_record_communities_service.add(
+        community_owner.identity,
+        record["id"],
+        {"communities": submitted_communities},
+    )
+    # check that the resulting requests did not include one for the dummy_id
+    # which the component should have removed
+    assert len(requests) == 1
+    assert "dummy_id" not in [c["community_id"] for c in requests]
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = []
+
+
+def test_remove_component_called(community, uploader, record_factory):
+    """The component `remove` method is called and modifies the supplied arguments."""
+
+    class MockRemoveComponent(ServiceComponent):
+        def remove(self, identity, record, communities, uow):
+            communities.pop(-1)
+
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = [
+        MockRemoveComponent
+    ]
+
+    record = record_factory.create_record(uploader=uploader, community=community)
+
+    requests, errors = current_record_communities_service.remove(
+        system_identity,
+        record["id"],
+        {"communities": [{"id": str(community.id)}, {"id": "dummy_id"}]},
+    )
+    assert len(requests) == 1
+    assert requests[0]["community"] == str(community.id)
+    # If the component is not called, the "dummy_id" in the communtiy list
+    # will prompt an error with a message that the record is "not included in the
+    # community dummy_id"
+    assert len(errors) == 0
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = []
+
+
+def test_set_default_component_called(
+    db, community, community2, uploader, record_factory
+):
+    """The component `set_default` method is called and modifies the supplied arguments."""
+
+    class MockSetDefaultComponent(ServiceComponent):
+        def set_default(self, identity, record, default_community_id, valid_data, uow):
+            record.parent.communities.default = community2.id
+
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = [
+        MockSetDefaultComponent
+    ]
+
+    record = record_factory.create_record(uploader=uploader, community=community)
+
+    # add the record to the second community
+    record.parent.communities.add(community2._record, default=False)
+    record.parent.commit()
+    db.session.commit()
+    current_rdm_records_service.indexer.index(record, arguments={"refresh": True})
+
+    current_record_communities_service.set_default(
+        system_identity,
+        record["id"],
+        {"default": str(community.id)},
+    )
+
+    result = current_rdm_records_service.record_cls.pid.resolve(record["id"])
+    assert str(result.parent.communities.default.id) == str(community2.id)
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = []
+
+
+def test_bulk_add_component_called(community, uploader, record_factory):
+    """The component `bulk_add` method is called and modifies the supplied arguments."""
+
+    class MockBulkAddComponent(ServiceComponent):
+        def bulk_add(self, identity, community_id, record_ids, set_default, uow):
+            record_ids.pop(-1)
+            set_default["value"] = False
+
+    current_app.config["RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS"] = [
+        MockBulkAddComponent
+    ]
+
+    record = record_factory.create_record(uploader=uploader, community=None)
+    record2 = record_factory.create_record(uploader=uploader, community=None)
+    record3 = record_factory.create_record(uploader=uploader, community=None)
+
+    errors = current_record_communities_service.bulk_add(
+        system_identity,
+        str(community.id),
+        [record.pid.pid_value, record2.pid.pid_value, record3.pid.pid_value],
+        set_default=False,
+    )
+
+    assert len(errors) == 0
+    result1 = current_rdm_records_service.record_cls.pid.resolve(record.pid.pid_value)
+    assert str(result1.parent.communities.default.id) == community.id
+    assert community.id in result1.parent.communities.ids
+    result2 = current_rdm_records_service.record_cls.pid.resolve(record2.pid.pid_value)
+    assert str(result2.parent.communities.default.id) == community.id
+    assert community.id in result2.parent.communities.ids
+    result3 = current_rdm_records_service.record_cls.pid.resolve(record3.pid.pid_value)
+    assert community.id not in result3.parent.communities.ids
+    assert result3.parent.communities.default is None


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The unique methods in RecordCommunitiesService lack the call to service component methods that are usual in record service operations. This PR 
- adds those calls in the `add`, `remove`, `set_default`, and `bulk_add` methods 
- and adds a `components` property in the service config that reads components from the `RDM_RECORD_COMMUNITIES_SERVICE_COMPONENTS` variable if present (defaults to [])

The placement of the component calls in each method is intended to allow maximum customization of the service call's input data before the data is actually applied to change the records.

Note that in `bulk_add` I've wrapped the `set_default` argument value in a dictionary (making it mutable) so that it can be updated inside the components. 

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [X] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [X] I've added relevant test cases.
- [X] I've added relevant documentation.
- [X] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [X] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [X] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [X] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [X] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
