### PR TITLE
Backport tokens: disable "sub" verification

### DIFF
--- a/invenio_rdm_records/tokens/resource_access.py
+++ b/invenio_rdm_records/tokens/resource_access.py
@@ -7,7 +7,7 @@
 
 """Resource access tokens API."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import jwt
 from flask import current_app
@@ -63,15 +63,25 @@ def validate_rat(token):
                 "RDM_RESOURCE_ACCESS_TOKENS_WHITELISTED_JWT_ALGORITHMS",
                 ["HS256", "HS384", "HS512"],
             ),
-            options={"require_iat": True},
+            options={
+                # Based on the JWT spec (https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2)
+                # the "sub" claim has to be a string. However, we are not enforcing this
+                # and are assuming that the "sub" claim is an object/dictionary.
+                # PyJWT v2.10.0 started enforcing this and we are disabling this check.
+                "verify_sub": False,
+                "require": ["iat", "sub"],
+            },
         )
+
+        if not isinstance(payload.get("sub"), dict):
+            raise InvalidTokenError()
 
         token_lifetime = current_app.config.get(
             "RDM_RESOURCE_ACCESS_TOKENS_JWT_LIFETIME", timedelta(minutes=30)
         )
         # Verify that the token is not expired based on its issue time
-        issued_at = datetime.utcfromtimestamp(payload["iat"])
-        if (issued_at + token_lifetime) < datetime.utcnow():
+        issued_at = datetime.fromtimestamp(payload["iat"], tz=timezone.utc)
+        if (issued_at + token_lifetime) < datetime.now(timezone.utc):
             raise ExpiredTokenError()
 
     except jwt.DecodeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ from invenio_vocabularies.contrib.subjects.api import Subject
 from invenio_vocabularies.proxies import current_service as vocabulary_service
 from invenio_vocabularies.records.api import Vocabulary
 from marshmallow import fields
+from werkzeug.local import LocalProxy
 
 from invenio_rdm_records import config
 from invenio_rdm_records.notifications.builders import (
@@ -248,7 +249,11 @@ def app_config(app_config, mock_datacite_client):
         },
     }
 
-    app_config["INDEXER_DEFAULT_INDEX"] = "rdmrecords-records-record-v6.0.0"
+    records_index = LocalProxy(
+        lambda: current_rdm_records_service.record_cls.index._name
+    )
+    app_config["OAISERVER_RECORD_INDEX"] = records_index
+    app_config["INDEXER_DEFAULT_INDEX"] = records_index
     # Variable not used. We set it to silent warnings
     app_config["JSONSCHEMAS_HOST"] = "not-used"
 

--- a/tests/services/schemas/test_publication_date.py
+++ b/tests/services/schemas/test_publication_date.py
@@ -62,6 +62,10 @@ def test_asymmetric_interval(app, minimal_record):
     _assert_meta(minimal_record["metadata"], "2020-01/2020-12-01")
 
 
+def test_unknown_bound_interval(app, minimal_record):
+    _assert_meta(minimal_record["metadata"], "/2020-12")
+    _assert_meta(minimal_record["metadata"], "2020-12/")
+
+
 def test_invalid_interval(app, minimal_record):
     _assert_fails(minimal_record["metadata"], "2021-01/2020-12")
-    _assert_fails(minimal_record["metadata"], "/2020-12")

--- a/tests/tokens/test_resource_access.py
+++ b/tests/tokens/test_resource_access.py
@@ -135,9 +135,16 @@ def test_rat_validation_failed(app, db, uploader, superuser_identity, oauth2_cli
         # generate token issued an hour ago
         validate_rat(
             _rat_gen(
-                pat["token"], payload={"iat": datetime.utcnow() - timedelta(hours=1)}
+                pat["token"],
+                payload={"iat": datetime.utcnow() - timedelta(hours=1), "sub": {}},
             )
         )
+    # case: RAT is missing "sub" key
+    with pytest.raises(InvalidTokenError):
+        validate_rat(_rat_gen(pat["token"]))
+    # case: RAT has a non-dictionary "sub" key
+    with pytest.raises(InvalidTokenError):
+        validate_rat(_rat_gen(pat["token"], payload={"sub": "test-string-sub"}))
 
 
 def test_rec_files_permissions_with_rat(
@@ -704,7 +711,7 @@ def test_rec_files_permissions_with_rat_expired_token_error(
     # generate expired RAT
     pat = _generate_pat_token(db, uploader, oauth2_client, "rat_token")["token"]
     rat_token = jwt.encode(
-        payload={"iat": datetime.utcnow() - timedelta(hours=1)},
+        payload={"iat": datetime.utcnow() - timedelta(hours=1), "sub": {}},
         key=pat.access_token,
         algorithm="HS256",
         headers={"kid": str(pat.id)},


### PR DESCRIPTION
This backports https://github.com/inveniosoftware/invenio-rdm-records/pull/2005/commits/7184dca53d6a63b61ee931d54adcd2439f6771cb to fix tokens on PyJWT 2.1+

It also includes https://github.com/inveniosoftware/invenio-rdm-records/pull/2005/commits/03db56d9fcc0423f1c5b8d61fa22a6227916b31b and part of https://github.com/inveniosoftware/invenio-rdm-records/commit/f9b7a58bf7fd70020afdc3e0260e7aff7deabccf to fix CI tests.

### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
