### PR TITLE
Implementation of RFC 0072 - Pluggable transfer types - backend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,20 @@
 Changes
 =======
 
+Version v19.0.0 (released 2025-06-03)
+
+- setup: version bump on dependent packages
+- fix: added permissions for getting/setting transfer metadata
+  * Added extra permissions to get/update transfer metadata. These permissions
+  are not used by REST API, they are used in background tasks, at this
+  moment for fetch transfer (not enabled by default and not supported in UI)
+- test: fixed test - file key is now required
+- permissions: multipart upload with local fs storage
+- Implementation of RFC 0072 - Pluggable transfer types
+  * IfFileIsLocal is not used anymore as it was handling just one type of transport
+  * Switched to IfTransferType permission generators
+- installation: remove collections dependency
+
 Version v18.14.0 (released 2025-06-02)
 
 - config: make community request type classes customizable

--- a/invenio_rdm_records/__init__.py
+++ b/invenio_rdm_records/__init__.py
@@ -12,6 +12,6 @@
 
 from .ext import InvenioRDMRecords
 
-__version__ = "18.14.0"
+__version__ = "19.0.0"
 
 __all__ = ("__version__", "InvenioRDMRecords")

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -330,6 +330,7 @@ class RDMRecordMediaFilesResourceConfig(FileResourceConfig, ConfiguratorMixin):
         "item": "/media-files/<key>",
         "item-content": "/media-files/<key>/content",
         "item-commit": "/media-files/<key>/commit",
+        "item-multipart-content": "/media-files/<path:key>/content/<int:part>",
         "list-archive": "/media-files-archive",
     }
 
@@ -370,6 +371,7 @@ class RDMDraftMediaFilesResourceConfig(FileResourceConfig, ConfiguratorMixin):
         "item": "/media-files/<key>",
         "item-content": "/media-files/<key>/content",
         "item-commit": "/media-files/<key>/commit",
+        "item-multipart-content": "/media-files/<path:key>/content/<int:part>",
         "list-archive": "/media-files-archive",
     }
 

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021-2024 CERN.
 # Copyright (C) 2021 TU Wien.
+# Copyright (C) 2024 CESNET.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -14,19 +15,15 @@ from collections import namedtuple
 from functools import partial, reduce
 from itertools import chain
 
-from flask import g
 from flask_principal import UserNeed
-from invenio_communities.config import COMMUNITIES_ROLES
 from invenio_communities.generators import CommunityRoleNeed, CommunityRoles
 from invenio_communities.proxies import current_roles
 from invenio_records_permissions.generators import ConditionalGenerator, Generator
-from invenio_records_resources.services.files.transfer import TransferType
 from invenio_search.engine import dsl
 
 from ..records import RDMDraft
 from ..records.systemfields.access.grants import Grant
 from ..records.systemfields.deletion_status import RecordDeletionStatusEnum
-from ..requests import CommunityInclusion
 from ..requests.access import AccessRequestTokenNeed
 from ..tokens.permissions import RATNeed
 
@@ -96,28 +93,6 @@ class IfDraft(ConditionalGenerator):
     def _condition(self, record, **kwargs):
         """Check if the record is a draft."""
         return isinstance(record, RDMDraft)
-
-
-class IfFileIsLocal(ConditionalGenerator):
-    """Conditional generator for file storage class."""
-
-    def _condition(self, record, file_key=None, **kwargs):
-        """Check if the file is local."""
-        is_file_local = True
-        if file_key:
-            file_record = record.files.get(file_key)
-            # file_record __bool__ returns false for `if file_record`
-            file = file_record.file if file_record is not None else None
-            is_file_local = not file or file.storage_class == TransferType.LOCAL
-        else:
-            file_records = record.files.entries
-            for file_record in file_records:
-                file = file_record.file
-                if file and file.storage_class != TransferType.LOCAL:
-                    is_file_local = False
-                    break
-
-        return is_file_local
 
 
 class IfNewRecord(ConditionalGenerator):

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -160,6 +160,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_draft_set_content_files = [
         # review is the same as create_files
         IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        IfTransferType(MULTIPART_TRANSFER_TYPE, can_review),
         SystemProcess(),
     ]
     can_draft_get_content_files = [

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -176,6 +176,10 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     ]
     can_draft_update_files = can_review
     can_draft_delete_files = can_review
+
+    can_draft_get_file_transfer_metadata = [SystemProcess()]
+    can_draft_update_file_transfer_metadata = [SystemProcess()]
+
     # Allow enabling/disabling files
     can_manage_files = [
         IfConfig(
@@ -329,6 +333,9 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_set_content_files = [Disable()]
     can_commit_files = [Disable()]
     can_update_files = [Disable()]
+
+    can_get_file_transfer_metadata = [Disable()]
+    can_update_file_transfer_metadata = [Disable()]
 
     # Used to hide the `parent.is_verified` field. It should be set to
     # correct permissions based on which the field will be exposed only to moderators

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2019-2024 CERN.
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2023 TU Wien.
+# Copyright (C) 2024 CESNET.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -19,6 +20,11 @@ from invenio_records_permissions.generators import (
     SystemProcess,
 )
 from invenio_records_permissions.policies.records import RecordPermissionPolicy
+from invenio_records_resources.services.files.generators import IfTransferType
+from invenio_records_resources.services.files.transfer import (
+    LOCAL_TRANSFER_TYPE,
+    MULTIPART_TRANSFER_TYPE,
+)
 from invenio_requests.services.generators import Receiver, Status
 from invenio_requests.services.permissions import (
     PermissionPolicy as RequestPermissionPolicy,
@@ -34,7 +40,6 @@ from .generators import (
     IfCreate,
     IfDeleted,
     IfExternalDOIRecord,
-    IfFileIsLocal,
     IfNewRecord,
     IfOneCommunity,
     IfRecordDeleted,
@@ -131,7 +136,8 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_get_content_files = [
         # note: even though this is closer to business logic than permissions,
         # it was simpler and less coupling to implement this as permission check
-        IfFileIsLocal(then_=can_read_files, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_read_files),
+        SystemProcess(),
     ]
     # Allow submitting new record
     can_create = can_authenticated
@@ -153,15 +159,19 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_draft_create_files = can_review
     can_draft_set_content_files = [
         # review is the same as create_files
-        IfFileIsLocal(then_=can_review, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        SystemProcess(),
     ]
     can_draft_get_content_files = [
         # preview is same as read_files
-        IfFileIsLocal(then_=can_draft_read_files, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_draft_read_files),
+        SystemProcess(),
     ]
     can_draft_commit_files = [
         # review is the same as create_files
-        IfFileIsLocal(then_=can_review, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        IfTransferType(MULTIPART_TRANSFER_TYPE, can_review),
+        SystemProcess(),
     ]
     can_draft_update_files = can_review
     can_draft_delete_files = can_review
@@ -257,15 +267,18 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_draft_media_create_files = can_review
     can_draft_media_read_files = can_review
     can_draft_media_set_content_files = [
-        IfFileIsLocal(then_=can_review, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        SystemProcess(),
     ]
     can_draft_media_get_content_files = [
         # preview is same as read_files
-        IfFileIsLocal(then_=can_preview, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_preview),
+        SystemProcess(),
     ]
     can_draft_media_commit_files = [
         # review is the same as create_files
-        IfFileIsLocal(then_=can_review, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        SystemProcess(),
     ]
     can_draft_media_update_files = can_review
     can_draft_media_delete_files = can_review
@@ -280,7 +293,8 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_media_get_content_files = [
         # note: even though this is closer to business logic than permissions,
         # it was simpler and less coupling to implement this as permission check
-        IfFileIsLocal(then_=can_read, else_=[SystemProcess()])
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_read),
+        SystemProcess(),
     ]
     can_media_create_files = [Disable()]
     can_media_set_content_files = [Disable()]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019 Northwestern University.
 # Copyright (C) 2022 Universität Hamburg.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -38,17 +38,17 @@ install_requires =
     Faker>=2.0.3
     flask-iiif>=1.0.0,<2.0.0
     ftfy>=4.4.3,<5.0.0
-    invenio-administration>=3.0.0,<4.0.0
-    invenio-communities>=18.2.0,<19.0.0
-    invenio-drafts-resources>=6.0.0,<7.0.0
-    invenio-records-resources>=7.3.0,<8.0.0
-    invenio-github>=2.0.0,<3.0.0
+    invenio-administration>=4.0.0,<5.0.0
+    invenio-communities>=19.0.0,<20.0.0
+    invenio-drafts-resources>=7.0.0,<8.0.0
+    invenio-records-resources>=8.0.0,<9.0.0
+    invenio-github>=3.0.0,<4.0.0
     invenio-i18n>=3.0.0,<4.0.0
-    invenio-jobs>=3.0.0,<4.0.0
+    invenio-jobs>=4.0.0,<5.0.0
     invenio-oaiserver>=3.0.0,<4.0.0
     invenio-oauth2server>=3.0.0,<4.0.0
     invenio-stats>=5.0.0,<6.0.0
-    invenio-vocabularies>=7.0.0,<8.0.0
+    invenio-vocabularies>=8.0.0,<9.0.0
     nameparser>=1.1.1
     pycountry>=22.3.5
     pydash>=6.0.0,<7.0.0

--- a/tests/secret_links/test_sharing.py
+++ b/tests/secret_links/test_sharing.py
@@ -125,7 +125,7 @@ def test_permission_levels(service, restricted_record, identity_simple, client):
     pytest.raises(PermissionDeniedError, service.new_version, anon, id_)
     pytest.raises(PermissionDeniedError, service.publish, anon, id_)
     with pytest.raises(PermissionDeniedError):
-        service.draft_files.init_files(anon, id_, {})
+        service.draft_files.init_files(anon, id_, [{"key": "test.pdf"}])
     with pytest.raises(PermissionDeniedError):
         service.draft_files.update_file_metadata(anon, id_, "test.pdf", {})
     with pytest.raises(PermissionDeniedError):


### PR DESCRIPTION
### Description

This PR implements changes from RFC 0072 - introduction of pluggable transfer types. `IfFileIsLocal` has been
removed in favour of more generic `IfTransferType`. It handles only the backend part, frontend part is 
in PR #1930 .

Note: needs https://github.com/inveniosoftware/invenio-records-resources/pull/604

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
