### PR TITLE
metadata: add copyrights

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
@@ -1,0 +1,42 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2023 CERN.
+// Copyright (C) 2020-2022 Northwestern University.
+// Copyright (C) 2021 Graz University of Technology.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import { FieldLabel, TextField } from "react-invenio-forms";
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+
+export class CopyrightsField extends Component {
+  render() {
+    const { fieldPath, label, required } = this.props;
+    return (
+      <>
+        <TextField
+          fieldPath={fieldPath}
+          label={
+            <FieldLabel htmlFor={fieldPath} icon="copyright outline" label={label} />
+          }
+          required={required}
+          optimized
+        />
+      </>
+    );
+  }
+}
+
+CopyrightsField.propTypes = {
+  fieldPath: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+};
+
+CopyrightsField.defaultProps = {
+  label: i18next.t("Copyrights"),
+  required: false,
+};

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
@@ -23,6 +23,9 @@ export class CopyrightsField extends Component {
             <FieldLabel htmlFor={fieldPath} icon="copyright outline" label={label} />
           }
           required={required}
+          helpText={i18next.t(
+            "Optionally specify holder, year and copyright statement for this resource (if any)"
+          )}
           optimized
         />
       </>

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/CopyrightsField.js
@@ -40,6 +40,6 @@ CopyrightsField.propTypes = {
 };
 
 CopyrightsField.defaultProps = {
-  label: i18next.t("Copyrights"),
+  label: i18next.t("Copyright"),
   required: false,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/index.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/CopyrightsField/index.js
@@ -1,0 +1,1 @@
+export { CopyrightsField } from "./CopyrightsField";

--- a/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
@@ -203,8 +203,8 @@
             }
           }
         },
-        "copyrights": {
-          "description": "Copyrights for record (may contain HTML).",
+        "copyright": {
+          "description": "Copyright for record (may contain HTML).",
           "type": "string"
         },
         "description": {

--- a/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
@@ -203,6 +203,10 @@
             }
           }
         },
+        "copyrights": {
+          "description": "Copyrights for record (may contain HTML).",
+          "type": "string"
+        },
         "description": {
           "description": "Description for record (may contain HTML).",
           "type": "string"

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -809,7 +809,7 @@
               }
             }
           },
-          "copyrights": {
+          "copyright": {
             "type": "text"
           },
           "creators": {

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -809,6 +809,9 @@
               }
             }
           },
+          "copyrights": {
+            "type": "text"
+          },
           "creators": {
             "properties": {
               "affiliations": {

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -898,7 +898,7 @@
               }
             }
           },
-          "copyrights": {
+          "copyright": {
             "type": "text"
           },
           "dates": {

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -45,8 +45,13 @@
         "accent_analyzer": {
           "tokenizer": "standard",
           "type": "custom",
-          "char_filter": ["strip_special_chars"],
-          "filter": ["lowercase", "asciifolding"]
+          "char_filter": [
+            "strip_special_chars"
+          ],
+          "filter": [
+            "lowercase",
+            "asciifolding"
+          ]
         }
       }
     }
@@ -892,6 +897,9 @@
                 }
               }
             }
+          },
+          "copyrights": {
+            "type": "text"
           },
           "dates": {
             "properties": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -809,7 +809,7 @@
               }
             }
           },
-          "copyrights": {
+          "copyright": {
             "type": "text"
           },
           "creators": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -809,6 +809,9 @@
               }
             }
           },
+          "copyrights": {
+            "type": "text"
+          },
           "creators": {
             "properties": {
               "affiliations": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -807,7 +807,7 @@
               }
             }
           },
-          "copyrights": {
+          "copyright": {
             "type": "text"
           },
           "creators": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -807,6 +807,9 @@
               }
             }
           },
+          "copyrights": {
+            "type": "text"
+          },
           "creators": {
             "properties": {
               "affiliations": {

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -556,7 +556,8 @@ class DataCite43Schema(BaseSerializerSchema):
     def get_rights(self, obj):
         """Get datacite rigths."""
         rights = obj["metadata"].get("rights", [])
-        if not rights:
+        copyright = obj["metadata"].get("copyright", None)
+        if not rights and not copyright:
             return missing
 
         serialized_rights = []
@@ -573,6 +574,13 @@ class DataCite43Schema(BaseSerializerSchema):
             if link:
                 entry["rightsUri"] = link
             serialized_rights.append(entry)
+        if copyright:
+            serialized_rights.append(
+                {
+                    "rights": copyright,
+                    "rightsUri": "http://rightsstatements.org/vocab/InC/1.0/",
+                }
+            )
 
         return serialized_rights if serialized_rights else missing
 

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -385,6 +385,7 @@ class MetadataSchema(Schema):
     )
     version = SanitizedUnicode()
     rights = fields.List(fields.Nested(RightsSchema))
+    copyrights = SanitizedHTML(validate=validate.Length(min=3))
     description = SanitizedHTML(validate=validate.Length(min=3))
     additional_descriptions = fields.List(fields.Nested(DescriptionSchema))
     locations = fields.Nested(FeatureSchema)

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -385,7 +385,7 @@ class MetadataSchema(Schema):
     )
     version = SanitizedUnicode()
     rights = fields.List(fields.Nested(RightsSchema))
-    copyrights = SanitizedHTML(validate=validate.Length(min=3))
+    copyright = SanitizedHTML(validate=validate.Length(min=1))
     description = SanitizedHTML(validate=validate.Length(min=3))
     additional_descriptions = fields.List(fields.Nested(DescriptionSchema))
     locations = fields.Nested(FeatureSchema)

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -108,6 +108,7 @@ def test_datacite43_serializer(running_app, full_record_to_dict):
             "title": {"en": "No rightsUri license"},
         }
     )
+    full_record_to_dict["metadata"]["copyright"] = "2025 © Author(s)"
     # for HTML stripping test purposes
     expected_data = {
         "contributors": [
@@ -224,6 +225,10 @@ def test_datacite43_serializer(running_app, full_record_to_dict):
                 "rightsUri": "https://creativecommons.org/licenses/by/4.0/legalcode",
             },
             {"rights": "No rightsUri license"},
+            {
+                "rights": "2025 © Author(s)",
+                "rightsUri": "http://rightsstatements.org/vocab/InC/1.0/",
+            },
         ],
         "schemaVersion": "http://datacite.org/schema/kernel-4",
         "sizes": ["11 pages"],


### PR DESCRIPTION
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/381
* proposal of the solution to add copyrights field, discussed on the 8th of April telecon
* I tried to apply what we came up with in the breakout room and:
    *  I explored the possibility of adding the field alongside license field. Unfortunately the current implementation of license field is a bit too rigid to handle this, license field would need to be refactored (unfortunately this is not feasible in the scope of this PR)
    * putting the field inside the modal requires some thoughts and design on the UX of representing the current value when updating the record
    * explored adding the value to datacite serializer, it seems we don't have a field to accommodate it at the moment https://datacite-metadata-schema.readthedocs.io/en/4.5/properties/rights/