### PR TITLE
UX: change from checkbox to radio

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
@@ -16,7 +16,7 @@ import React, { Component, useState } from "react";
 import Dropzone from "react-dropzone";
 import {
   Button,
-  Checkbox,
+  Radio,
   Grid,
   Header,
   Icon,
@@ -33,7 +33,9 @@ const FileTableHeader = ({ filesLocked }) => (
       <Table.HeaderCell>
         {i18next.t("Preview")}{" "}
         <Popup
-          content={i18next.t("Set the default preview")}
+          content={i18next.t(
+            "Choose which file to preview on the published record landing page"
+          )}
           trigger={<Icon fitted name="help circle" size="small" />}
         />
       </Table.HeaderCell>
@@ -88,9 +90,7 @@ const FileTableRow = ({
   return (
     <Table.Row key={file.name}>
       <Table.Cell data-label={i18next.t("Default preview")} width={2}>
-        {/* TODO: Investigate if react-deposit-forms optimized Checkbox field
-                  would be more performant */}
-        <Checkbox
+        <Radio
           checked={isDefaultPreview}
           onChange={() => setDefaultPreview(isDefaultPreview ? "" : file.name)}
         />


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

As you cannot select multiple files to preview, it is incorrect to use a checkbox here

Before and after
<img width="861" alt="image" src="https://github.com/user-attachments/assets/899bceda-b5ec-49fb-bbcc-dc82769cde74" />

Message before
<img width="296" alt="image" src="https://github.com/user-attachments/assets/6fca8f0d-e731-4f38-9ea0-28779bbba79e" />

Message after
<img width="341" alt="image" src="https://github.com/user-attachments/assets/c95165ab-7c67-444e-b263-a61fedd85af0" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
