### PR TITLE
schemas: set default value for notes in quota increases

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,10 @@
 Changes
 =======
 
+Version <next>
+
+- schemas: provide default value for quota increase notes
+
 Version v18.8.0 (released 2025-05-06)
 
 - services: make commit file link dependent on allow_upload

--- a/invenio_rdm_records/services/schemas/quota.py
+++ b/invenio_rdm_records/services/schemas/quota.py
@@ -16,4 +16,4 @@ class QuotaSchema(Schema):
 
     quota_size = fields.Number(required=True)
     max_file_size = fields.Number(required=True)
-    notes = SanitizedUnicode()
+    notes = SanitizedUnicode(default="")


### PR DESCRIPTION
On the administration panel, the `notes` field is marked as optional:
![image](https://github.com/user-attachments/assets/b86a02ce-2cb7-4dfa-9dbd-861a79ce2d23)


However, if this value is omitted, this may result in the `data` not having a `notes` field at all, which crashes the service layer here: https://github.com/inveniosoftware/invenio-rdm-records/blob/master/invenio_rdm_records/services/services.py#L694