### PR TITLE
mappings: remove objectfields from "index.query.default_field" settings

### DIFF
--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -18,8 +18,6 @@
       "metadata.funding.award.identifiers.identifier",
       "metadata.funding.award.acronym.text",
       "metadata.funding.award.number",
-      "metadata.funding.award.subjects",
-      "metadata.funding.award.organizations",
       "metadata.funding.funder.name",
       "metadata.identifiers.identifier",
       "metadata.locations.features.place",

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -18,8 +18,6 @@
       "metadata.funding.award.identifiers.identifier",
       "metadata.funding.award.acronym.text",
       "metadata.funding.award.number",
-      "metadata.funding.award.subjects",
-      "metadata.funding.award.organizations",
       "metadata.funding.funder.name",
       "metadata.identifiers.identifier",
       "metadata.locations.features.place",

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/records/record-v6.0.0.json
@@ -1553,8 +1553,6 @@
       "metadata.funding.award.identifiers.identifier",
       "metadata.funding.award.acronym.text",
       "metadata.funding.award.number",
-      "metadata.funding.award.subjects",
-      "metadata.funding.award.organizations",
       "metadata.funding.funder.name",
       "metadata.identifiers.identifier",
       "metadata.locations.features.place",


### PR DESCRIPTION
* Having object-level fields in this setting caused issues with the
  OAI-PMH percolator index complaining about "No field mapping can be
  found for the field with name [metadata.funding.award.subjects]"
  when indexing percolator queries to it.
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/388