### PR TITLE
fix: SADeprecationWarning

### DIFF
--- a/invenio_rdm_records/oaiserver/services/services.py
+++ b/invenio_rdm_records/oaiserver/services/services.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -171,8 +171,12 @@ class OAIPMHServerService(Service):
                 ]
             )
 
+        # if filters == [] -> True
+        # if filters != [] -> False
+        default_element = not bool(len(filters))
+
         oai_sets = (
-            OAISet.query.filter(or_(*filters))
+            OAISet.query.filter(or_(default_element, *filters))
             .order_by(
                 search_params["sort_direction"](text(",".join(search_params["sort"])))
             )


### PR DESCRIPTION
* SADeprecationWarning: Invoking or_() without arguments is deprecated,
  and will be disallowed in a future release.   For an empty or_()
  construct, use 'or_(false(), *args)' or 'or_(False, *args)'.

* sqlalchemy/sqlalchemy#5054
