### PR TITLE
serializers/datacite: configurable dumping of access right

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -628,8 +628,13 @@ RDM_FILES_DEFAULT_MAX_FILE_SIZE = None
 RDM_DATACITE_FUNDER_IDENTIFIERS_PRIORITY = ("ror", "doi", "grid", "isni", "gnd")
 """Priority of funder identifiers types to be used for DataCite serialization."""
 
-RDM_DATACITE_DUMP_ACCESS_RIGHTS = False
-"""Flag to show whether DataCite access rights level should be dumped or not."""
+RDM_DATACITE_DUMP_OPENAIRE_ACCESS_RIGHTS = False
+"""Flag to control dumping DataCite OpenAIRE access rights.
+
+See https://guidelines.openaire.eu/en/latest/data/field_rights.html for further 
+information on how the OpenAIRE Guidelines expect access rights to be exposed 
+via the DataCite schema.
+"""
 
 RDM_IIIF_MANIFEST_FORMATS = [
     "gif",

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -574,7 +574,7 @@ class DataCite43Schema(BaseSerializerSchema):
 
         # Add info:eu-repo access rights (if configured)
         dump_access_rights = current_app.config.get(
-            "RDM_DATACITE_DUMP_ACCESS_RIGHTS", False
+            "RDM_DATACITE_DUMP_OPENAIRE_ACCESS_RIGHTS", False
         )
         access_right = obj.get("access", {}).get("status")
         if dump_access_rights and access_right:

--- a/tests/resources/serializers/test_datacite_serializer.py
+++ b/tests/resources/serializers/test_datacite_serializer.py
@@ -415,7 +415,7 @@ def test_datacite43_access_right(running_app, minimal_record, set_app_config_fn_
     assert "rightsList" not in serialized_record
 
     # Test with access rights dumping enabled
-    set_app_config_fn_scoped({"RDM_DATACITE_DUMP_ACCESS_RIGHTS": True})
+    set_app_config_fn_scoped({"RDM_DATACITE_DUMP_OPENAIRE_ACCESS_RIGHTS": True})
     serialized_record = serializer.dump_obj(minimal_record)
     rights_list = serialized_record["rightsList"]
     assert {"rightsUri": "info:eu-repo/semantics/openAccess"} in rights_list


### PR DESCRIPTION
* Closes #2046.
* Adds a new `RDM_DATACITE_DUMP_ACCESS_RIGHTS` config variable to
  control if the access right level is included in the DataCite
  serialization. The value is based on the vocabulary documented at
  <https://wiki.surfnet.nl/spaces/standards/pages/11055603/info-eu-repo#infoeurepo-AccessRights>
