### PR TITLE
deposit: fix global server errors in frontend

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
@@ -7,6 +7,7 @@
 
 import axios from "axios";
 import _get from "lodash/get";
+import _isEmpty from "lodash/isEmpty";
 
 const BASE_HEADERS = {
   "json": { "Content-Type": "application/json" },
@@ -108,7 +109,7 @@ export class RDMDepositApiClient extends DepositApiClient {
         error.response.data.errors || []
       );
       // this is to serialize raised error from the backend on publish
-      if (errors) errorData = errors;
+      if (!_isEmpty(errors)) errorData = errors;
       throw new DepositApiClientResponse({}, errorData);
     }
   }

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedback.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedback.js
@@ -211,8 +211,9 @@ class DisconnectedFormFeedback extends Component {
         ? "suggestive"
         : initialFeedback;
 
-    // if no field is specified on the backend, then the message is on the `_schema` field
-    const backendErrorMessage = errors._schema;
+    // if no field is specified on the backend, then the validation message is on the `_schema` field
+    // if the backend returns an explicit message e.g server error, then we use that instead of the default one
+    const backendErrorMessage = errors.message || errors._schema;
 
     // Retrieve the corresponding icon and type if the feedback is a valid key,
     // else fallback to warning.


### PR DESCRIPTION
Global server errors of the format `{status: 400, message: 'Error'}` were not displaying in the deposit form. This PR fixes that.

![Screenshot 2025-05-22 at 10 34 22](https://github.com/user-attachments/assets/0399bc2b-338e-42f0-a42a-caea1f4602e5)
![Screenshot 2025-05-22 at 10 34 29](https://github.com/user-attachments/assets/74b4b515-d329-4919-bd4d-d8de8e7f0c9b)

closes https://github.com/inveniosoftware/invenio-rdm-records/issues/2049