### PR TITLE
refactor: remove usage of marshmallow context

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2019-2025 CERN.
 # Copyright (C) 2019 Northwestern University.
-# Copyright (C) 2021-2024 Graz University of Technology.
+# Copyright (C) 2021-2025 Graz University of Technology.
 # Copyright (C) 2023 TU Wien.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
@@ -423,7 +423,7 @@ RDM_PARENT_PERSISTENT_IDENTIFIER_PROVIDERS = [
     providers.DataCitePIDProvider(
         "datacite",
         client=providers.DataCiteClient("datacite", config_prefix="DATACITE"),
-        serializer=DataCite43JSONSerializer(schema_context={"is_parent": True}),
+        serializer=DataCite43JSONSerializer(is_parent=True),
         label=_("Concept DOI"),
     ),
 ]

--- a/invenio_rdm_records/resources/serializers/datacite/__init__.py
+++ b/invenio_rdm_records/resources/serializers/datacite/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021-2024 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -18,13 +19,16 @@ from .schema import DataCite43Schema
 class DataCite43JSONSerializer(MarshmallowSerializer):
     """Marshmallow based DataCite serializer for records."""
 
-    def __init__(self, **options):
+    def __init__(self, is_parent=False, **options):
         """Constructor."""
         super().__init__(
             format_serializer_cls=JSONSerializer,
             object_schema_cls=DataCite43Schema,
             list_schema_cls=BaseListSchema,
-            schema_kwargs={"dumpers": [JournalDataciteDumper()]},  # Order matters
+            schema_kwargs={
+                "dumpers": [JournalDataciteDumper()],  # Order matters
+                "is_parent": is_parent,
+            },
             **options,
         )
 

--- a/invenio_rdm_records/resources/serializers/datacite/schema.py
+++ b/invenio_rdm_records/resources/serializers/datacite/schema.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2021-2024 CERN.
 # Copyright (C) 2021-2025 Northwestern University.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2025 Graz University of Technology.
 # Copyright (C) 2023 Caltech.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
@@ -204,6 +204,11 @@ class DataCite43Schema(BaseSerializerSchema):
     geoLocations = fields.Method("get_locations")
     fundingReferences = fields.Method("get_funding")
     schemaVersion = fields.Constant("http://datacite.org/schema/kernel-4")
+
+    def __init__(self, is_parent=False, **kwargs):
+        """Construct."""
+        super().__init__(**kwargs)
+        self.is_parent = is_parent
 
     def get_type(self, obj):
         """Get resource type."""
@@ -408,7 +413,7 @@ class DataCite43Schema(BaseSerializerSchema):
                 serialized_identifiers.append(serialized_identifier)
 
         # Generate parent/child versioning relationships
-        if self.context.get("is_parent"):
+        if self.is_parent:
             # Fetch DOIs for all versions
             # NOTE: The refresh is safe to do here since we'll be in Celery task
             current_rdm_records_service.indexer.refresh()


### PR DESCRIPTION
* this change enables the to move to marshmallow>=4.0 which removes the
  context paramater
