### PR TITLE
installation: remove collections dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     flask-iiif>=1.0.0,<2.0.0
     ftfy>=4.4.3,<5.0.0
     invenio-administration>=3.0.0,<4.0.0
-    invenio-collections>=0.4.0,<1.0.0
     invenio-communities>=18.2.0,<19.0.0
     invenio-drafts-resources>=6.0.0,<7.0.0
     invenio-records-resources>=7.3.0,<8.0.0


### PR DESCRIPTION
Making Invenio-RDM-Records dependent on Invenio-Collections creates an unnecessary circular dependency. 
Moreover, this module doesn't actually use collections; Invenio-APP-RDM does. Moving the dependency there seems sensible. https://github.com/inveniosoftware/invenio-app-rdm/pull/3068

Thanks @utnapischtim! 