### PR TITLE
tests: update error to reflect records-resources file permission change

### DIFF
--- a/tests/services/files/test_deleted_record_files.py
+++ b/tests/services/files/test_deleted_record_files.py
@@ -10,7 +10,10 @@
 from io import BytesIO
 
 import pytest
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.errors import (
+    FileKeyNotFoundError,
+    PermissionDeniedError,
+)
 
 from invenio_rdm_records.proxies import current_rdm_records_service
 from invenio_rdm_records.services.errors import RecordDeletedException
@@ -90,7 +93,7 @@ def test_deleted_records_file_flow(
         file_service.init_files(identity_simple, recid, file_to_initialise)
 
     # Update file content
-    with pytest.raises(PermissionDeniedError):
+    with pytest.raises(FileKeyNotFoundError):
         content = BytesIO(b"test file content")
         file_service.set_file_content(
             identity_simple,
@@ -101,5 +104,5 @@ def test_deleted_records_file_flow(
         )
 
     # Commit file
-    with pytest.raises(PermissionDeniedError):
+    with pytest.raises(FileKeyNotFoundError):
         file_service.commit_file(identity_simple, recid, "article.txt")


### PR DESCRIPTION

:heart: Thank you for your contribution!

### Description

The order of file permission checks were changed here https://github.com/inveniosoftware/invenio-records-resources/pull/629, which changes the error that is returned for setting content on a non-existant file.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
