### PR TITLE
fix: Disabled remote and fetch transport in permissions

### DIFF
--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -156,7 +156,12 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     # Allow updating metadata of a draft
     can_update_draft = can_review
     # Allow uploading, updating and deleting files in drafts
-    can_draft_create_files = can_review
+    can_draft_create_files = [
+        # review is the same as create_files
+        IfTransferType(LOCAL_TRANSFER_TYPE, can_review),
+        IfTransferType(MULTIPART_TRANSFER_TYPE, can_review),
+        SystemProcess(),
+    ]
     can_draft_set_content_files = [
         # review is the same as create_files
         IfTransferType(LOCAL_TRANSFER_TYPE, can_review),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,6 +312,16 @@ def app_config(app_config, mock_datacite_client):
     app_config["RDM_FILES_DEFAULT_QUOTA_SIZE"] = 10**6
     app_config["RDM_FILES_DEFAULT_MAX_FILE_SIZE"] = 10**6
 
+    # allowed domains for remotely linked files
+    app_config["RECORDS_RESOURCES_FILES_ALLOWED_REMOTE_DOMAINS"] = [
+        "example.com",
+    ]
+
+    # allowed domains for fetched files
+    app_config["RECORDS_RESOURCES_FILES_ALLOWED_DOMAINS"] = [
+        "example.com",
+    ]
+
     # Communities
     app_config["COMMUNITIES_SERVICE_COMPONENTS"] = CommunityServiceComponents
 

--- a/tests/resources/test_draft_file_permissions.py
+++ b/tests/resources/test_draft_file_permissions.py
@@ -14,6 +14,10 @@ Not every case is tested, but enough high-level ones for it to be useful.
 from io import BytesIO
 
 import pytest
+from invenio_records_resources.services.files.transfer.constants import (
+    FETCH_TRANSFER_TYPE,
+    REMOTE_TRANSFER_TYPE,
+)
 
 from tests.helpers import login_user, logout_user
 
@@ -30,6 +34,19 @@ def init_file(client, recid, headers):
     """Init a file for draft with given recid."""
     return client.post(
         f"/records/{recid}/draft/files", headers=headers, json=[{"key": "test.pdf"}]
+    )
+
+
+def init_file_with_transfer(client, recid, headers, transfer_data):
+    return client.post(
+        f"/records/{recid}/draft/files",
+        headers=headers,
+        json=[
+            {
+                "key": "test.pdf",
+                "transfer": transfer_data,
+            }
+        ],
     )
 
 
@@ -72,6 +89,84 @@ def test_only_owners_can_init_file_upload(
     login_user(client, users[0])
     response = init_file(client, recid, headers)
     assert response.status_code == 201
+
+
+def test_no_one_can_init_remote_file(
+    client, headers, running_app, minimal_record, users
+):
+    login_user(client, users[0])
+
+    recid = create_draft(client, minimal_record, headers)
+
+    # Anonymous user can't init file for it
+    logout_user(client)
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": REMOTE_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
+
+    # Different user can't init file for it
+    login_user(client, users[1])
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": REMOTE_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
+
+    # Owner can init file for it
+    logout_user(client)
+    login_user(client, users[0])
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": REMOTE_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
+
+
+def test_no_one_can_init_file_fetch(
+    client, headers, running_app, minimal_record, users
+):
+    login_user(client, users[0])
+
+    recid = create_draft(client, minimal_record, headers)
+
+    # Anonymous user can't init file for it
+    logout_user(client)
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": FETCH_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
+
+    # Different user can't init file for it
+    login_user(client, users[1])
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": FETCH_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
+
+    # Owner can init file for it
+    logout_user(client)
+    login_user(client, users[0])
+    response = init_file_with_transfer(
+        client,
+        recid,
+        headers,
+        {"type": FETCH_TRANSFER_TYPE, "url": "https://example.com/test.pdf"},
+    )
+    assert response.status_code == 403
 
 
 def test_only_owners_can_upload_file(


### PR DESCRIPTION
### Description

([See PR in docs for context](https://github.com/inveniosoftware/docs-invenio-rdm/pull/737#discussion_r2156833316))  

This fix restricts RDM permissions to only include the local and multipart transfer types in the default permissions. Users can still enable additional transfer types by following the documentation steps, which involve:  
1. Overriding the permission policy  
2. Setting up allowed domains in the `invenio.cfg` file  

This PR also adds tests demonstrating that fetch and remote transports are disabled by default.  

**Note**: This PR depends on [invenio-drafts-resources#307](https://github.com/inveniosoftware/invenio-drafts-resources/pull/307).  

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
