### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_rdm_records/fixtures/vocabularies.py
+++ b/invenio_rdm_records/fixtures/vocabularies.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2021-2022 Northwestern University.
 # Copyright (C) 2024 TU Wien.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -17,9 +17,9 @@ from collections import defaultdict
 from os.path import splitext
 from pathlib import Path
 
-import pkg_resources
 import yaml
 from flask import current_app
+from invenio_base.utils import entry_points
 from invenio_db import db
 from invenio_vocabularies.proxies import current_service
 from invenio_vocabularies.records.models import VocabularyScheme, VocabularyType
@@ -161,19 +161,8 @@ class PrioritizedVocabulariesFixtures:
         self._loaded_vocabularies = set()
 
     def _entry_points(self):
-        """List entrypoints.
-
-        Python now officially recommends importlib.metadata
-        (importlib_metadata backport) for entrypoints:
-        - https://docs.python.org/3/library/importlib.metadata.html
-        - https://packaging.python.org/guides/creating-and-discovering-plugins/
-          #using-package-metadata
-
-        but Invenio is much invested in pkg_resources (``entry_points``
-        fixture assumes it). So we use pkg_resources for now until
-        _entry_points implementation can be changed.
-        """
-        return list(pkg_resources.iter_entry_points("invenio_rdm_records.fixtures"))
+        """List entrypoints."""
+        return entry_points("invenio_rdm_records.fixtures")
 
     def load(self, reload=None):
         """Load the fixtures.

--- a/invenio_rdm_records/resources/serializers/dcat/__init__.py
+++ b/invenio_rdm_records/resources/serializers/dcat/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023-2025 CERN
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -8,13 +9,13 @@
 """Datacite to DCAT serializer."""
 
 import mimetypes
+from importlib.resources import files
 
 from datacite import schema43
 from flask_resources import BaseListSchema, MarshmallowSerializer
 from flask_resources.serializers import SimpleSerializer
 from idutils import detect_identifier_schemes, to_url
 from lxml import etree as ET
-from pkg_resources import resource_stream
 from werkzeug.utils import cached_property
 
 from ....contrib.journal.processors import JournalDataciteDumper
@@ -47,9 +48,11 @@ class DCATSerializer(MarshmallowSerializer):
     @cached_property
     def xslt_transform_func(self):
         """Return the DCAT XSLT transformation function."""
-        with resource_stream(
-            "invenio_rdm_records.resources.serializers", "dcat/datacite-to-dcat-ap.xsl"
-        ) as f:
+        file_ = (
+            files("invenio_rdm_records.resources.serializers")
+            / "dcat/datacite-to-dcat-ap.xsl"
+        )
+        with file_.open("rb") as f:
             xsl = ET.XML(f.read())
         transform = ET.XSLT(xsl)
         return transform

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     flask-iiif>=1.0.0,<2.0.0
     ftfy>=4.4.3,<5.0.0
     invenio-administration>=4.0.0,<5.0.0
+    invenio-base>=2.3.0,<3.0.0
     invenio-checks>=0.5.0,<1.0.0
     invenio-communities>=19.0.0,<20.0.0
     invenio-drafts-resources>=7.0.0,<8.0.0


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.

* invenio-base provides a wrapper for importlib.metadata.entry_points
  to still support python3.9 until end of life
