### PR TITLE
tests: have fixture test ignore load order

### DIFF
--- a/tests/fixtures/load_error/test_vocabularies_load_error.py
+++ b/tests/fixtures/load_error/test_vocabularies_load_error.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2025 California Institute of Technology.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -25,14 +26,11 @@ def test_conflicting_load(app):
         vocabularies.load()
 
     messages = e.value.errors
-    expected_messages = set(
-        [
-            "Vocabulary 'resourcetypes' cannot have multiple sources "
-            "['tests.fixtures.load_error.conflicting_module_A.fixtures.vocabularies', "
-            "'tests.fixtures.load_error.conflicting_module_B.fixtures.vocabularies']",
-            "Vocabulary 'MeSH' cannot have multiple sources "
-            "['tests.fixtures.load_error.conflicting_module_A.fixtures.vocabularies', "
-            "'tests.fixtures.load_error.conflicting_module_B.fixtures.vocabularies']",
-        ]
-    )
-    assert expected_messages == set(messages)
+    expected_messages = [
+        "Vocabulary 'resourcetypes' cannot have multiple sources ",
+        "'tests.fixtures.load_error.conflicting_module_A.fixtures.vocabularies'",
+        "'tests.fixtures.load_error.conflicting_module_B.fixtures.vocabularies'",
+        "Vocabulary 'MeSH' cannot have multiple sources ",
+    ]
+    for line in expected_messages:
+        assert any(line in message for message in messages)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

With the pkg_resources replacement PR https://github.com/inveniosoftware/invenio-rdm-records/pull/2082, on Python 3.9 the entry point order can change. This makes the test not care about the order of the error message.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
