### PR TITLE
fix: conflicting s3 part size for 1M-5M files

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
@@ -266,13 +266,8 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
     const maxPartSize = 5 * GiB;
     const maxParts = this.#maxMultipartParts;
 
-    const fileSizeLimit = this.opts.quota?.maxFileSize || maxFileSize;
-
     // Calculate max allowed part size based on maxFileSize and maxParts, capped by S3 limit
-    const maxAllowedPartSize = Math.min(
-      maxPartSize,
-      Math.ceil(fileSizeLimit / maxParts)
-    );
+    const maxAllowedPartSize = Math.min(maxPartSize, Math.ceil(maxFileSize / maxParts));
 
     const steps = 5;
     const logMin = Math.log(minPartSize);


### PR DESCRIPTION
### Description

* the code tried to adjust possible part sizes based on the max file size setting in the RDM configuration. This conflicted with the uppy plugin's internal chunking.

* this fix always computes part sizes from AWS limits to be in sync with uppy internals. See [uppy implementation](https://github.com/transloadit/uppy/blob/main/packages/%40uppy/aws-s3/src/MultipartUploader.ts#L130)

This fixes https://github.com/inveniosoftware/invenio-app-rdm/issues/3091

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
