### PR TITLE
services: create RDMCommunityRecordSearchOptions

### DIFF
--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -210,6 +210,26 @@ class RDMSearchOptions(SearchOptions, SearchOptionsMixin):
     ]
 
 
+class RDMCommunityRecordSearchOptions(SearchOptions, SearchOptionsMixin):
+    """Search options for community record search."""
+
+    facets = {
+        "resource_type": facets.resource_type,
+        "languages": facets.language,
+        "access_status": facets.access_status,
+    }
+
+    # without VerifiedRecordsSortParam as communities review records they accept
+    params_interpreters_cls = [
+        AllVersionsParam.factory("versions.is_latest"),
+        QueryStrParam,
+        PaginationParam,
+        FacetsParam,
+        StatusParam,
+        PublishedRecordsParam,
+    ] + SearchOptions.params_interpreters_cls
+
+
 class RDMSearchDraftsOptions(SearchDraftsOptions, SearchOptionsMixin):
     """Search options for drafts search."""
 
@@ -827,8 +847,8 @@ class RDMCommunityRecordsConfig(BaseRecordServiceConfig, ConfiguratorMixin):
         "RDM_SEARCH",
         "RDM_SORT_OPTIONS",
         "RDM_FACETS",
-        search_option_cls=RDMSearchOptions,
-        search_option_cls_key="RDM_SEARCH_OPTIONS_CLS",
+        search_option_cls=RDMCommunityRecordSearchOptions,
+        search_option_cls_key="RDM_COMMUNITY_RECORD_SEARCH_OPTIONS_CLS",
     )
     search_versions = FromConfigSearchOptions(
         "RDM_SEARCH_VERSIONING",

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -191,6 +191,8 @@ def get_record_thumbnail_file(record, **kwargs):
 class RDMSearchOptions(SearchOptions, SearchOptionsMixin):
     """Search options for record search."""
 
+    verified_sorting_enabled = True
+
     facets = {
         "resource_type": facets.resource_type,
         "languages": facets.language,
@@ -210,24 +212,10 @@ class RDMSearchOptions(SearchOptions, SearchOptionsMixin):
     ]
 
 
-class RDMCommunityRecordSearchOptions(SearchOptions, SearchOptionsMixin):
+class RDMCommunityRecordSearchOptions(RDMSearchOptions):
     """Search options for community record search."""
 
-    facets = {
-        "resource_type": facets.resource_type,
-        "languages": facets.language,
-        "access_status": facets.access_status,
-    }
-
-    # without VerifiedRecordsSortParam as communities review records they accept
-    params_interpreters_cls = [
-        AllVersionsParam.factory("versions.is_latest"),
-        QueryStrParam,
-        PaginationParam,
-        FacetsParam,
-        StatusParam,
-        PublishedRecordsParam,
-    ] + SearchOptions.params_interpreters_cls
+    verified_sorting_enabled = False
 
 
 class RDMSearchDraftsOptions(SearchDraftsOptions, SearchOptionsMixin):

--- a/invenio_rdm_records/services/sort.py
+++ b/invenio_rdm_records/services/sort.py
@@ -19,7 +19,10 @@ class VerifiedRecordsSortParam(SortParam):
         If the config "RDM_SEARCH_SORT_BY_VERIFIED" is set, then all the sorting is
         prepended by the record's `is_verified` property.
         """
-        if current_app.config["RDM_SEARCH_SORT_BY_VERIFIED"]:
+        if (
+            current_app.config["RDM_SEARCH_SORT_BY_VERIFIED"]
+            and self.config.verified_sorting_enabled
+        ):
             fields = self._compute_sort_fields(params)
             return search.sort(*["-parent.is_verified", *fields])
         return super().apply(identity, search, params)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Currently the community records search uses the same search options as the record search, which means that they both currently de-rank records from unverified users. This creates confusion and frustration in community administrators as they review and accept records into their communities from unverified users, and then cannot find it. Either they think that the inclusion request failed or that the search is broken for their community. To fix this, instance administrators have to verify the community members and the owners of records in that community

As records are manually reviewed before they are accepted into communities, there is no reason to apply the de-ranking in communities.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
