### PR TITLE
ci: switch to uv for Python tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   Python:
-    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@uv
 
   JS:
     uses: inveniosoftware/workflows/.github/workflows/tests-js.yml@master


### PR DESCRIPTION
> [!IMPORTANT]
> This is not meant to be merged, but just as a precautionary check to see if the `uv` CI workflow works without issues. Once done, we'll actually merge [the workflows `uv` branch](https://github.com/inveniosoftware/workflows/tree/uv) to `master` and thus propagate the change to all repos