### PR TITLE
fix: improve rendering of ErrorMessage

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewModal.js
@@ -6,7 +6,6 @@
 
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import { Formik } from "formik";
-import _get from "lodash/get";
 import Overridable from "react-overridable";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
@@ -183,7 +182,14 @@ class SubmitReviewModalComponent extends Component {
             >
               <Modal.Header>{modalContent.headerTitle}</Modal.Header>
               <Modal.Content>
-                {errors && <ErrorMessage errors={errors} />}
+                {errors && (
+                  <ErrorMessage
+                    header={i18next.t("Unable to submit request.")}
+                    content={errors}
+                    icon="exclamation"
+                    negative
+                  />
+                )}
                 <Message visible warning>
                   <p>
                     <Icon name="warning sign" />
@@ -264,7 +270,7 @@ SubmitReviewModalComponent.propTypes = {
   initialReviewComment: PropTypes.string,
   publishModalExtraContent: PropTypes.string,
   directPublish: PropTypes.bool,
-  errors: PropTypes.node, // TODO FIXME: Use a common error cmp to display errros.
+  errors: PropTypes.string, // TODO FIXME: Use a common error cmp to display errros.
   loading: PropTypes.bool,
   record: PropTypes.object.isRequired,
   extraCheckboxes: PropTypes.arrayOf(
@@ -281,7 +287,7 @@ SubmitReviewModalComponent.defaultProps = {
   initialReviewComment: "",
   publishModalExtraContent: undefined,
   directPublish: false,
-  errors: undefined,
+  errors: "",
   loading: false,
   extraCheckboxes: [],
   beforeContent: () => undefined,


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Currently we're sending a react node to the ErrorMessage, but it actually only takes an [array of messages](https://github.com/inveniosoftware/react-invenio-forms/blob/master/src/lib/elements/ErrorMessage.js#L72) via `errors`

<img width="900" height="707" alt="image" src="https://github.com/user-attachments/assets/f824e472-7eee-48e1-9bb7-686e75547c26" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
