### PR TITLE
fix(schemaorg): chase award schema relaxation from Invenio-Vocabularies

### DIFF
--- a/invenio_rdm_records/resources/serializers/schemaorg/schema.py
+++ b/invenio_rdm_records/resources/serializers/schemaorg/schema.py
@@ -362,11 +362,11 @@ class SchemaorgSchema(BaseSerializerSchema, CommonFieldsMixin):
             number = award.get("number")
             id_ = award.get("id")
 
-            if not (id_ or (title and number)):
-                # One of 'id' or '(title' and 'number') must be provided
+            if not (id_ or title or number):
+                # One of 'id', 'title', or 'number' must be provided
                 raise ValidationError(
                     _(
-                        "Funding serialization failed on award: one of 'id' or ('number' and 'title') are required."
+                        "Funding serialization failed on award: one of 'id', 'number', or 'title' are required."
                     )
                 )
 


### PR DESCRIPTION
This chases the awards schema changes from Invenio-Vocabularies: https://github.com/inveniosoftware/invenio-vocabularies/pull/429