### PR TITLE
deposit-form: add fallback message if checksum is not yet available

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileUploaderArea.js
@@ -120,7 +120,7 @@ const FileTableRow = ({
             </a>
           )}
           <br />
-          {file.checksum && (
+          {(file.checksum && (
             <div className="ui text-muted">
               <span style={{ fontSize: "10px" }}>{file.checksum}</span>{" "}
               <Popup
@@ -130,6 +130,12 @@ const FileTableRow = ({
                 trigger={<Icon fitted name="help circle" size="small" />}
                 position="top center"
               />
+            </div>
+          )) || (
+            <div className="ui text-muted">
+              <span style={{ fontSize: "10px" }}>
+                {i18next.t("Checksum not yet calculated.")}
+              </span>{" "}
             </div>
           )}
         </div>


### PR DESCRIPTION
This is relevant for the multipart file upload with local file storage, where the checksum gets calculated in a background task after finalizing the upload.

See also: https://github.com/inveniosoftware/invenio-records-resources/pull/650