### PR TITLE
fix: mark doiDefaultSelection as a string

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField/PIDFieldCmp.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField/PIDFieldCmp.js
@@ -1,6 +1,6 @@
 // This file is part of Invenio-RDM-Records
 // Copyright (C) 2020-2023 CERN.
-// Copyright (C) 2020-2022 Northwestern University.
+// Copyright (C) 2020-2025 Northwestern University.
 //
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -53,7 +53,7 @@ PIDField.propTypes = {
   required: PropTypes.bool,
   unmanagedHelpText: PropTypes.string,
   record: PropTypes.object.isRequired,
-  doiDefaultSelection: PropTypes.object.isRequired,
+  doiDefaultSelection: PropTypes.string.isRequired,
   optionalDOItransitions: PropTypes.array.isRequired,
 };
 


### PR DESCRIPTION
May or may not accumulate little fixes to the deposit page in here.

- fixes "Warning: Failed prop type: Invalid prop `doiDefaultSelection` of type `string` supplied to `PIDField`, expected `object`." . It's clearly meant to be a string: https://github.com/inveniosoftware/invenio-app-rdm/blob/master/invenio_app_rdm/records_ui/views/deposits.py#L74