### PR TITLE
(fix)lift embargo: removing pid reserving

### DIFF
--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -143,7 +143,6 @@ class RDMRecordService(RecordService):
             "lift_embargo", identity, draft=draft, record=record, uow=uow
         )
 
-        self._pids.pid_manager.create_and_reserve(record)
         uow.register(RecordCommitOp(record, indexer=self.indexer))
         uow.register(TaskOp(register_or_update_pid, record["id"], "doi", parent=False))
         # If the record was previously public it will still keep the parent PID


### PR DESCRIPTION
* removing the manager method as it does not change anything (if DOI was not already on the record, it won't be created here)

