### PR TITLE
iiif: add error handler for `MultimediaImageNotFound`

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -18,6 +18,7 @@ import marshmallow as ma
 import requests
 from flask import Response, current_app, g, request, send_file
 from flask_cors import cross_origin
+from flask_iiif.errors import MultimediaImageNotFound
 from flask_resources import (
     HTTPJSONException,
     JSONSerializer,
@@ -105,6 +106,11 @@ class IIIFResourceConfig(ResourceConfig, ConfiguratorMixin):
                 description=_(
                     "The record associated with this file has been deleted. See deletion notice."
                 ),
+            )
+        ),
+        MultimediaImageNotFound: create_error_handler(
+            lambda e: HTTPJSONException(
+                code=404, description=_("The requested image cannot be found.")
             )
         ),
     }


### PR DESCRIPTION
Add error handler for `flask_iiif.errors.MultimediaImageNotFound` in the IIIF resource, to get a 404 response instead of a 500.

Example URL: `https://test.researchdata.tuwien.ac.at/api/iiif/record:9tp42-0pk88:example_upload.tiff/full/!800,800/0/default.jpg`

:detective: **Note**: The file `example_upload.tiff` is actually a text file, probably that's why the IIIF file can't be found.

---

```
Exception on /iiif/record:9tp42-0pk88:example_upload.tiff/full/!800,800/0/default.jpg [GET]
Traceback (most recent call last):
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_iiif/api.py", line 592, in open_image
    image = Image.open(source)
  File "/var/instance/.venv/lib/python3.13/site-packages/PIL/Image.py", line 3580, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BufferedReader name=b'/mnt/data-volume/uploaded_data/b6/6b/e75f-55af-4587-914b-1cd7f69f9dcb/data'>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/instance/.venv/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/instance/.venv/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/instance/.venv/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/instance/.venv/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_resources/resources.py", line 65, in view
    return view_meth()
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_resources/content_negotiation.py", line 116, in inner_content_negotiation
    return f(*args, **kwargs)
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_cors/decorator.py", line 121, in wrapped_function
    resp = make_response(f(*args, **kwargs))
                         ~^^^^^^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_resources/parsers/decorators.py", line 51, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_resources/parsers/decorators.py", line 51, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_resources/parsers/decorators.py", line 51, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.13/site-packages/invenio_rdm_records/resources/iiif.py", line 152, in _wrapper
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.13/site-packages/invenio_rdm_records/resources/iiif.py", line 262, in image_api
    to_serve = self.service.image_api(
        identity=g.identity,
    ...<5 lines>...
        image_format=image_format,
    )
  File "/var/instance/.venv/lib/python3.13/site-packages/invenio_rdm_records/services/iiif/service.py", line 166, in image_api
    image = IIIFImageAPIWrapper.open_image(data)
  File "/var/instance/.venv/lib/python3.13/site-packages/flask_iiif/api.py", line 594, in open_image
    raise MultimediaImageNotFound("The requested image cannot be opened")
flask_iiif.errors.MultimediaImageNotFound: 'Error message: The requested image cannot be opened. Error code: 404'
```