### PR TITLE
resource_types: Remove publication-thesis

### DIFF
--- a/invenio_rdm_records/fixtures/data/vocabularies/resource_types.yaml
+++ b/invenio_rdm_records/fixtures/data/vocabularies/resource_types.yaml
@@ -416,28 +416,6 @@
   tags:
     - depositable
     - linkable
-- id: publication-thesis
-  icon: file alternate
-  props:
-    csl: thesis
-    datacite_general: Text
-    datacite_type: Thesis
-    openaire_resourceType: "0006"
-    openaire_type: publication
-    eurepo: info:eu-repo/semantics/doctoralThesis
-    schema.org: https://schema.org/Thesis
-    subtype: publication-thesis
-    type: publication
-    marc21_type: publication
-    marc21_subtype: thesis
-  title:
-    en: Thesis
-    sv: Avhandling
-    de: Abschlussarbeit
-    cs: Závěrečná práce
-  tags:
-    - depositable
-    - linkable
 - id: publication-workingpaper
   icon: file alternate
   props:
@@ -497,10 +475,10 @@
     marc21_type: publication
     marc21_subtype: dissertation
   title:
-    en: Dissertation
+    en: Thesis
     sv: Avhandling
-    de: Dissertation
-    cs: Disertační práce
+    de: Abschlussarbeit
+    cs: Závěrečná práce
   tags:
     - depositable
     - linkable

--- a/invenio_rdm_records/resources/serializers/bibtex/schema.py
+++ b/invenio_rdm_records/resources/serializers/bibtex/schema.py
@@ -60,7 +60,9 @@ class BibTexSchema(BaseSerializerSchema, CommonFieldsMixin):
         ],
         "publication-article": [BibTexFormatter.article],
         "publication-preprint": [BibTexFormatter.unpublished],
-        "publication-thesis": [BibTexFormatter.thesis],
+        "publication-dissertation": [
+            BibTexFormatter.thesis
+        ],  # Previously publication-thesis
         "publication-technicalnote": [BibTexFormatter.manual],
         "publication-workingpaper": [BibTexFormatter.unpublished],
         # Software

--- a/tests/resources/serializers/test_bibtex_serializer.py
+++ b/tests/resources/serializers/test_bibtex_serializer.py
@@ -438,7 +438,9 @@ def test_serialize_publication_thesis(running_app, updated_minimal_record):
 
     It serializes into 'phdthesis'.
     """
-    updated_minimal_record["metadata"]["resource_type"]["id"] = "publication-thesis"
+    updated_minimal_record["metadata"]["resource_type"][
+        "id"
+    ] = "publication-dissertation"  # Previously publication-thesis
 
     updated_minimal_record.update(
         {"custom_fields": {"thesis:university": "A university"}}


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-rdm/issues/522

# Recipe
### To update resource-types in existing data

Run:
```
invenio rdm-records add-to-fixture resourcetypes
```

Run the following script for updating the existing records with resource type publication-thesis to publication-dissertation:
```python
from invenio_access.permissions import system_identity
from invenio_rdm_records.proxies import current_rdm_records_service

hits = current_rdm_records_service.search(system_identity, {"q": "metadata.resource_type.id:publication-thesis"})
for hit in hits:
    draft = current_rdm_records_service.edit(system_identity, hit['id'])
    draft.data["metadata"]["resource_type"]["id"] = "publication-dissertation"
    
    updated_draft = current_rdm_records_service.update_draft(system_identity, draft.id, draft.data)
    
    current_rdm_records_service.publish(system_identity, updated_draft.id)
```

Run the following script for updating existing drafts with resource type publication-thesis to publication-dissertation:
```python
from invenio_access.permissions import system_identity
from invenio_rdm_records.proxies import current_rdm_records_service

hits = current_rdm_records_service.search_drafts(system_identity, params={"q": "metadata.resource_type.id:publication-thesis"})
for hit in hits:
    draft = current_rdm_records_service.edit(system_identity, hit['id'])
    draft.data['metadata']['resource_type']['id'] = 'publication-dissertation'

    updated_draft = current_rdm_records_service.update_draft(system_identity, draft.id, draft.data)
```