### PR TITLE
setup: unpin ftfy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     dcxml>=0.1.2,<1.0.0
     Faker>=2.0.3
     flask-iiif>=1.0.0,<2.0.0
-    ftfy>=4.4.3,<5.0.0
     invenio-administration>=4.0.0,<5.0.0
     invenio-base>=2.3.0,<3.0.0
     invenio-checks>=1.0.0,<2.0.0


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

ftfy isn't used in invenio-rdm-records, was pinned more than 3 years ago, and there aren't any obvious breaking changes in the 6.0 series. Pinning to 5.0 causes a pkg_resources deprecation warning. I think we can just remove the pin.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
