### PR TITLE
fix(record-deletion): add safety net permission

### DIFF
--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -319,6 +319,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     #
     can_delete = [Administration(), SystemProcess()]
     can_delete_files = [SystemProcess()]
+    can_request_deletion = can_manage
     can_purge = [SystemProcess()]
 
     #

--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -260,6 +260,8 @@ class RDMRecordService(RecordService):
         """Request deletion of a record."""
         record = self.record_cls.pid.resolve(id_)
 
+        self.require_permission(identity, "request_deletion", record=record)
+
         if record.deletion_status.is_deleted:
             raise DeletionStatusException(record, RecordDeletionStatusEnum.PUBLISHED)
 


### PR DESCRIPTION
* Adds a `can_request_deletion` permission for the
  `RDMRecordService.request_deletion` service call.
* This is meant to be a "safety net" to narrow down the set of
  actors that can manage the record. The configured deletion policy will
  actually check the specifics of whether a record is within policy for
  immediate deletion or a deletion request.
