### PR TITLE
feat: config: add last reply sort option

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -321,6 +321,14 @@ RDM_SORT_OPTIONS = {
     "mostdownloaded": dict(
         title=_("Most downloaded"), fields=["-stats.all_versions.unique_downloads"]
     ),
+    "newestactivity": dict(
+        title=_("Newest activity"),
+        fields=["-last_activity_at"],
+    ),
+    "oldestactivity": dict(
+        title=_("Oldest activity"),
+        fields=["last_activity_at"],
+    ),
 }
 """Definitions of available record sort options.
 


### PR DESCRIPTION
Defines globally `last_replied` as an available sorting field.

Related:
* inveniosoftware/invenio-requests#485
* inveniosoftware/invenio-app-rdm#3191
