### PR TITLE
feat: Add configuration to make expiration date of share links required

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -754,3 +754,6 @@ RDM_RECORDS_RESTRICTION_GRACE_PERIOD = timedelta(days=30)
 
 RDM_RECORDS_ALLOW_RESTRICTION_AFTER_GRACE_PERIOD = False
 """Whether record access restriction is allowed after the grace period or not."""
+
+RDM_RECORDS_REQUIRE_SECRET_LINKS_EXPIRATION = False
+"""Whether share access links require an expiration date to be set or not."""

--- a/invenio_rdm_records/services/access/service.py
+++ b/invenio_rdm_records/services/access/service.py
@@ -130,6 +130,15 @@ class RecordAccessService(RecordService):
         was set in the given data, or if it was omitted (which makes a
         difference in patch operations).
         """
+        if (
+            current_app.config["RDM_RECORDS_REQUIRE_SECRET_LINKS_EXPIRATION"]
+            and not expires_at
+        ):
+            raise ValidationError(
+                message=_("Expiration date is required"),
+                field_name="expires_at",
+            )
+
         if expires_at and is_specified:
             # if the expiration date was specified, check if it's in the future
             expires_at = arrow.get(expires_at).to("utc").datetime


### PR DESCRIPTION
### Description

---

This is a redo of https://github.com/inveniosoftware/invenio-rdm-records/pull/2119

The corresponding frontend part is https://github.com/inveniosoftware/invenio-app-rdm/pull/3187.

The frontend PR has to be merged AFTER this one.

In the original PR @max-moser was ok with the naming of `RDM_RECORDS_REQUIRE_SECRET_LINKS_EXPIRATION` and Nicola suggested that a test for the new if-clause would be nice.

---

This PR adds a config var to make it configurable whether an expiration date must be set on a share access link or not.

<img width="1348" height="1061" alt="image" src="https://github.com/user-attachments/assets/839c642c-3f03-400a-8bbb-8bb3b5ec2402" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).