### PR TITLE
OAI-PMH (GetRecord verb): handle broader permission denied errors

### DIFF
--- a/invenio_rdm_records/oai.py
+++ b/invenio_rdm_records/oai.py
@@ -14,7 +14,7 @@ from flask import current_app, g
 from invenio_pidstore.errors import PersistentIdentifierError, PIDDoesNotExistError
 from invenio_pidstore.fetchers import FetchedPID
 from invenio_pidstore.models import PersistentIdentifier
-from invenio_records_resources.services.errors import PermissionDeniedError
+from invenio_records_resources.services.errors import PermissionDenied
 from invenio_search import RecordsSearch
 from invenio_search.engine import dsl
 from lxml import etree
@@ -130,7 +130,7 @@ def getrecord_fetcher(record_id):
 
     try:
         result = current_rdm_records.records_service.read(g.identity, recid.pid_value)
-    except PermissionDeniedError:
+    except PermissionDenied:
         # if it is a restricted record.
         raise PIDDoesNotExistError("recid", None)
 


### PR DESCRIPTION
Previously, the `GetRecord` verb targeting a restricted record would result in a HTTP 500 response due to an unhandled error.

The `getrecord_fetcher()` function only handled `PermissionDeniedError` exceptions but not `RecordPermissionDeniedError`, which are the ones raised by services.

Since both of them are subclasses of `PermissionDenied`, we simply handle that instead.