### PR TITLE
fix(services): Make 'notes' parameter optional in _update_quota

### DIFF
--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -706,7 +706,7 @@ class RDMRecordService(RecordService):
     #
     # Record file quota handling
     #
-    def _update_quota(self, record, quota_size, max_file_size, notes):
+    def _update_quota(self, record, quota_size, max_file_size, notes=None):
         """Update record with quota values."""
         record.quota_size = quota_size
         if max_file_size:


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The "Notes" field is optional in the UI and in the function, but required in the function definition. This PR makes it optional.

If you set a quota once in the administrative panel without providing a note, it works fine. If you set a quota again, it fails with `RDMRecordService._update_quota() missing 1 required positional argument: 'notes'` because the second time the update method gets used.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
