### PR TITLE
fix: showing all available suggestions in lang picker

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/DescriptionsField/components/AdditionalDescriptionsField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/DescriptionsField/components/AdditionalDescriptionsField.js
@@ -69,7 +69,7 @@ export class AdditionalDescriptionsField extends Component {
                       suggestions.map((item) => ({
                         text: item.title_l10n,
                         value: item.id,
-                        fieldPathPrefix: item.id,
+                        key: item.id,
                       }))
                     }
                     initialOptions={

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/TitlesField/AdditionalTitlesField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/TitlesField/AdditionalTitlesField.js
@@ -63,7 +63,7 @@ class AdditionalTitlesFieldComponent extends Component {
                   suggestions.map((item) => ({
                     text: item.title_l10n,
                     value: item.id,
-                    fieldPathPrefix: item.id,
+                    key: item.id,
                   }))
                 }
                 initialOptions={languagesInitialOptions}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

Language selector in additional titles and additional descriptions is only showing one suggestion, even though API returnes plenty of results. I don't know if this could be intentional, but I would assume it is not. 

Before:
<img width="2836" height="1340" alt="image" src="https://github.com/user-attachments/assets/8900c504-ec68-4d66-a2ee-f9b2a461d039" />

After:

<img width="1348" height="468" alt="image" src="https://github.com/user-attachments/assets/b62986a7-b0d3-45c0-968f-43cb93576467" />


### Checklist



**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
