### PR TITLE
fix(config): reuse community records search params config

### DIFF
--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -586,6 +586,10 @@ class RDMCommunityRecordsResourceConfig(RecordResourceConfig, ConfiguratorMixin)
         default=record_serializers,
     )
 
+    request_search_args = FromConfig(
+        "RDM_SEARCH_ARGS_SCHEMA", default=RDMSearchRequestArgsSchema
+    )
+
 
 class RDMRecordCommunitiesResourceConfig(CommunityResourceConfig, ConfiguratorMixin):
     """Record communities resource config."""


### PR DESCRIPTION
* Search params configured by `RDM_SEARCH_ARGS_SCHEMA` were
  not used in the `/api/communities/{id}/records` endpoint.
