### PR TITLE
config: add RDM_MODERATION_REQUEST_TYPES

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -29,6 +29,7 @@ from invenio_rdm_records.services.components.verified import UserModerationHandl
 from . import tokens
 from .requests.community_inclusion import CommunityInclusion
 from .requests.community_submission import CommunitySubmission
+from .requests.record_deletion import RecordDeletion
 from .resources.serializers import DataCite45JSONSerializer
 from .services import facets
 from .services.config import lock_edit_published_files
@@ -223,6 +224,8 @@ RDM_COMMUNITY_REQUIRED_TO_PUBLISH = False
 RDM_COMMUNITY_INCLUSION_REQUEST_CLS = CommunityInclusion
 """Request type for record inclusion requests."""
 
+RDM_MODERATION_REQUEST_TYPES = [RecordDeletion.type_id]
+"""List of moderation request types for RDM records."""
 #
 # Search configuration
 #


### PR DESCRIPTION
Add moderation request types to config.

> [!NOTE]
> I am conflicted on where to add this config. This place makes the most sense to me logically but it could be confusing when adding other request types/changing this config. Any feedback is welcome.


Fixes https://github.com/inveniosoftware/invenio-app-rdm/issues/3242