### PR TITLE
feat(permissions): add `RDM_ALLOW_OWNERS_REMOVE_COMMUNITY`

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -279,6 +279,16 @@ RDM_COMMUNITY_REQUIRED_TO_PUBLISH = False
 """Enforces at least one community per record."""
 RDM_COMMUNITY_INCLUSION_REQUEST_CLS = CommunityInclusion
 """Request type for record inclusion requests."""
+RDM_ALLOW_OWNERS_REMOVE_COMMUNITY_FROM_RECORD = True
+"""Allow record owners to remove communities from records.
+
+When set to False, only community curators, managers, and owners can remove
+communities from records. This applies to published records.
+Record owners will still be able to add communities, but removal is restricted
+to community curators, managers, and owners.
+
+Default: True (backwards compatible - owners can remove communities)
+"""
 
 #
 # Search configuration

--- a/invenio_rdm_records/services/communities/service.py
+++ b/invenio_rdm_records/services/communities/service.py
@@ -217,7 +217,10 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
 
         try:
             self.require_permission(
-                identity, "remove_community", record=record, community_id=community_id
+                identity,
+                "remove_community_from_record",
+                record=record,
+                community_id=community_id,
             )
             # By default, admin/superuser has permission to do everything,
             # so PermissionDeniedError won't be raised for admin in any case
@@ -233,7 +236,7 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
 
         # Run components
         self.run_components(
-            "remove_community",
+            "remove_community_from_record",
             identity,
             record=record,
             community=community,

--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -251,21 +251,23 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     # Who can add record to a community
     can_add_community = can_manage
     # Who can remove a community from a record
-    can_remove_community_ = [
-        RecordOwners(),
-        CommunityCurators(),
-        SystemProcess(),
+    can_remove_community_from_record_ = [
+        IfConfig(
+            "RDM_ALLOW_OWNERS_REMOVE_COMMUNITY_FROM_RECORD",
+            then_=[RecordOwners(), CommunityCurators(), SystemProcess()],
+            else_=[CommunityCurators(), SystemProcess()],
+        ),
     ]
-    can_remove_community = [
+    can_remove_community_from_record = [
         IfConfig(
             "RDM_COMMUNITY_REQUIRED_TO_PUBLISH",
             then_=[
                 IfOneCommunity(
                     then_=[Administration(), SystemProcess()],
-                    else_=can_remove_community_,
+                    else_=can_remove_community_from_record_,
                 ),
             ],
-            else_=can_remove_community_,
+            else_=can_remove_community_from_record_,
         ),
     ]
     # Who can remove records from a community

--- a/tests/resources/test_resources_community_records.py
+++ b/tests/resources/test_resources_community_records.py
@@ -18,7 +18,9 @@ def service():
     return current_community_records_service
 
 
-def test_remove_community(client, curator, record_community, headers, community):
+def test_remove_community_from_record(
+    client, curator, record_community, headers, community
+):
     """Remove a record from the community."""
     client = curator.login(client)
     record = record_community.create_record()

--- a/tests/services/test_service_record_communities.py
+++ b/tests/services/test_service_record_communities.py
@@ -98,14 +98,14 @@ def test_add_community_component_called(
     assert "dummy_id" not in [c["community_id"] for c in requests]
 
 
-def test_remove_community_component_called(
+def test_remove_community_from_record_component_called(
     db, community, community2, uploader, record_factory, set_app_config_fn_scoped
 ):
-    """The component `remove_community` method is called and blocks the removal."""
+    """The component `remove_community_from_record` method is called and blocks the removal."""
     test_community_id = community.id
 
     class MockRemoveComponent(ServiceComponent):
-        def remove_community(
+        def remove_community_from_record(
             self, identity, record, community, valid_data, errors, **kwargs
         ):
             if community["id"] == str(community2.id):


### PR DESCRIPTION
* add ``RDM_ALLOW_OWNERS_REMOVE_COMMUNITY`` configuration variable to control whether record owners can remove communities from records. When set to False, only community curators, managers, and owners can remove communities.
* closes https://github.com/CERNDocumentServer/cds-rdm/issues/630

<img width="1147" height="400" alt="image" src="https://github.com/user-attachments/assets/ca938b55-0ee0-45f0-8ef5-5c6325cebab9" />
