### PR TITLE
fix(tests): make logic to restore last revision more robust

### DIFF
--- a/tests/services/files/test_revert_of_deleted_files_in_published_record.py
+++ b/tests/services/files/test_revert_of_deleted_files_in_published_record.py
@@ -82,7 +82,9 @@ def test_revert_of_deleted_files_in_published_record(
     deleted_file = all_files["test.pdf"]
 
     # revert deleted file
-    deleted_file.revert(deleted_file.revision_id - 1)
+    # note that the list of revision IDs may have "holes" in it, so we use
+    # negative array indexing to find the second-to-last revision
+    deleted_file.revert(deleted_file.revisions[-2].revision_id)
 
     files = service.files.list_files(identity_simple, record.id)
     files_keys = [f["key"] for f in files.to_dict()["entries"]]


### PR DESCRIPTION
The `invenio_records.api.RevisionsIterator` definition mentions that the list of revision IDs may have "holes" in it: https://github.com/inveniosoftware/invenio-records/blob/master/invenio_records/api.py#L627-L635

The PR https://github.com/inveniosoftware/invenio-records-resources/pull/662 caused this test to fail because it introduced another "hole" in the list of revision IDs:
```python
ipdb> [v.version_id for v in self.model.versions]
[3, 5, 7]
```
With the old logic here, this looked for revision with ID 6, which doesn't exist.

---

:information_source: It's noteworthy that the above PR didn't introduce holes in general, only in the spot that would offend this test.
Without the PR above, the list of revision IDs looks like follows (from a local test run, with a breakpoint):
```python
ipdb> [v.revision_id for v in deleted_file.revisions]
[2, 4, 5]
```