### PR TITLE
`SanitizedHTML`: Take allowed HTML tags & attributes from the application configuration

### DIFF
--- a/invenio_rdm_records/resources/deserializers/rocrate/schema.py
+++ b/invenio_rdm_records/resources/deserializers/rocrate/schema.py
@@ -10,7 +10,9 @@
 
 from invenio_i18n import lazy_gettext as _
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, pre_load, validate
-from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode
+from marshmallow_utils.fields import SanitizedUnicode
+
+from ....services.schemas.fields import SanitizedHTML
 
 
 def _list_value(lst):

--- a/invenio_rdm_records/resources/serializers/cff/schema.py
+++ b/invenio_rdm_records/resources/serializers/cff/schema.py
@@ -10,7 +10,9 @@
 from flask_resources.serializers import BaseSerializerSchema
 from invenio_i18n import lazy_gettext as _
 from marshmallow import ValidationError, fields, missing
-from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode
+from marshmallow_utils.fields import SanitizedUnicode
+
+from ....services.schemas.fields import SanitizedHTML
 
 
 def _serialize_person(person):

--- a/invenio_rdm_records/resources/serializers/schemaorg/schema.py
+++ b/invenio_rdm_records/resources/serializers/schemaorg/schema.py
@@ -20,9 +20,10 @@ from flask_resources.serializers import BaseSerializerSchema
 from idutils import to_url
 from invenio_i18n import lazy_gettext as _
 from marshmallow import Schema, ValidationError, fields, missing
-from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode
+from marshmallow_utils.fields import SanitizedUnicode
 from pydash import py_
 
+from ....services.schemas.fields import SanitizedHTML
 from ..schemas import CommonFieldsMixin
 from ..utils import convert_size, get_vocabulary_props
 

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -33,8 +33,8 @@ from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode, StrippedHT
 from marshmallow_utils.fields.babel import gettext_from_dict
 from pyparsing import ParseException
 
-from invenio_rdm_records.services.request_policies import RDMRecordDeletionPolicy
-
+from ....services.request_policies import RDMRecordDeletionPolicy
+from ....services.schemas.fields import SanitizedHTML
 from .fields import AccessStatusField
 
 

--- a/invenio_rdm_records/services/schemas/fields.py
+++ b/invenio_rdm_records/services/schemas/fields.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2025 TU Wien.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Marshmallow field definitions."""
+
+
+from flask import current_app
+from marshmallow_utils.fields import SanitizedHTML as SanitizedHTMLBase
+
+
+class SanitizedHTML(SanitizedHTMLBase):
+    """String field that sanitizes HTML tags with the ``bleach`` library.
+
+    In contrast to the base class, this field takes the Flask application's
+    configuration into account.
+    """
+
+    @property
+    def tags(self):
+        """Get the list of allowed HTML tags.
+
+        If no application context is available, use the field's set value as fallback.
+        """
+        try:
+            return current_app.config["ALLOWED_HTML_TAGS"]
+        except RuntimeError:
+            return self._tags
+
+    @tags.setter
+    def tags(self, value):
+        """Set the field's fallback value for allowed HTML tags."""
+        self._tags = value
+
+    @property
+    def attrs(self):
+        """Get the dictionary for allowed attributes per HTML tag.
+
+        If no application context is available, use the field's set value as fallback.
+        """
+        try:
+            return current_app.config["ALLOWED_HTML_ATTRS"]
+        except RuntimeError:
+            return self._attrs
+
+    @attrs.setter
+    def attrs(self, value):
+        """Set the field's fallback value for allowed HTML attributes."""
+        self._attrs = value

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -35,11 +35,12 @@ from marshmallow_utils.fields import (
     EDTFDateTimeString,
     IdentifierSet,
     IdentifierValueSet,
-    SanitizedHTML,
     SanitizedUnicode,
 )
 from marshmallow_utils.schemas import GeometryObjectSchema, IdentifierSchema
 from werkzeug.local import LocalProxy
+
+from .fields import SanitizedHTML
 
 record_personorg_schemes = LocalProxy(
     lambda: current_app.config["RDM_RECORDS_PERSONORG_SCHEMES"]

--- a/invenio_rdm_records/services/schemas/parent/access.py
+++ b/invenio_rdm_records/services/schemas/parent/access.py
@@ -17,11 +17,12 @@ from marshmallow import Schema, fields, validate
 from marshmallow.validate import OneOf
 from marshmallow_utils.fields import (
     ISODateString,
-    SanitizedHTML,
     SanitizedUnicode,
     TZDateTime,
 )
 from marshmallow_utils.permissions import FieldPermissionsMixin
+
+from ..fields import SanitizedHTML
 
 
 class GrantSubject(Schema):

--- a/invenio_rdm_records/services/schemas/record.py
+++ b/invenio_rdm_records/services/schemas/record.py
@@ -21,13 +21,13 @@ from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_dump, pre
 from marshmallow_utils.fields import (
     EDTFDateTimeString,
     NestedAttribute,
-    SanitizedHTML,
     SanitizedUnicode,
     TZDateTime,
 )
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
 from .access import AccessSchema
+from .fields import SanitizedHTML
 from .files import FilesSchema
 from .metadata import MetadataSchema
 from .parent import RDMParentSchema


### PR DESCRIPTION
Previously, the set of allowed HTML tags and attributes was actually taken from a hard-coded list in [`marshmallow_utils.html`](https://github.com/inveniosoftware/marshmallow-utils/blob/master/marshmallow_utils/html.py#L24) because they weren't specified as arguments to the constructor.

This means that the configuration wasn't taken into account, and it easily possible to change the list of allowed tags and attributes, e.g. to allow the `<img>` tag.

The latter is not part of the hard-coded list, causing the image feature in the TinyMCE editor to not work properly.