### PR TITLE
fix(tests): update wikidata identifier

### DIFF
--- a/tests/resources/serializers/conftest.py
+++ b/tests/resources/serializers/conftest.py
@@ -310,7 +310,7 @@ def full_record_to_dict():
                         },
                         "identifiers": [
                             {
-                                "identifier": "12345abcde",
+                                "identifier": "Q39",
                                 "scheme": "wikidata",
                             },
                             {

--- a/tests/services/schemas/test_location.py
+++ b/tests/services/schemas/test_location.py
@@ -38,6 +38,16 @@ def test_valid_full(app, valid_full_location):
         ({"description": "test location description"}),
         ({"place": "test location place"}),
         ({"identifiers": [{"identifier": "Q39", "scheme": "wikidata"}]}),
+        (
+            {
+                "identifiers": [
+                    {
+                        "identifier": "https://www.geonames.org/2660646",
+                        "scheme": "geonames",
+                    }
+                ]
+            }
+        ),
     ],
 )
 def test_valid_minimal(app, valid_minimal_location):


### PR DESCRIPTION
### Description

* recent [update in idutils](https://github.com/inveniosoftware/idutils/pull/131) started normalizing wikidata identifier
* tests here were using fake value and thus started failing
* using real CERN's identifier fixes the test

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
