### PR TITLE
fix(iiif): validate expected shape of identifiers

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -42,7 +42,7 @@ from invenio_records_resources.services.base.config import ConfiguratorMixin, Fr
 from PIL.Image import DecompressionBombError
 from werkzeug.utils import cached_property, secure_filename
 
-from ..services.errors import RecordDeletedException
+from ..services.errors import IdentifierShapeException, RecordDeletedException
 from .serializers import (
     IIIFCanvasV2JSONSerializer,
     IIIFInfoV2JSONSerializer,
@@ -109,6 +109,9 @@ class IIIFResourceConfig(ResourceConfig, ConfiguratorMixin):
             lambda e: HTTPJSONException(
                 code=404, description=_("The requested image cannot be found.")
             )
+        ),
+        IdentifierShapeException: create_error_handler(
+            lambda e: HTTPJSONException(code=400, description=e.description)
         ),
     }
 

--- a/invenio_rdm_records/services/errors.py
+++ b/invenio_rdm_records/services/errors.py
@@ -216,3 +216,21 @@ class CannotRemoveCommunityError(Exception):
     """Error thrown when the last community is being removed from the record."""
 
     description = _("A record should be part of at least 1 community.")
+
+
+class IdentifierShapeException(ValueError):
+    """Error denoting that an identifier did not match an expected shape."""
+
+    def __init__(self, identifier, expected_shape):
+        """Constructor."""
+        self.identifier = identifier
+        self.expected_shape = expected_shape
+
+    @property
+    def description(self):
+        """Exception description."""
+        return _(
+            "The identifier '%(id)s' did not match the expected shape '%(shape)s'",
+            id=self.identifier,
+            shape=self.expected_shape,
+        )

--- a/invenio_rdm_records/services/iiif/service.py
+++ b/invenio_rdm_records/services/iiif/service.py
@@ -11,6 +11,8 @@ import io
 from flask_iiif.api import IIIFImageAPIWrapper
 from invenio_records_resources.services import Service
 
+from ..errors import IdentifierShapeException
+
 try:
     metadata.distribution("wand")
     from wand.image import Image
@@ -48,16 +50,26 @@ class IIIFService(Service):
 
         We assume the uuid is build as ``<record|draft>:<pid_value>``.
         """
-        type_, id_ = uuid.split(":", 1)
-        return type_, id_
+        try:
+            type_, id_ = uuid.split(":")
+            return type_, id_
+
+        except ValueError as e:
+            raise IdentifierShapeException(uuid, "<record|draft>:<pid_value>") from e
 
     def _iiif_image_uuid(self, uuid):
         """Split the uuid content.
 
         We assume the uuid is build as ``<record|draft>:<pid_value>:<key>``.
         """
-        type_, id_, key = uuid.split(":", 2)
-        return type_, id_, key
+        try:
+            type_, id_, key = uuid.split(":", 2)
+            return type_, id_, key
+
+        except ValueError as e:
+            raise IdentifierShapeException(
+                uuid, "<record|draft>:<pid_value>:<key>"
+            ) from e
 
     def file_service(self, type_):
         """Get the correct instance of the file service, draft vs record."""

--- a/tests/resources/test_iiif_image_api.py
+++ b/tests/resources/test_iiif_image_api.py
@@ -172,6 +172,16 @@ def test_api_info_not_found(running_app, search_clear, client):
     assert response.status_code == 404
 
 
+def test_api_invalid_keys(running_app, search_clear, client):
+    # gives 0 colons instead of the 2 expected
+    response = client.get(f"/iiif/record;1234-abcd;notfound.png/info.json")
+    assert response.status_code == 400
+
+    # gives 1 colon instead of the 2 expected
+    response = client.get(f"/iiif/record:1234-abcd;notfound.png/info.json")
+    assert response.status_code == 400
+
+
 def test_iiif_base_restricted_files(
     running_app,
     search_clear,


### PR DESCRIPTION
Some IIIF API endpoints expect passed identifiers to have a specific shape (either two or three separator colons).
Currently, this is not validated beyond a simple `id.split(":")` which causes a 500 internal server error if the identifier doesn't match the expected shape.

This PR introduces a new exception type that indicates the case that an identifier did not match the expected shape.