### PR TITLE
fix (deposit): better js serializer customization

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormApp.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFormApp.js
@@ -27,12 +27,34 @@ import { DepositService } from "./DepositService";
 import { configureStore } from "../store";
 import { RDMUploadProgressNotifier } from "../components/UploadProgressNotifier";
 
+/**
+ * Instantiates a class if a constructor is provided, otherwise returns the object as-is.
+ * @param {Function|Object|null} classOrInstance - A class constructor or an instance
+ * @param {Array} args - Arguments to pass to the constructor if instantiating
+ * @returns {Object|null} The instance or null if input is null/undefined
+ */
+const asInstance = (classOrInstance, ...args) => {
+  if (!classOrInstance) {
+    return null;
+  }
+
+  if (typeof classOrInstance === "function") {
+    return new classOrInstance(...args);
+  }
+
+  return classOrInstance;
+};
+
 export class DepositFormApp extends Component {
   constructor(props) {
     super(props);
 
     const recordSerializer = props.recordSerializer
-      ? props.recordSerializer
+      ? asInstance(
+          props.recordSerializer,
+          props.config.default_locale,
+          props.config.custom_fields.vocabularies
+        )
       : new RDMDepositRecordSerializer(
           props.config.default_locale,
           props.config.custom_fields.vocabularies


### PR DESCRIPTION
Right now, if you want to customize the deposit JS serializer, you need to "overwrite" the entire deposit form because `DepositFormApp` expects an object instead of a class. The only way (that I know of) to instantiate that object with the proper arguments is within the `render` method from `RDMDepositForm`.

With this change, we allow passing a class, which in turn allows us to use `Overridables` to change the deposit serializer.

```js
import { DepositFormApp } from "@js/invenio_rdm_records/src/deposit/api/DepositFormApp";
import { AwesomeSerializer} from "@js/site/records/deposit/DepositRecordSerializer"

const parametrizedRDMDepositForm = parametrize(DepositFormApp, {"recordSerializer": AwesomeSerializer})

export const overriddenComponents = {
  // Deposit
  "InvenioAppRdm.Deposit.RDMDepositForm.layout": parametrizedRDMDepositForm,
...
}
```

The whole reason for the `asInstance` function is to make it backwards compatible and to allow using it with the rest of the props in the future.