### PR TITLE
fix: add preview button to publish modal

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PreviewButton/PreviewButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PreviewButton/PreviewButton.js
@@ -24,13 +24,19 @@ export class PreviewButtonComponent extends Component {
 
   handlePreview = (event, handleSubmit) => {
     const { setSubmitContext } = this.context;
+    const { depositFormHandleSubmit } = this.props;
 
     setSubmitContext(DepositFormSubmitActions.PREVIEW);
-    handleSubmit(event);
+
+    if (depositFormHandleSubmit) {
+      depositFormHandleSubmit();
+    } else {
+      handleSubmit(event);
+    }
   };
 
   render() {
-    const { actionState, formik, ...ui } = this.props;
+    const { actionState, formik, depositFormHandleSubmit, ...ui } = this.props;
     const { handleSubmit, isSubmitting } = formik;
 
     const uiProps = _omit(ui, ["dispatch"]);
@@ -38,6 +44,7 @@ export class PreviewButtonComponent extends Component {
     return (
       <Button
         name="preview"
+        type="button"
         disabled={isSubmitting}
         onClick={(e) => this.handlePreview(e, handleSubmit)}
         loading={isSubmitting && actionState === DRAFT_PREVIEW_STARTED}
@@ -53,10 +60,12 @@ export class PreviewButtonComponent extends Component {
 PreviewButtonComponent.propTypes = {
   actionState: PropTypes.string,
   formik: PropTypes.object.isRequired,
+  depositFormHandleSubmit: PropTypes.func,
 };
 
 PreviewButtonComponent.defaultProps = {
   actionState: undefined,
+  depositFormHandleSubmit: undefined,
 };
 
 const mapStateToProps = (state) => ({

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishButton.js
@@ -124,6 +124,7 @@ class PublishButtonComponent extends Component {
             onSubmit={this.handlePublish}
             publishModalExtraContent={publishModalExtraContent}
             buttonLabel={buttonLabel}
+            depositFormHandleSubmit={formik.handleSubmit}
           />
         )}
       </>

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/PublishModal.js
@@ -15,6 +15,7 @@ import {
   PublishCheckboxComponent,
   ensureUniqueProps,
 } from "./PublishCheckboxComponent";
+import { PreviewButton } from "../PreviewButton";
 
 class PublishModalComponent extends Component {
   constructor(props) {
@@ -55,6 +56,7 @@ class PublishModalComponent extends Component {
       extraCheckboxes,
       beforeContent,
       afterContent,
+      depositFormHandleSubmit,
     } = this.props;
     return (
       <Formik
@@ -107,6 +109,7 @@ class PublishModalComponent extends Component {
                 <Button onClick={onClose} floated="left">
                   {i18next.t("Cancel")}
                 </Button>
+                <PreviewButton depositFormHandleSubmit={depositFormHandleSubmit} />
                 <Button
                   name="publish"
                   onClick={(event) => {
@@ -138,6 +141,7 @@ PublishModalComponent.propTypes = {
   ),
   beforeContent: PropTypes.func,
   afterContent: PropTypes.func,
+  depositFormHandleSubmit: PropTypes.func,
 };
 
 PublishModalComponent.defaultProps = {
@@ -146,6 +150,7 @@ PublishModalComponent.defaultProps = {
   extraCheckboxes: [],
   beforeContent: () => undefined,
   afterContent: () => undefined,
+  depositFormHandleSubmit: undefined,
 };
 
 export const PublishModal = Overridable.component(


### PR DESCRIPTION
Closes: #2061

:heart: Thank you for your contribution!

### Description

Because the PreviewButton has to be inside the PublishModal, and the preview button uses connectFormik which looks for the nearest Formik context, we need to prop drill the depositFormHandleSubmit into the preview button. This allows us to trigger save draft + redirect to preview and not checkbox validation + publish.

<img width="888" height="377" alt="image" src="https://github.com/user-attachments/assets/dae263af-8185-4be0-ab2a-0434a0cbb7cf" />

