### PR TITLE
fix: use role id instead of role name

### DIFF
--- a/invenio_rdm_records/records/systemfields/access/grants.py
+++ b/invenio_rdm_records/records/systemfields/access/grants.py
@@ -74,12 +74,7 @@ class Grant:
             self._subject = self.resolve_subject()
 
             if self._subject is not None:
-                if self._subject_type == "role":
-                    # NOTE: `RoleNeed` objects work with their name rather than ID
-                    #       c.f. `invenio_access.utils:get_identity`
-                    self._subject_id = self._subject.name
-                else:
-                    self._subject_id = str(self._subject.id)
+                self._subject_id = str(self._subject.id)
 
         return self._subject
 
@@ -97,7 +92,7 @@ class Grant:
             with db.session.no_autoflush:
                 subject = current_datastore.get_user_by_id(self._subject_id)
         elif type_ == "role":
-            subject = current_datastore.find_role(self._subject_id)
+            subject = current_datastore.find_role_by_id(self._subject_id)
 
         # check if the subject could be resolved or is a registered system role
         if (type_ in ["user", "role"] and subject is None) or (
@@ -131,7 +126,7 @@ class Grant:
             return self._subject_id
 
         if self.subject_type == "role":
-            return self.subject.name
+            return str(self.subject.id)
 
         return self.subject.id
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1122,10 +1122,13 @@ def moderator_user(UserFixture, app, database, moderator_role):
 def mod_identity(app, moderator_user):
     """Admin user for requests."""
     idt = Identity(moderator_user.id)
-    REQUESTS_MODERATION_ROLE = app.config["REQUESTS_MODERATION_ROLE"]
-
-    # Add Role user_moderator
-    idt.provides.add(RoleNeed(REQUESTS_MODERATION_ROLE))
+    # Role needs are now keyed by role id.
+    mod_role = next(
+        role
+        for role in moderator_user.user.roles
+        if role.name == app.config["REQUESTS_MODERATION_ROLE"]
+    )
+    idt.provides.add(RoleNeed(mod_role.id))
     # Search requires user to be authenticated
     idt.provides.add(Need(method="system_role", value="authenticated_user"))
     return idt

--- a/tests/records/systemfields/test_access_systemfield.py
+++ b/tests/records/systemfields/test_access_systemfield.py
@@ -100,7 +100,7 @@ def test_grant_creation(users, roles):
 
     grant = Grant("view", "N/A", subject=role)
     assert grant.subject_type == "role"
-    assert grant.subject_id == role.name
+    assert grant.subject_id == role.id
     assert grant.subject == role
 
     grant = Grant(
@@ -148,7 +148,7 @@ def test_grant_to_need(users, roles):
     grant = Grant("view", "N/A", subject=role)
     need = grant.to_need()
     assert need.method == "role"
-    assert need.value == role.name
+    assert need.value == role.id
 
     dict_ = {
         "subject": {"type": "system_role", "id": "authenticated_user"},

--- a/tests/resources/test_access_requests.py
+++ b/tests/resources/test_access_requests.py
@@ -345,7 +345,7 @@ def test_access_grant_for_role(
                 {
                     "subject": {
                         "type": "role",
-                        "id": str(role.name),
+                        "id": str(role.id),
                     },
                     "permission": "view",
                 }

--- a/tests/services/test_service_access.py
+++ b/tests/services/test_service_access.py
@@ -70,7 +70,7 @@ def test_cant_create_multiple_grants_for_same_role(running_app, minimal_record, 
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
             }
         ]
@@ -84,7 +84,7 @@ def test_cant_create_multiple_grants_for_same_role(running_app, minimal_record, 
             "hits": [
                 {
                     "permission": "preview",
-                    "subject": {"id": "test", "type": "role"},
+                    "subject": {"id": roles[0].id, "type": "role"},
                     "origin": None,
                     "id": 0,
                 }
@@ -307,7 +307,7 @@ def test_read_grant_by_subjectid_provide_role(running_app, minimal_record, roles
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
             }
         ]
@@ -418,7 +418,7 @@ def test_delete_grant_by_subjectid_provide_role(running_app, minimal_record, rol
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
             }
         ]
@@ -469,7 +469,7 @@ def test_read_all_grants_by_subject_found(running_app, minimal_record, users, ro
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
             }
         ]
@@ -502,7 +502,7 @@ def test_read_all_grants_by_subject_not_found(
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
             }
         ]
@@ -571,7 +571,7 @@ def test_update_grant_by_subject_not_found(running_app, minimal_record, roles):
     grant_payload = {
         "grants": [
             {
-                "subject": {"type": "role", "id": "test"},
+                "subject": {"type": "role", "id": roles[0].id},
                 "permission": "preview",
                 "origin": "origin",
             }


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* related to changes in invenio-users-resources > v10.2.0
* related to:
   fix broken tests due users resources release flask-security-fork#90
   fix: role.name to role.id invenio-rdm-records#2253


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
