### PR TITLE
fix(request-events): include anchor method in override

### DIFF
--- a/invenio_rdm_records/requests/base.py
+++ b/invenio_rdm_records/requests/base.py
@@ -10,6 +10,7 @@
 
 from invenio_records_resources.services import EndpointLink
 from invenio_requests.customizations import RequestType
+from invenio_requests.services.events.config import request_event_anchor
 
 
 class BaseRequest(RequestType):
@@ -20,6 +21,7 @@ class BaseRequest(RequestType):
             "invenio_app_rdm_requests.user_dashboard_request_view",
             params=["request_pid_value"],
             vars=lambda obj, vars: vars.update(request_pid_value=vars["request"].id),
+            anchor=request_event_anchor,
         ),
     }
 


### PR DESCRIPTION
**Release together with https://github.com/inveniosoftware/invenio-requests/pull/577**

* Added the `request_event_anchor` method to the `BaseRequest` from which all RDM-specific request types inherit. This allows including the `#commentevent-{id}` anchor at the end of the `self_html` link of request events.

* This method is added in https://github.com/inveniosoftware/invenio-requests/pull/577.