### PR TITLE
feat: Add max lenght to version field to prevent mis-rendering

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/VersionField/VersionField.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/VersionField/VersionField.js
@@ -29,7 +29,10 @@ class VersionFieldComponent extends Component {
           {" "}
           semver.org
         </a>
-        {i18next.t(", but any version string is accepted.")}
+        {i18next.t(", but any version string is accepted.")}{" "}
+        {i18next.t(
+          "Maximum 191 characters. For longer descriptions, use 'Additional descriptions' with type 'Note'."
+        )}
       </span>
     );
 
@@ -51,6 +54,7 @@ class VersionFieldComponent extends Component {
           placeholder={placeholder}
           disabled={disabled}
           required={required}
+          maxLength={191}
         />
       </Overridable>
     );

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -388,7 +388,7 @@ class MetadataSchema(Schema):
     formats = fields.List(
         SanitizedUnicode(validate=_not_blank(_("Format cannot be a blank string.")))
     )
-    version = SanitizedUnicode()
+    version = SanitizedUnicode(validate=validate.Length(max=191))
     rights = fields.List(fields.Nested(RightsSchema))
     copyright = SanitizedHTML(validate=validate.Length(min=1))
     description = SanitizedHTML(validate=validate.Length(min=3))

--- a/tests/services/schemas/test_version.py
+++ b/tests/services/schemas/test_version.py
@@ -28,3 +28,21 @@ def test_invalid_version(version, app, minimal_record):
 
     with pytest.raises(ValidationError):
         data = MetadataSchema().load(metadata)
+
+
+@pytest.mark.parametrize("version", ["v" + "1" * 190])
+def test_valid_version_max_length(version, app, minimal_record):
+    """Test that a version string of exactly 191 characters is accepted."""
+    metadata = minimal_record["metadata"]
+    metadata["version"] = version
+    data = MetadataSchema().load(metadata)
+    assert data["version"] == metadata["version"]
+
+
+@pytest.mark.parametrize("version", ["v" + "1" * 191])
+def test_invalid_version_too_long(version, app, minimal_record):
+    """Test that a version string exceeding 191 characters is rejected."""
+    metadata = minimal_record["metadata"]
+    metadata["version"] = version
+    with pytest.raises(ValidationError):
+        MetadataSchema().load(metadata)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

As stated in this issue: https://github.com/inveniosoftware/invenio-app-rdm/issues/3261, a hardcoded limit has been set on the length of the version field, making it 191 characters long at most, to prevent mis rendering. A PR has also been submitted to the ivenio-app-rdm to add a popup warning about the limit and encouraging users to make lengthy comments in the notes section.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
