### PR TITLE
fix: malformed web link

### DIFF
--- a/invenio_rdm_records/resources/serializers/signposting/__init__.py
+++ b/invenio_rdm_records/resources/serializers/signposting/__init__.py
@@ -35,6 +35,8 @@ class FAIRSignpostingProfileLvl1Serializer(MarshmallowSerializer):
                 link = f'<{value["href"]}> ; rel="{rel}"'
                 if "type" in value:
                     link += f' ; type="{value["type"]}"'
+                if "profile" in value:
+                    link += f' ; profile="{value["profile"]}"'
                 links.append(link)
         return " , ".join(links)
 

--- a/invenio_rdm_records/resources/serializers/signposting/schema.py
+++ b/invenio_rdm_records/resources/serializers/signposting/schema.py
@@ -69,12 +69,20 @@ class LandingPageSchema(Schema):
         # Has to be placed here to prevent circular dependency.
         from invenio_rdm_records.resources.config import record_serializers
 
-        result = [
-            {"href": obj["links"]["self"], "type": mimetype}
-            for mimetype in sorted(record_serializers)
+        result = []
+        for mimetype in sorted(record_serializers):
             # Remove the linkset serializer, so that the linkset does not link to itself.
-            if mimetype != "application/linkset+json"
-        ]
+            if mimetype == "application/linkset+json":
+                continue
+            if ";" in mimetype:
+                media_type, _, params = mimetype.partition(";")
+                entry = {"href": obj["links"]["self"], "type": media_type.strip()}
+                params = params.strip()
+                if params.startswith('profile="') and params.endswith('"'):
+                    entry["profile"] = params[len('profile="'):-1]
+            else:
+                entry = {"href": obj["links"]["self"], "type": mimetype}
+            result.append(entry)
 
         return result or missing
 

--- a/tests/resources/serializers/test_signposting_serializer.py
+++ b/tests/resources/serializers/test_signposting_serializer.py
@@ -131,7 +131,8 @@ def test_signposting_serializer_full(
                     },
                     {
                         "href": "https://127.0.0.1:5000/api/records/12345-abcde",
-                        "type": 'application/ld+json;profile="https://datapackage.org/profiles/2.0/datapackage.json"',
+                        "type": "application/ld+json",
+                        "profile": "https://datapackage.org/profiles/2.0/datapackage.json",
                     },
                     {
                         "href": "https://127.0.0.1:5000/api/records/12345-abcde",
@@ -326,7 +327,7 @@ def test_signposting_lvl1_serializer_full_collections_size_ok(
         f'<{api_url}> ; rel="describedby" ; type="application/dcat+xml"',
         f'<{api_url}> ; rel="describedby" ; type="application/json"',
         f'<{api_url}> ; rel="describedby" ; type="application/ld+json"',
-        f'<{api_url}> ; rel="describedby" ; type="application/ld+json;profile="https://datapackage.org/profiles/2.0/datapackage.json""',
+        f'<{api_url}> ; rel="describedby" ; type="application/ld+json" ; profile="https://datapackage.org/profiles/2.0/datapackage.json"',
         f'<{api_url}> ; rel="describedby" ; type="application/marcxml+xml"',
         f'<{api_url}> ; rel="describedby" ; type="application/vnd.citationstyles.csl+json"',
         f'<{api_url}> ; rel="describedby" ; type="application/vnd.datacite.datacite+json"',
@@ -383,7 +384,8 @@ def test_signposting_serializer_minimal(running_app, minimal_record_to_dict):
                     },
                     {
                         "href": "https://127.0.0.1:5000/api/records/67890-fghij",
-                        "type": 'application/ld+json;profile="https://datapackage.org/profiles/2.0/datapackage.json"',
+                        "type": "application/ld+json",
+                        "profile": "https://datapackage.org/profiles/2.0/datapackage.json",
                     },
                     {
                         "href": "https://127.0.0.1:5000/api/records/67890-fghij",
@@ -464,7 +466,7 @@ def test_signposting_lvl1_serializer_minimal(running_app, minimal_record_to_dict
         f'<{api_url}> ; rel="describedby" ; type="application/dcat+xml"',
         f'<{api_url}> ; rel="describedby" ; type="application/json"',
         f'<{api_url}> ; rel="describedby" ; type="application/ld+json"',
-        f'<{api_url}> ; rel="describedby" ; type="application/ld+json;profile="https://datapackage.org/profiles/2.0/datapackage.json""',
+        f'<{api_url}> ; rel="describedby" ; type="application/ld+json" ; profile="https://datapackage.org/profiles/2.0/datapackage.json"',
         f'<{api_url}> ; rel="describedby" ; type="application/marcxml+xml"',
         f'<{api_url}> ; rel="describedby" ; type="application/vnd.citationstyles.csl+json"',
         f'<{api_url}> ; rel="describedby" ; type="application/vnd.datacite.datacite+json"',


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

> Please describe briefly your pull request.

As stated in https://github.com/inveniosoftware/invenio-app-rdm/issues/3308, the Link field header entry was malformed when receiving type and profile simultaneously, which is solved in this PR by parsing that value in FAIRSignpostingProfileLvl1Serializer and LandingPageSchema

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
