### PR TITLE
deposit: ensure draft review is up-to-date before reserving PID

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
@@ -1,6 +1,7 @@
 // This file is part of Invenio-RDM-Records
 // Copyright (C) 2020-2025 CERN.
 // Copyright (C) 2020-2022 Northwestern University.
+// Copyright (C)      2026 CESNET.
 //
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
@@ -327,15 +328,37 @@ export const reservePID = (draft, { pidType }) => {
       payload: { pidType: pidType },
     });
 
+    let response;
     try {
-      let response = await saveDraftWithUrlUpdate(draft, config.service.drafts);
+      response = await _saveDraft(draft, config.service.drafts, {
+        depositState: getState().deposit,
+        dispatchFn: dispatch,
+        failType: RESERVE_PID_FAILED,
+        partialValidationActionType: "RESERVE_PID_VALIDATION_SILENT",
+        showOnlyValidationErrorsWithSeverityError: false,
+      });
+    } catch (error) {
+      // Validation errors are caught but do not block PID reservation.
+      // _saveDraft ensures the review was updated before throwing.
+      if (error.errors) {
+        response = error;
+      } else {
+        // Rethrow non-validation errors
+        console.error("Error saving draft before reserving PID", error, draft);
+        throw error;
+      }
+    }
 
+    try {
       const draftWithLinks = response.data;
-      response = await config.service.drafts.reservePID(draftWithLinks.links, pidType);
+      const reserveResponse = await config.service.drafts.reservePID(
+        draftWithLinks.links,
+        pidType
+      );
 
       dispatch({
         type: RESERVE_PID_SUCCEEDED,
-        payload: { data: response.data },
+        payload: { data: reserveResponse.data },
       });
     } catch (error) {
       console.error("Error reserving PID", error, draft);


### PR DESCRIPTION
### Description

Updates the `reservePID` Redux action to use `_saveDraft` instead of `saveDraftWithUrlUpdate`. This ensures the draft has an existing and up-to-date review request containing the selected community ID assigned before calling the reservePID service. Although draft validation is triggered by this change, validation errors raised don't block PID reservation, still allowing users to reserve a DOI even with incomplete metadata.

Enables the reservePID service to perform community-specific actions (e.g., applying a community-specific DOI prefix when reserving an identifier).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
