### PR TITLE
contrib: add thesis template for thesis custom field

### DIFF
--- a/invenio_rdm_records/contrib/thesis/custom_fields.py
+++ b/invenio_rdm_records/contrib/thesis/custom_fields.py
@@ -65,6 +65,7 @@ THESIS_CUSTOM_FIELDS_UI = {
         {
             "field": "thesis:thesis",
             "ui_widget": "Thesis",
+            "template": "thesis.html",
             "props": {
                 "label": _("Thesis"),
                 "labelIcon": "university",

--- a/invenio_rdm_records/templates/semantic-ui/thesis.html
+++ b/invenio_rdm_records/templates/semantic-ui/thesis.html
@@ -1,0 +1,24 @@
+{% if field_value.get('university') %}
+  <dt class="ui tiny header">{{ _("Awarding university") }}</dt>
+  <dd>{{ field_value.get('university') }}</dd>
+{% endif %}
+
+{% if field_value.get('department') %}
+  <dt class="ui tiny header">{{ _("Awarding department") }}</dt>
+  <dd>{{ field_value.get('department') }}</dd>
+{% endif %}
+
+{% if field_value.get('type') %}
+  <dt class="ui tiny header">{{ _("Thesis type") }}</dt>
+  <dd>{{ field_value.get('type') }}</dd>
+{% endif %}
+
+{% if field_value.get('date_submitted') %}
+  <dt class="ui tiny header">{{ _("Submission date") }}</dt>
+  <dd>{{ field_value.get('date_submitted') }}</dd>
+{% endif %}
+
+{% if field_value.get('date_defended') %}
+  <dt class="ui tiny header">{{ _("Defense date") }}</dt>
+  <dd>{{ field_value.get('date_defended') }}</dd>
+{% endif %}


### PR DESCRIPTION
fixes: https://github.com/CERNDocumentServer/cds-rdm/issues/538
:heart: Thank you for your contribution!

### Description

Adds a custom template for rendering the thesis custom field in the record view.

Previously the thesis metadata was displayed as a raw dictionary in the preview tab.
This change introduces a dedicated template that properly formats the thesis
information (university, department, submission date, defense date).

### Screenshot

Before: 
<img width="1644" height="230" alt="474979666-5bb1915e-6c4c-4aaf-b55d-32ec23c4d5b3" src="https://github.com/user-attachments/assets/38dfda6f-d11a-4db6-81b7-87023c22e352" />



After:
<img width="598" height="776" alt="image" src="https://github.com/user-attachments/assets/93aecc86-e03f-4647-b2ad-64a897a6fd67" />



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
