### PR TITLE
fix: not resetting errors after reservePID or file upload actions

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
@@ -266,7 +266,6 @@ const depositReducer = (state = {}, action) => {
           action.payload.data,
           state.editorState.selectedCommunity
         ),
-        errors: {},
         actionState: action.type,
         actionStateExtra: {},
       };
@@ -282,7 +281,6 @@ const depositReducer = (state = {}, action) => {
           action.payload.data,
           state.editorState.selectedCommunity
         ),
-        errors: {},
         actionState: action.type,
         actionStateExtra: {},
       };


### PR DESCRIPTION
* When you upload a file or when you reserve pid, you lose all errors
* previously existing in Redux, which is missleading



### Description

> Please describe briefly your pull request.

When you upload a file or reservePID the errors get cleared from the redux store. From UI perspective this is wrong, because it gives a wrong impression to the user. Also, logically speaking, I do not see a reason why these actions would clear existing errors from previous interactions with the server. I am not sure if there could be some obscure reason for explicitly resetting the errors in the reducer. I could not find any. 

https://github.com/user-attachments/assets/74aadb9a-84e3-4bfe-9854-63ec0d93891b


