### PR TITLE
Implement Uppy uploader metadata editing and event handling

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositApiClient.js
@@ -335,6 +335,10 @@ export class DepositFileApiClient {
     throw new Error("Not implemented.");
   }
 
+  updateFileMetadata(updateUrl, fileMeta) {
+    throw new Error("Not implemented.");
+  }
+
   deleteFile(fileLinks) {
     throw new Error("Not implemented.");
   }
@@ -383,6 +387,12 @@ export class RDMDepositFileApiClient extends DepositFileApiClient {
 
   finalizeFileUpload(finalizeUploadUrl) {
     return this.axiosWithConfig.post(finalizeUploadUrl, {});
+  }
+
+  updateFileMetadata(updateUrl, fileMeta) {
+    return this.axiosWithConfig.put(updateUrl, fileMeta, {
+      headers: { "Content-Type": "application/json" },
+    });
   }
 
   importParentRecordFiles(draftLinks) {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.js
@@ -102,6 +102,10 @@ export class DepositFilesService {
     throw new Error("Not implemented.");
   }
 
+  async updateFileMetadata(updateUrl, fileMeta) {
+    throw new Error("Not implemented.");
+  }
+
   async delete(fileLinks) {
     throw new Error("Not implemented.");
   }
@@ -224,6 +228,10 @@ export class RDMDepositFilesService extends DepositFilesService {
   finalizeUpload = async (commitFileURL, file) => {
     return (await this.fileApiClient.finalizeFileUpload(commitFileURL)).data;
   };
+
+  updateFileMetadata = async (updateUrl, fileMeta) => {
+    return (await this.fileApiClient.updateFileMetadata(updateUrl, fileMeta)).data;
+  }
 
   importParentRecordFiles = async (draftLinks) => {
     const response = await this.fileApiClient.importParentRecordFiles(draftLinks);

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.test.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositFilesService.test.js
@@ -13,6 +13,7 @@ let fakeApiIsCancelled;
 let fakeApiInitializeFileUpload;
 let fakeApiUploadFile;
 let fakeApiFinalizeFileUpload;
+let fakeApiUpdateFileMetadata;
 let fakeApiDeleteFile;
 class FakeFileApiClient extends DepositFileApiClient {
   isCancelled(error) {
@@ -29,6 +30,10 @@ class FakeFileApiClient extends DepositFileApiClient {
 
   finalizeFileUpload(finalizeUploadUrl) {
     return fakeApiFinalizeFileUpload(finalizeUploadUrl);
+  }
+
+  updateFileMetadata(updateUrl, fileMeta) {
+    return fakeApiUpdateFileMetadata(updateUrl, fileMeta);
   }
 
   deleteFile(fileLinks) {
@@ -75,6 +80,7 @@ beforeEach(() => {
     progressFn(20);
   });
   fakeApiFinalizeFileUpload = jest.fn();
+  fakeApiUpdateFileMetadata = jest.fn();
   fakeApiDeleteFile = jest.fn();
 
   fakeOnUploadAdded = jest.fn();
@@ -210,6 +216,14 @@ describe("DepositFilesService tests", () => {
       expect(fakeOnUploadProgress).not.toHaveBeenCalled();
       expect(fakeOnUploadCompleted).not.toHaveBeenCalled();
       expect(fakeOnUploadFailed).not.toHaveBeenCalled();
+    });
+
+    it("it should call updateFileMetadata without errors", async () => {
+      fakeApiUpdateFileMetadata.mockReturnValueOnce({ data: { message: "ok" } });
+      const updateUrl = "updateUrl";
+      const fileMeta = { id: "file1", links: {}, metadata: { description: "123" } };
+      await filesService.updateFileMetadata(updateUrl, fileMeta);
+      expect(fakeApiUpdateFileMetadata).toHaveBeenCalledWith(updateUrl, fileMeta);
     });
   });
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/utils.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/utils.js
@@ -18,6 +18,7 @@ export const getFilesList = (filesState) => {
       name: fileState.name,
       size: fileState.size,
       checksum: fileState.checksum,
+      metadata: fileState.metadata,
       links: fileState.links,
       uploadState: {
         // initial: fileState.status === UploadState.initial,

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
@@ -219,6 +219,7 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
     try {
       const response = await this.opts.initializeFileUpload(this.draftRecord, file);
       this.uppy.setFileMeta(file.id, {
+        ...file.meta,
         file_id: response.file_id,
         links: response.links,
       });
@@ -322,6 +323,7 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
 
     // Map any links to Uppy file state for further use (e.g. to fetch signed part URLs)
     this.uppy.setFileMeta(file.id, {
+      ...file.meta,
       file_id: response.file_id,
       links: response.links,
     });
@@ -367,6 +369,7 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
 
       file.meta.links = response.links;
       this.uppy.setFileMeta(file.id, {
+        ...file.meta,
         links: response.links,
       });
 
@@ -396,6 +399,9 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
    */
   async completeMultipartUpload(file) {
     const response = await this.opts.finalizeUpload(file);
+    if (file.meta?.metadata && Object.keys(file.meta.metadata).length > 0 && this.opts.updateFileMetadata) {
+      await this.opts.updateFileMetadata(this.draftRecord, response, file);
+    }
     return response.links.content;
   }
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
@@ -398,10 +398,10 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
    *  - The default implementation calls out to Companion’s S3 signing endpoints.
    */
   async completeMultipartUpload(file) {
-    const response = await this.opts.finalizeUpload(file);
     if (file.meta?.metadata && Object.keys(file.meta.metadata).length > 0 && this.opts.updateFileMetadata) {
-      await this.opts.updateFileMetadata(this.draftRecord, response, file);
+      await this.opts.updateFileMetadata(this.draftRecord, file);
     }
+    const response = await this.opts.finalizeUpload(file);
     return response.links.content;
   }
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
@@ -25,7 +25,7 @@ import {
   defaultAllowedMetaFields,
   getMetaFieldsRenderers,
   onBeforeUploadProcessMetaFields,
-} from "./utils";
+} from "./metaFields";
 import {
   UPPY_EVENTS,
   getUppyDashboardEventsProps,
@@ -91,6 +91,7 @@ export const UppyUploaderComponent = ({
   permissions,
   record,
   initializeFileUpload,
+  updateFileMetadata,
   finalizeUpload,
   deleteFile,
   uploadPart,
@@ -104,8 +105,7 @@ export const UppyUploaderComponent = ({
   decimalSizeDisplay,
   filesLocked,
   allowEmptyFiles,
-  allowedMetaFields = [],
-  modifyExistingFiles,
+  allowedMetaFields,
   startEvent,
   ...uiProps
 }) => {
@@ -163,6 +163,7 @@ export const UppyUploaderComponent = ({
         quota,
         // Bind Redux file actions to the uploader plugin
         initializeFileUpload,
+        updateFileMetadata,
         finalizeUpload,
         saveAndFetchDraft,
         setUploadProgress,
@@ -332,12 +333,10 @@ export const UppyUploaderComponent = ({
                     disabled={!filesLeft || lockFileUploader}
                     // `null` means "do not display a Done button in a status bar"
                     doneButtonHandler={null}
-                    note={modifyExistingFiles ? i18next.t("Select existing files to modify metadata.") : i18next.t(
-                      "File addition, removal or modification are not allowed after you have published your upload."
-                    )}
+                    note={i18next.t("File addition, removal or modification are not allowed after you have published your upload.")}
                     metaFields={activeAllowedMetaFields && activeAllowedMetaFields.length > 0 ? getMetaFieldsRenderers(activeAllowedMetaFields) : undefined}
                     {...defaultDashboardProps}
-                    {...getUppyDashboardEventsProps(startEvent, modifyExistingFiles)}
+                    {...(startEvent && getUppyDashboardEventsProps(startEvent))}
                     {...uiProps}
                   />
                 )}
@@ -409,6 +408,7 @@ UppyUploaderComponent.propTypes = {
   isFileImportInProgress: PropTypes.bool,
   importParentFiles: PropTypes.func.isRequired,
   initializeFileUpload: PropTypes.func.isRequired,
+  updateFileMetadata: PropTypes.func.isRequired,
   finalizeUpload: PropTypes.func.isRequired,
   uploadPart: PropTypes.func.isRequired,
   setUploadProgress: PropTypes.func.isRequired,
@@ -422,7 +422,6 @@ UppyUploaderComponent.propTypes = {
     PropTypes.shape({
       id: PropTypes.string.isRequired,
       defaultValue: PropTypes.any,
-      isUserInput: PropTypes.bool,
       name: PropTypes.string,
       placeholder: PropTypes.string,
       render: PropTypes.func,
@@ -433,7 +432,6 @@ UppyUploaderComponent.propTypes = {
     event: PropTypes.oneOf(Object.values(UPPY_EVENTS)),
     file: PropTypes.object,
   }),
-  modifyExistingFiles: PropTypes.bool,
 };
 
 UppyUploaderComponent.defaultProps = {
@@ -456,5 +454,4 @@ UppyUploaderComponent.defaultProps = {
   allowEmptyFiles: true,
   allowedMetaFields: undefined,
   startEvent: undefined,
-  modifyExistingFiles: false,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
@@ -185,10 +185,10 @@ export const UppyUploaderComponent = ({
 
   React.useEffect(() => {
     uppy.setOptions({
-      onBeforeUpload: (files) => {
+      onBeforeUpload: (uppyFiles) => {
         return activeAllowedMetaFields && activeAllowedMetaFields.length > 0 
-          ? onBeforeUploadProcessMetaFields(files, activeAllowedMetaFields)
-          : files;
+          ? onBeforeUploadProcessMetaFields(uppyFiles, files, activeAllowedMetaFields)
+          : uppyFiles;
       }
     });
   }, [uppy, activeAllowedMetaFields]);

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
@@ -21,6 +21,16 @@ import { UploadState } from "../../state/reducers/files";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import { getFilesList, FilesListTable, FileUploaderToolbar } from "../FileUploader";
 import { useUppyLocale } from "./locale";
+import {
+  defaultAllowedMetaFields,
+  getMetaFieldsRenderers,
+  onBeforeUploadProcessMetaFields,
+} from "./utils";
+import {
+  UPPY_EVENTS,
+  getUppyDashboardEventsProps,
+  useUppyFileEditSaveSync,
+} from "./events";
 
 const defaultDashboardProps = {
   showRemoveButtonAfterComplete: false,
@@ -43,8 +53,10 @@ const normalizeFileName = (name) =>
 const defaultOnBeforeFileAdded = (currentFile, currentFiles = {}) =>
   !Object.hasOwn(currentFiles, currentFile.id);
 
-const createDuplicateFileChecker = (uppy, filesList) => {
+const createDuplicateFileChecker = (uppy, filesList, startEvent) => {
   return (file, files) => {
+    if (startEvent?.event === UPPY_EVENTS.EDIT_FILE) return true;
+
     const normalizedName = normalizeFileName(file.name);
     if (!normalizedName) {
       return defaultOnBeforeFileAdded(file, files);
@@ -92,6 +104,9 @@ export const UppyUploaderComponent = ({
   decimalSizeDisplay,
   filesLocked,
   allowEmptyFiles,
+  allowedMetaFields = [],
+  modifyExistingFiles,
+  startEvent,
   ...uiProps
 }) => {
   // We extract the working copy of the draft stored as `values` in formik
@@ -99,6 +114,7 @@ export const UppyUploaderComponent = ({
   const { filesList } = getFilesList(files ?? {});
   const hasError = (errors.files || initialErrors?.files) && files;
   const locale = useUppyLocale();
+  const activeAllowedMetaFields = config?.allowedMetaFields || allowedMetaFields || defaultAllowedMetaFields;
   const filesEnabled = _get(formikDraft, "files.enabled", false);
   const filesSize = filesList.reduce((totalSize, file) => (totalSize += file.size), 0);
   const lockFileUploader = !isDraftRecord && filesLocked;
@@ -122,10 +138,10 @@ export const UppyUploaderComponent = ({
   const restrictions = React.useMemo(
     () => ({
       minFileSize: allowEmptyFiles ? 0 : 1,
-      maxNumberOfFiles: quota.maxFiles - filesList.length,
+      maxNumberOfFiles: startEvent?.event === UPPY_EVENTS.EDIT_FILE ? 1 : quota.maxFiles - filesList.length,
       maxTotalFileSize: quota.maxStorage - filesSize,
     }),
-    [allowEmptyFiles, quota, filesList, filesSize]
+    [allowEmptyFiles, quota, filesList, filesSize, startEvent]
   );
 
   const isTransferSupported = React.useCallback(
@@ -165,9 +181,19 @@ export const UppyUploaderComponent = ({
   }, [uppy]);
 
   React.useEffect(() => {
-    const onBeforeFileAdded = createDuplicateFileChecker(uppy, filesList);
+    const onBeforeFileAdded = createDuplicateFileChecker(uppy, filesList, startEvent);
     uppy.setOptions({ onBeforeFileAdded });
-  }, [uppy, filesList]);
+  }, [uppy, filesList, startEvent]);
+
+  React.useEffect(() => {
+    uppy.setOptions({
+      onBeforeUpload: (files) => {
+        return activeAllowedMetaFields && activeAllowedMetaFields.length > 0 
+          ? onBeforeUploadProcessMetaFields(files, activeAllowedMetaFields)
+          : files;
+      }
+    });
+  }, [uppy, activeAllowedMetaFields]);
 
   React.useEffect(() => {
     const uploaderPlugin = uppy.getPlugin("RDMUppyUploaderPlugin");
@@ -176,6 +202,8 @@ export const UppyUploaderComponent = ({
       uploaderPlugin.draftRecord = formikDraft;
     }
   }, [uppy, formikDraft]);
+
+  useUppyFileEditSaveSync(uppy, startEvent);
 
   React.useEffect(() => {
     // Synchronize uppy locale with i18next
@@ -304,10 +332,12 @@ export const UppyUploaderComponent = ({
                     disabled={!filesLeft || lockFileUploader}
                     // `null` means "do not display a Done button in a status bar"
                     doneButtonHandler={null}
-                    note={i18next.t(
+                    note={modifyExistingFiles ? i18next.t("Select existing files to modify metadata.") : i18next.t(
                       "File addition, removal or modification are not allowed after you have published your upload."
                     )}
+                    metaFields={activeAllowedMetaFields && activeAllowedMetaFields.length > 0 ? getMetaFieldsRenderers(activeAllowedMetaFields) : undefined}
                     {...defaultDashboardProps}
+                    {...getUppyDashboardEventsProps(startEvent, modifyExistingFiles)}
                     {...uiProps}
                   />
                 )}
@@ -388,6 +418,22 @@ UppyUploaderComponent.propTypes = {
   filesLocked: PropTypes.bool,
   permissions: PropTypes.object,
   allowEmptyFiles: PropTypes.bool,
+  allowedMetaFields: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      defaultValue: PropTypes.any,
+      isUserInput: PropTypes.bool,
+      name: PropTypes.string,
+      placeholder: PropTypes.string,
+      render: PropTypes.func,
+      condition: PropTypes.func,
+    })
+  ),
+  startEvent: PropTypes.shape({
+    event: PropTypes.oneOf(Object.values(UPPY_EVENTS)),
+    file: PropTypes.object,
+  }),
+  modifyExistingFiles: PropTypes.bool,
 };
 
 UppyUploaderComponent.defaultProps = {
@@ -408,4 +454,7 @@ UppyUploaderComponent.defaultProps = {
   decimalSizeDisplay: true,
   filesLocked: false,
   allowEmptyFiles: true,
+  allowedMetaFields: undefined,
+  startEvent: undefined,
+  modifyExistingFiles: false,
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
@@ -29,7 +29,6 @@ import {
 import {
   UPPY_EVENTS,
   getUppyDashboardEventsProps,
-  useUppyFileEditSaveSync,
 } from "./events";
 
 const defaultDashboardProps = {
@@ -53,10 +52,8 @@ const normalizeFileName = (name) =>
 const defaultOnBeforeFileAdded = (currentFile, currentFiles = {}) =>
   !Object.hasOwn(currentFiles, currentFile.id);
 
-const createDuplicateFileChecker = (uppy, filesList, startEvent) => {
+const createDuplicateFileChecker = (uppy, filesList) => {
   return (file, files) => {
-    if (startEvent?.event === UPPY_EVENTS.EDIT_FILE) return true;
-
     const normalizedName = normalizeFileName(file.name);
     if (!normalizedName) {
       return defaultOnBeforeFileAdded(file, files);
@@ -138,10 +135,10 @@ export const UppyUploaderComponent = ({
   const restrictions = React.useMemo(
     () => ({
       minFileSize: allowEmptyFiles ? 0 : 1,
-      maxNumberOfFiles: startEvent?.event === UPPY_EVENTS.EDIT_FILE ? 1 : quota.maxFiles - filesList.length,
+      maxNumberOfFiles: quota.maxFiles - filesList.length,
       maxTotalFileSize: quota.maxStorage - filesSize,
     }),
-    [allowEmptyFiles, quota, filesList, filesSize, startEvent]
+    [allowEmptyFiles, quota, filesList, filesSize]
   );
 
   const isTransferSupported = React.useCallback(
@@ -182,9 +179,9 @@ export const UppyUploaderComponent = ({
   }, [uppy]);
 
   React.useEffect(() => {
-    const onBeforeFileAdded = createDuplicateFileChecker(uppy, filesList, startEvent);
+    const onBeforeFileAdded = createDuplicateFileChecker(uppy, filesList);
     uppy.setOptions({ onBeforeFileAdded });
-  }, [uppy, filesList, startEvent]);
+  }, [uppy, filesList]);
 
   React.useEffect(() => {
     uppy.setOptions({
@@ -203,8 +200,6 @@ export const UppyUploaderComponent = ({
       uploaderPlugin.draftRecord = formikDraft;
     }
   }, [uppy, formikDraft]);
-
-  useUppyFileEditSaveSync(uppy, startEvent);
 
   React.useEffect(() => {
     // Synchronize uppy locale with i18next
@@ -429,8 +424,8 @@ UppyUploaderComponent.propTypes = {
     })
   ),
   startEvent: PropTypes.shape({
-    event: PropTypes.oneOf(Object.values(UPPY_EVENTS)),
-    file: PropTypes.object,
+    event: PropTypes.oneOf(Object.values(UPPY_EVENTS)).isRequired,
+    payload: PropTypes.object,
   }),
 };
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
@@ -1,0 +1,89 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2025 CERN.
+// Copyright (C)      2025 CESNET.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import React from "react";
+
+/**
+ * Enumeration of possible supported Uppy dashboard events.
+ * @constant {Object}
+ * @property {string} EDIT_FILE - Event triggered when a single file is requested for metadata editing.
+ * @property {string} UPLOAD_FILE_WITHOUT_EDIT - Event triggered for auto-uploading without explicit editing user interaction.
+ */
+export const UPPY_EVENTS = {
+  EDIT_FILE: "edit-file",
+  UPLOAD_FILE_WITHOUT_EDIT: "upload-file-without-edit",
+};
+
+/**
+ * Computes conditional UI properties for the Uppy Dashboard based on the active event state.
+ *
+ * @param {Object} startEvent - The currently active event, if any (e.g. { event: UPPY_EVENTS.EDIT_FILE }).
+ * @param {boolean} modifyExistingFiles - Flag specifying if existing files in the record are allowed to be modified.
+ * @returns {Object} A dictionary of props specifically mapped to the `<Dashboard />` component dynamically.
+ */
+export const getUppyDashboardEventsProps = (startEvent, modifyExistingFiles) => {
+  if (!startEvent) {
+    return {
+      autoOpen: null,
+      hideUploadButton: false,
+      disableLocalFiles: modifyExistingFiles || false,
+      showSelectedFiles: true,
+      hideCancelButton: false,
+    };
+  }
+
+  return {
+    autoOpen: startEvent.event === UPPY_EVENTS.EDIT_FILE ? "metaEditor" : null,
+    hideUploadButton: startEvent.event === UPPY_EVENTS.EDIT_FILE ? true : false,
+    disableLocalFiles: modifyExistingFiles || false,
+    showSelectedFiles: startEvent.event === UPPY_EVENTS.UPLOAD_FILE_WITHOUT_EDIT ? false : true,
+    hideCancelButton: startEvent.event === UPPY_EVENTS.EDIT_FILE ? true : false,
+  };
+};
+
+/**
+ * React hook that binds a custom listener bridging Uppy UI's internal 'save changes' button
+ * (in the meta editor panel) to automatically trigger file upload when the `EDIT_FILE` event is active.
+ *
+ * @param {Object} uppy - The active Uppy instance.
+ * @param {Object} startEvent - The active Uppy start event specifying current user interaction mode.
+ */
+export const useUppyFileEditSaveSync = (uppy, startEvent) => {
+  React.useEffect(() => {
+    if (!uppy || !startEvent || startEvent.event !== UPPY_EVENTS.EDIT_FILE) return;
+
+    uppy.on("dashboard:file-edit-start", async (file) => {
+      // inline delay and DOM check helper
+      const waitForElement = (selector) => {
+        return new Promise((resolve) => {
+          if (document.querySelector(selector)) {
+            return resolve(document.querySelector(selector));
+          }
+          const observer = new MutationObserver((mutations) => {
+            if (document.querySelector(selector)) {
+              observer.disconnect();
+              resolve(document.querySelector(selector));
+            }
+          });
+          observer.observe(document.body, { childList: true, subtree: true });
+        });
+      };
+
+      const saveChangesButton = await waitForElement(
+        ".uppy-Dashboard-FileCard-actions > button[type=submit]"
+      );
+      const uploadCallback = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for the Uppy file.meta state to update
+        uppy.upload();
+      };
+      saveChangesButton.addEventListener("click", uploadCallback);
+      uppy.on("complete", (result) => {
+        saveChangesButton.removeEventListener("click", uploadCallback);
+      });
+    });
+  }, [uppy, startEvent]);
+};

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
@@ -6,6 +6,7 @@
 // under the terms of the MIT License; see LICENSE file for more details.
 
 import React from "react";
+import { i18next } from "@translations/invenio_rdm_records/i18next";
 
 /**
  * Enumeration of possible supported Uppy dashboard events.
@@ -22,26 +23,18 @@ export const UPPY_EVENTS = {
  * Computes conditional UI properties for the Uppy Dashboard based on the active event state.
  *
  * @param {Object} startEvent - The currently active event, if any (e.g. { event: UPPY_EVENTS.EDIT_FILE }).
- * @param {boolean} modifyExistingFiles - Flag specifying if existing files in the record are allowed to be modified.
  * @returns {Object} A dictionary of props specifically mapped to the `<Dashboard />` component dynamically.
  */
-export const getUppyDashboardEventsProps = (startEvent, modifyExistingFiles) => {
-  if (!startEvent) {
-    return {
-      autoOpen: null,
-      hideUploadButton: false,
-      disableLocalFiles: modifyExistingFiles || false,
-      showSelectedFiles: true,
-      hideCancelButton: false,
-    };
-  }
+export const getUppyDashboardEventsProps = (startEvent) => {
+  const isEditEvent = startEvent?.event === UPPY_EVENTS.EDIT_FILE;
 
   return {
-    autoOpen: startEvent.event === UPPY_EVENTS.EDIT_FILE ? "metaEditor" : null,
-    hideUploadButton: startEvent.event === UPPY_EVENTS.EDIT_FILE ? true : false,
-    disableLocalFiles: modifyExistingFiles || false,
+    autoOpen: isEditEvent ? "metaEditor" : null,
+    hideUploadButton: isEditEvent ? true : false,
+    disableLocalFiles: isEditEvent ? true : false,
     showSelectedFiles: startEvent.event === UPPY_EVENTS.UPLOAD_FILE_WITHOUT_EDIT ? false : true,
-    hideCancelButton: startEvent.event === UPPY_EVENTS.EDIT_FILE ? true : false,
+    hideCancelButton: isEditEvent ? true : false,
+    ...(isEditEvent && { note: i18next.t("Select existing files to modify metadata.") }),
   };
 };
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/events.js
@@ -5,17 +5,12 @@
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import React from "react";
-import { i18next } from "@translations/invenio_rdm_records/i18next";
-
 /**
  * Enumeration of possible supported Uppy dashboard events.
  * @constant {Object}
- * @property {string} EDIT_FILE - Event triggered when a single file is requested for metadata editing.
  * @property {string} UPLOAD_FILE_WITHOUT_EDIT - Event triggered for auto-uploading without explicit editing user interaction.
  */
 export const UPPY_EVENTS = {
-  EDIT_FILE: "edit-file",
   UPLOAD_FILE_WITHOUT_EDIT: "upload-file-without-edit",
 };
 
@@ -26,57 +21,7 @@ export const UPPY_EVENTS = {
  * @returns {Object} A dictionary of props specifically mapped to the `<Dashboard />` component dynamically.
  */
 export const getUppyDashboardEventsProps = (startEvent) => {
-  const isEditEvent = startEvent?.event === UPPY_EVENTS.EDIT_FILE;
-
   return {
-    autoOpen: isEditEvent ? "metaEditor" : null,
-    hideUploadButton: isEditEvent ? true : false,
-    disableLocalFiles: isEditEvent ? true : false,
     showSelectedFiles: startEvent.event === UPPY_EVENTS.UPLOAD_FILE_WITHOUT_EDIT ? false : true,
-    hideCancelButton: isEditEvent ? true : false,
-    ...(isEditEvent && { note: i18next.t("Select existing files to modify metadata.") }),
   };
-};
-
-/**
- * React hook that binds a custom listener bridging Uppy UI's internal 'save changes' button
- * (in the meta editor panel) to automatically trigger file upload when the `EDIT_FILE` event is active.
- *
- * @param {Object} uppy - The active Uppy instance.
- * @param {Object} startEvent - The active Uppy start event specifying current user interaction mode.
- */
-export const useUppyFileEditSaveSync = (uppy, startEvent) => {
-  React.useEffect(() => {
-    if (!uppy || !startEvent || startEvent.event !== UPPY_EVENTS.EDIT_FILE) return;
-
-    uppy.on("dashboard:file-edit-start", async (file) => {
-      // inline delay and DOM check helper
-      const waitForElement = (selector) => {
-        return new Promise((resolve) => {
-          if (document.querySelector(selector)) {
-            return resolve(document.querySelector(selector));
-          }
-          const observer = new MutationObserver((mutations) => {
-            if (document.querySelector(selector)) {
-              observer.disconnect();
-              resolve(document.querySelector(selector));
-            }
-          });
-          observer.observe(document.body, { childList: true, subtree: true });
-        });
-      };
-
-      const saveChangesButton = await waitForElement(
-        ".uppy-Dashboard-FileCard-actions > button[type=submit]"
-      );
-      const uploadCallback = async () => {
-        await new Promise((resolve) => setTimeout(resolve, 100)); // Wait for the Uppy file.meta state to update
-        uppy.upload();
-      };
-      saveChangesButton.addEventListener("click", uploadCallback);
-      uppy.on("complete", (result) => {
-        saveChangesButton.removeEventListener("click", uploadCallback);
-      });
-    });
-  }, [uppy, startEvent]);
 };

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/index.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/index.js
@@ -48,3 +48,6 @@ export const UppyUploader = connect(
   mapStateToProps,
   mapDispatchToProps
 )(UppyUploaderComponent);
+
+export { UPPY_EVENTS } from "./events";
+export { defaultAllowedMetaFields } from "./metaFields";

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/index.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/index.js
@@ -10,6 +10,7 @@ import {
   deleteFile,
   importParentFiles,
   initializeFileUpload,
+  updateFileMetadata,
   uploadPart,
   finalizeUpload,
   saveAndFetchDraft,
@@ -34,6 +35,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch) => ({
   initializeFileUpload: (draft, file) => dispatch(initializeFileUpload(draft, file)),
+  updateFileMetadata: (draft, serverFile, file) => dispatch(updateFileMetadata(draft, serverFile, file)),
   finalizeUpload: (file) => dispatch(finalizeUpload(file.meta.links.commit, file)),
   importParentFiles: () => dispatch(importParentFiles()),
   setUploadProgress: (file, percent) => dispatch(setUploadProgress(file, percent)),

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
@@ -105,38 +105,40 @@ export const getMetaFieldsRenderers = (allowedMetaFields) => {
  * This ensures that required parameters are not lost and metadata is 
  * consistently structured before uploading.
  *
- * @param {Object} files - The Uppy files object dictionary.
+ * @param {Object} uppyFiles - The Uppy files object dictionary.
+ * @param {Object} invenioFiles - The files object from Invenio.
  * @param {Array<Object>} allowedMetaFields - Configuration for metadata fields.
  * @returns {Object} Updated files dictionary.
  */
-export const onBeforeUploadProcessMetaFields = (files, allowedMetaFields) => {
+export const onBeforeUploadProcessMetaFields = (uppyFiles, invenioFiles, allowedMetaFields) => {
   const updatedFiles = {};
   
-  Object.keys(files).forEach((fileID) => {
-    const file = files[fileID];
-    file.meta["metadata"] = file.meta?.metadata || {};
+  Object.keys(uppyFiles).forEach((fileID) => {
+    const uppyFile = uppyFiles[fileID];
+    const invenioFile = invenioFiles[uppyFile.meta?.file_id ?? uppyFile.id] || {};
+    uppyFile.meta["metadata"] = uppyFile.meta?.metadata || invenioFile?.metadata || {};
     const metadataDefaults = {};
 
     (allowedMetaFields || []).forEach((field) => {
       // Determine if this field should apply defaults to this file
-      const isApplicable = typeof field.condition === "function" ? field.condition(file) : true;
+      const isApplicable = typeof field.condition === "function" ? field.condition(uppyFile) : true;
 
       if (isApplicable) {
-        if (file.meta.metadata?.[field.id] === undefined && file.meta?.[field.id] === undefined) {
-          const value = typeof field.defaultValue === "function" ? field.defaultValue(file) : field?.defaultValue;
+        if (uppyFile.meta.metadata?.[field.id] === undefined && uppyFile.meta?.[field.id] === undefined) {
+          const value = typeof field.defaultValue === "function" ? field.defaultValue(uppyFile) : field?.defaultValue;
           metadataDefaults[field.id] = value;
           return;
         }
-        metadataDefaults[field.id] = file.meta.metadata?.[field.id] || file.meta?.[field.id];
+        metadataDefaults[field.id] = uppyFile.meta.metadata?.[field.id] || uppyFile.meta?.[field.id];
       }
     });
 
     updatedFiles[fileID] = {
-      ...file,
+      ...uppyFile,
       meta: {
-        ...file.meta,
+        ...uppyFile.meta,
         metadata: {
-          ...file.meta.metadata,
+          ...uppyFile.meta.metadata,
           ...metadataDefaults,
         }
       }

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
@@ -14,27 +14,51 @@ export const defaultAllowedMetaFields = [
   { 
     id: "caption", 
     defaultValue: "", 
-    isUserInput: true,
+    name: i18next.t("Caption"),
+    placeholder: i18next.t("Set the Caption here"),
     condition: (file) => file.type && file.type.startsWith("image/") 
   },
   { 
     id: "featured", 
     defaultValue: false, 
-    isUserInput: true,
+    name: i18next.t("Feature Image"),
+    render: ({ value, onChange, required, form }, h) => {
+      return h("input", {
+        type: "checkbox",
+        onChange: (ev) => onChange(ev.target.checked),
+        checked: value,
+        defaultChecked: value,
+        required,
+        form,
+      });
+    },
     condition: (file) => file.type && file.type.startsWith("image/") 
   },
-  { id: "fileNote", defaultValue: "", isUserInput: true },
-  { id: "fileType", defaultValue: "", isUserInput: false },
+  { 
+    id: "fileNote", 
+    defaultValue: "", 
+    name: i18next.t("File Note"),
+    placeholder: i18next.t("Set the file Note here"),
+  },
+  { 
+    id: "fileType", 
+    defaultValue: (file) => {
+      if (file.type) {
+        if (file.type.startsWith("image/")) return "image";
+      }
+      return "other";
+    },
+  },
 ];
 
 /**
  * Higher-order function that generates a metaFields configuration function for Uppy Dashboard.
- * It combines standard built-in renderers ("fileNote", "caption", "featured") with any custom
- * fields passed in `allowedMetaFields`.
+ * Evaluates custom fields passed in `allowedMetaFields` to render them.
  * 
  * @param {Array<Object>} allowedMetaFields - Configuration for allowed meta fields. 
- * Expected shape: `{ id, defaultValue, isUserInput, name?, placeholder?, render?, condition? }`.
+ * Expected shape: `{ id, defaultValue, name?, placeholder?, render?, condition? }`.
  * Users can provide custom UI fields by explicitly setting `name` and/or `render` attributes.
+ * `defaultValue` can either be a static mapped value, or a dynamic function `(file) => any`.
  * 
  * @returns {Function} Function `(file) => Array<Object>` required by Uppy Dashboard `metaFields` prop.
  */
@@ -42,7 +66,7 @@ export const getMetaFieldsRenderers = (allowedMetaFields) => {
   return (file) => {
     const fields = [];
     (allowedMetaFields || []).forEach((field) => {
-      // 1) Evaluate if field has custom rendering properties (name, render).
+      // Evaluate if field has rendering properties (name, render).
       if (field.name || field.render) {
         const shouldRender = typeof field.condition === "function" ? field.condition(file) : true;
         if (shouldRender) {
@@ -52,39 +76,6 @@ export const getMetaFieldsRenderers = (allowedMetaFields) => {
             placeholder: field.placeholder || "",
             // Render is optional, if missing Uppy falls back to standard text input
             ...(field.render && { render: field.render }),
-          });
-        }
-        return; // Skip default handling
-      }
-
-      // 2) Default handlers for built-in known fields
-      if (field.id === "fileNote") {
-        fields.push({
-          id: "fileNote",
-          name: i18next.t("File Note"),
-          placeholder: i18next.t("Set the file Note here"),
-        });
-      } else if (file.type && file.type.startsWith("image/")) {
-        if (field.id === "caption") {
-          fields.push({
-            id: "caption",
-            name: i18next.t("Caption"),
-            placeholder: i18next.t("Set the Caption here"),
-          });
-        } else if (field.id === "featured") {
-          fields.push({
-            id: "featured",
-            name: i18next.t("Feature Image"),
-            render: ({ value, onChange, required, form }, h) => {
-              return h("input", {
-                type: "checkbox",
-                onChange: (ev) => onChange(ev.target.checked),
-                checked: value,
-                defaultChecked: value,
-                required,
-                form,
-              });
-            },
           });
         }
       }
@@ -108,19 +99,20 @@ export const onBeforeUploadProcessMetaFields = (files, allowedMetaFields) => {
   
   Object.keys(files).forEach((fileID) => {
     const file = files[fileID];
-    const metaDefaults = {};
+    file.meta["metadata"] = file.meta?.metadata || {};
+    const metadataDefaults = {};
 
     (allowedMetaFields || []).forEach((field) => {
       // Determine if this field should apply defaults to this file
-      let isApplicable = true;
-      if (typeof field.condition === "function") {
-        isApplicable = field.condition(file);
-      } else if (field.id === "caption" || field.id === "featured") {
-        isApplicable = file.type && file.type.startsWith("image/");
-      } // built-in 'fileNote' or any custom field without 'condition' is applicable universally
+      const isApplicable = typeof field.condition === "function" ? field.condition(file) : true;
 
       if (isApplicable) {
-        metaDefaults[field.id] = file.meta?.[field.id] ?? field.defaultValue;
+        if (file.meta.metadata?.[field.id] === undefined && file.meta?.[field.id] === undefined) {
+          const value = typeof field.defaultValue === "function" ? field.defaultValue(file) : field?.defaultValue;
+          metadataDefaults[field.id] = value;
+          return;
+        }
+        metadataDefaults[field.id] = file.meta.metadata?.[field.id] || file.meta?.[field.id];
       }
     });
 
@@ -128,7 +120,10 @@ export const onBeforeUploadProcessMetaFields = (files, allowedMetaFields) => {
       ...file,
       meta: {
         ...file.meta,
-        ...metaDefaults,
+        metadata: {
+          ...file.meta.metadata,
+          ...metadataDefaults,
+        }
       }
     };
   });

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/metaFields.js
@@ -5,50 +5,65 @@
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
-import { i18next } from "@translations/invenio_rdm_records/i18next";
-
 /**
  * Default allowed metadata fields configuration.
+ * @example
+ * [
+ *   { 
+ *     id: "caption", 
+ *     defaultValue: "", 
+ *     name: i18next.t("Caption"),
+ *     placeholder: i18next.t("Set the Caption here"),
+ *     condition: (file) => file.type && file.type.startsWith("image/") 
+ *   },
+ *   { 
+ *     id: "featured", 
+ *     defaultValue: false, 
+ *     name: i18next.t("Feature Image"),
+ *     render: ({ value, onChange, required, form }, h) => {
+ *       return h("input", {
+ *         type: "checkbox",
+ *         onChange: (ev) => onChange(ev.target.checked),
+ *         checked: value,
+ *         defaultChecked: value,
+ *         required,
+ *         form,
+ *       });
+ *     },
+ *     condition: (file) => file.type && file.type.startsWith("image/") 
+ *   },
+ *   { 
+ *     id: "fileNote", 
+ *     defaultValue: "", 
+ *     name: i18next.t("File Note"),
+ *     placeholder: i18next.t("Set the file Note here"),
+ *   },
+ *   { 
+ *     id: "fileType", 
+ *     defaultValue: (file) => {
+ *       if (file.type) {
+ *         if (file.type.startsWith("image/")) return "image";
+ *       }
+ *       return "other";
+ *     },
+ *   },
+ * ]
+ * 
+ * @type {Object[]} metaFields - Array of metadata field configuration objects. Each object defines how a specific metadata field should be handled and rendered in the Uppy Dashboard.
+ * @property {string} metaFields[].id - The unique identifier of the metadata field. Used as the key in the file.meta.metadata dictionary.
+ * @property {any|function(Object): any} [metaFields[].defaultValue] - Default value or a function resolving a default value based on the file object.
+ * @property {string} [metaFields[].name] - Optional display name of the field. If provided, it will be used to render a standard input field, otherwise it won't be editable in UI.
+ * @property {string} [metaFields[].placeholder] - Optional placeholder text for the input UI.
+ * @property {function(Object, Function): Object} [metaFields[].render] - Optional custom render function for advanced UI rendering of the field using Preact `h` function. If not provided, a standard text input will be rendered when `name` is set. See {@link https://uppy.io/docs/dashboard/#metafields|Uppy Dashboard metaFields documentation}.
+ * @property {function(Object): Boolean} [metaFields[].condition] - Optional function to conditionally attach or render the field based on the respective file properties (e.g. file.type).
  */
 export const defaultAllowedMetaFields = [
-  { 
-    id: "caption", 
-    defaultValue: "", 
-    name: i18next.t("Caption"),
-    placeholder: i18next.t("Set the Caption here"),
-    condition: (file) => file.type && file.type.startsWith("image/") 
-  },
-  { 
-    id: "featured", 
-    defaultValue: false, 
-    name: i18next.t("Feature Image"),
-    render: ({ value, onChange, required, form }, h) => {
-      return h("input", {
-        type: "checkbox",
-        onChange: (ev) => onChange(ev.target.checked),
-        checked: value,
-        defaultChecked: value,
-        required,
-        form,
-      });
-    },
-    condition: (file) => file.type && file.type.startsWith("image/") 
-  },
-  { 
-    id: "fileNote", 
-    defaultValue: "", 
-    name: i18next.t("File Note"),
-    placeholder: i18next.t("Set the file Note here"),
-  },
-  { 
-    id: "fileType", 
-    defaultValue: (file) => {
-      if (file.type) {
-        if (file.type.startsWith("image/")) return "image";
-      }
-      return "other";
-    },
-  },
+  // { 
+  //   id: "description",
+  //   defaultValue: "",
+  //   name: i18next.t("Description"),
+  //   placeholder: i18next.t("Set the file description here"),
+  // },
 ];
 
 /**

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/utils.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/utils.js
@@ -1,0 +1,137 @@
+// This file is part of Invenio-RDM-Records
+// Copyright (C) 2020-2025 CERN.
+// Copyright (C)      2025 CESNET.
+//
+// Invenio-RDM-Records is free software; you can redistribute it and/or modify it
+// under the terms of the MIT License; see LICENSE file for more details.
+
+import { i18next } from "@translations/invenio_rdm_records/i18next";
+
+/**
+ * Default allowed metadata fields configuration.
+ */
+export const defaultAllowedMetaFields = [
+  { 
+    id: "caption", 
+    defaultValue: "", 
+    isUserInput: true,
+    condition: (file) => file.type && file.type.startsWith("image/") 
+  },
+  { 
+    id: "featured", 
+    defaultValue: false, 
+    isUserInput: true,
+    condition: (file) => file.type && file.type.startsWith("image/") 
+  },
+  { id: "fileNote", defaultValue: "", isUserInput: true },
+  { id: "fileType", defaultValue: "", isUserInput: false },
+];
+
+/**
+ * Higher-order function that generates a metaFields configuration function for Uppy Dashboard.
+ * It combines standard built-in renderers ("fileNote", "caption", "featured") with any custom
+ * fields passed in `allowedMetaFields`.
+ * 
+ * @param {Array<Object>} allowedMetaFields - Configuration for allowed meta fields. 
+ * Expected shape: `{ id, defaultValue, isUserInput, name?, placeholder?, render?, condition? }`.
+ * Users can provide custom UI fields by explicitly setting `name` and/or `render` attributes.
+ * 
+ * @returns {Function} Function `(file) => Array<Object>` required by Uppy Dashboard `metaFields` prop.
+ */
+export const getMetaFieldsRenderers = (allowedMetaFields) => {
+  return (file) => {
+    const fields = [];
+    (allowedMetaFields || []).forEach((field) => {
+      // 1) Evaluate if field has custom rendering properties (name, render).
+      if (field.name || field.render) {
+        const shouldRender = typeof field.condition === "function" ? field.condition(file) : true;
+        if (shouldRender) {
+          fields.push({
+            id: field.id,
+            name: field.name,
+            placeholder: field.placeholder || "",
+            // Render is optional, if missing Uppy falls back to standard text input
+            ...(field.render && { render: field.render }),
+          });
+        }
+        return; // Skip default handling
+      }
+
+      // 2) Default handlers for built-in known fields
+      if (field.id === "fileNote") {
+        fields.push({
+          id: "fileNote",
+          name: i18next.t("File Note"),
+          placeholder: i18next.t("Set the file Note here"),
+        });
+      } else if (file.type && file.type.startsWith("image/")) {
+        if (field.id === "caption") {
+          fields.push({
+            id: "caption",
+            name: i18next.t("Caption"),
+            placeholder: i18next.t("Set the Caption here"),
+          });
+        } else if (field.id === "featured") {
+          fields.push({
+            id: "featured",
+            name: i18next.t("Feature Image"),
+            render: ({ value, onChange, required, form }, h) => {
+              return h("input", {
+                type: "checkbox",
+                onChange: (ev) => onChange(ev.target.checked),
+                checked: value,
+                defaultChecked: value,
+                required,
+                form,
+              });
+            },
+          });
+        }
+      }
+    });
+
+    return fields;
+  };
+};
+
+/**
+ * Extends file metadata prior to upload with configured default values.
+ * This ensures that required parameters are not lost and metadata is 
+ * consistently structured before uploading.
+ *
+ * @param {Object} files - The Uppy files object dictionary.
+ * @param {Array<Object>} allowedMetaFields - Configuration for metadata fields.
+ * @returns {Object} Updated files dictionary.
+ */
+export const onBeforeUploadProcessMetaFields = (files, allowedMetaFields) => {
+  const updatedFiles = {};
+  
+  Object.keys(files).forEach((fileID) => {
+    const file = files[fileID];
+    const metaDefaults = {};
+
+    (allowedMetaFields || []).forEach((field) => {
+      // Determine if this field should apply defaults to this file
+      let isApplicable = true;
+      if (typeof field.condition === "function") {
+        isApplicable = field.condition(file);
+      } else if (field.id === "caption" || field.id === "featured") {
+        isApplicable = file.type && file.type.startsWith("image/");
+      } // built-in 'fileNote' or any custom field without 'condition' is applicable universally
+
+      if (isApplicable) {
+        metaDefaults[field.id] = file.meta?.[field.id] ?? field.defaultValue;
+      }
+    });
+
+    updatedFiles[fileID] = {
+      ...file,
+      meta: {
+        ...file.meta,
+        ...metaDefaults,
+      }
+    };
+  });
+  
+  return updatedFiles;
+};

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
@@ -96,17 +96,17 @@ export const initializeFileUpload = (draft, file) => {
   };
 };
 
-export const updateFileMetadata = (draft, serverFile, file) => {
+export const updateFileMetadata = (draft, file) => {
   return async (dispatch, _, config) => {
     try {
-      const updateUrl = serverFile.links.self;
+      const updateUrl = file.meta.links.self;
       const newFileMetadata = {
         metadata: file.meta.metadata,
       };
       return await config.service.files.updateFileMetadata(updateUrl, newFileMetadata);
     } catch (error) {
       const axiosError = error?.t0 && error.t0.isAxiosError ? error.t0 : error;
-      console.error("Error updating file metadata", axiosError, draft, serverFile);
+      console.error("Error updating file metadata", axiosError, draft, file);
       const errorMessage =
         axiosError?.response?.data?.message || axiosError?.message || "Metadata update failed";
       throw new Error(errorMessage);

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/files.js
@@ -96,6 +96,24 @@ export const initializeFileUpload = (draft, file) => {
   };
 };
 
+export const updateFileMetadata = (draft, serverFile, file) => {
+  return async (dispatch, _, config) => {
+    try {
+      const updateUrl = serverFile.links.self;
+      const newFileMetadata = {
+        metadata: file.meta.metadata,
+      };
+      return await config.service.files.updateFileMetadata(updateUrl, newFileMetadata);
+    } catch (error) {
+      const axiosError = error?.t0 && error.t0.isAxiosError ? error.t0 : error;
+      console.error("Error updating file metadata", axiosError, draft, serverFile);
+      const errorMessage =
+        axiosError?.response?.data?.message || axiosError?.message || "Metadata update failed";
+      throw new Error(errorMessage);
+    }
+  };
+};
+
 export const uploadPart = (uploadParams) => {
   return async (dispatch, _, config) => {
     return config.service.files.uploadPart(uploadParams);

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
@@ -25,6 +25,7 @@ const preloadFiles = (files) => {
           name: file.key,
           size: file.size || 0,
           checksum: file.checksum || "",
+          metadata: file.metadata || {},
           links: file.links || {},
           mimetype: file.mimetype || "application/octet-stream",
           status: UploadState[file.status],


### PR DESCRIPTION
Replaced: https://github.com/inveniosoftware/invenio-rdm-records/pull/2278

---

:heart: Thank you for your contribution!

### Description

Implemented modular metadata editing support in the Uppy uploader and refactored event handling for better extensibility and maintainability.

Main changes:
- Extracted metadata-related logic into reusable utilities.
- Extracted event-related logic into a separate module.
- Introduced a centralized Uppy events enum and replaced hardcoded event strings.
- Made Dashboard metadata fields optional and extensible so integrators can provide custom renderer behavior via allowed metadata field configuration.
- Improved metadata default value processing before upload.
- Updated uploader prop type definitions to correctly document metadata field configuration and event-related props.
- Added JSDoc documentation for metadata and event utilities.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.