### PR TITLE
Fix DOI validation error display in deposit form

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField/components/UnmanagedIdentifierCmp.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/Identifiers/PIDField/components/UnmanagedIdentifierCmp.js
@@ -46,15 +46,19 @@ export class UnmanagedIdentifierCmp extends Component {
     const { localIdentifier } = this.state;
     const { form, fieldPath, helpText, pidPlaceholder, disabled } = this.props;
     const fieldError = getFieldErrors(form, fieldPath);
+    const displayError =
+      fieldError && typeof fieldError === "object" && fieldError.message
+        ? fieldError.message
+        : fieldError;
     return (
       <>
-        <Form.Field width={8} error={fieldError}>
+        <Form.Field width={8} error={displayError}>
           <Form.Input
             onChange={(e, { value }) => this.onChange(value)}
             value={localIdentifier}
             placeholder={pidPlaceholder}
             width={16}
-            error={fieldError}
+            error={displayError}
             disabled={disabled}
           />
         </Form.Field>


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/725
Related pr: https://github.com/CERNDocumentServer/cds-rdm/pull/749
https://github.com/inveniosoftware/invenio-checks/pull/58

This PR fixes how DOI validation errors are rendered under the DOI field in the deposit form.

After the backend-side fix in [cds-rdm#749](https://github.com/CERNDocumentServer/cds-rdm/pull/749) and [invenio-checks#58](https://github.com/inveniosoftware/invenio-checks/pull/58), the DOI validation error is now returned on the correct field path, pids.doi, so the DOI UI can pick it up. However, the error returned by the metadata check is not a plain string like the built-in DOI validation errors. Instead, it is a richer object containing multiple properties such as message, severity, and description.

The top DOI error message was already showing correctly because it is rendered through FeedbackLabel, which already knows how to read that richer object shape and extract the message from it. The lower field-level error area was not handling the same object in the same way. That part of the DOI input UI expects a simpler display value, so when it received the metadata-check error object, it did not render the message properly under the field.

This PR fixes that mismatch in the unmanaged DOI input component. If the field error is an object, the component now uses fieldError.message for the lower field-level error display. That way, the richer error object can still be used where it is already supported, while the DOI input now shows the validation message under the field the way users would expect.

Changes
Updated UnmanagedIdentifierCmp.js to detect object-style DOI validation errors.
Unpacked the metadata-check error object and used fieldError.message for the lower field-level display.
Kept the existing behavior unchanged for built-in string-based DOI errors such as Missing DOI for required field.

### Before: 
<img width="676" height="271" alt="image" src="https://github.com/user-attachments/assets/4afee628-3d38-4ed4-8367-a2662fdfd8ed" />


### After:
<img width="934" height="278" alt="image" src="https://github.com/user-attachments/assets/bf608f8b-e7c7-431e-a6ab-b4980aefc3d3" />




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
