### PR TITLE
feat: add formikConfig prop to DepositBootstrap

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositBootstrap.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositBootstrap.js
@@ -115,7 +115,7 @@ class DepositBootstrapComponent extends Component {
   };
 
   render() {
-    const { errors, record, children } = this.props;
+    const { errors, record, children, formikConfig } = this.props;
     return (
       <DepositFormSubmitContext.Provider
         value={{ setSubmitContext: this.setSubmitContext }}
@@ -133,6 +133,7 @@ class DepositBootstrapComponent extends Component {
             initialValues: record,
             // errors need to be repopulated after form is reinitialised
             ...(errors && { initialErrors: errors }),
+            ...formikConfig,
           }}
         >
           {children}
@@ -154,12 +155,14 @@ DepositBootstrapComponent.propTypes = {
   reservePIDAction: PropTypes.func.isRequired,
   discardPIDAction: PropTypes.func.isRequired,
   fileUploadOngoing: PropTypes.bool,
+  formikConfig: PropTypes.object,
 };
 
 DepositBootstrapComponent.defaultProps = {
   errors: undefined,
   children: undefined,
   fileUploadOngoing: false,
+  formikConfig: {},
 };
 
 const mapStateToProps = (state) => {


### PR DESCRIPTION
Allow passing additional Formik configuration options to BaseForm via a new formikConfig prop. The object is spread at the end of the formik config, allowing overrides of default settings.

:heart: Thank you for your contribution!

### Description

When using DepositBootstrap component, it is not possible to modify formik configuration in any way i.e. not possible to pass validationSchema or a ref to formik. Ref is especially useful, when you want to access state from a component not nested inside formik. I think it is a useful change without any downsides. Please let us know. 
