### PR TITLE
fix(rights): Require English translation in rights fields

### DIFF
--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -70,15 +70,21 @@ def _valid_url(error_msg):
     return validate.URL(error=error_msg)
 
 
-def locale_validation(value, field_name):
+def locale_validation(value, field_name, required_locale=None):
     """Validates the locale value."""
     valid_locales = current_app.extensions["invenio-i18n"].get_locales()
     valid_locales_code = [v.language for v in valid_locales]
     if value:
-        if len(value.keys()) > 1:
+        locales = list(value.keys())
+
+        if len(locales) > 1 and required_locale is None:
             raise ValidationError(_("Only one value is accepted."), field_name)
-        elif list(value.keys())[0] not in valid_locales_code:
+        elif any(locale not in valid_locales_code for locale in locales):
             raise ValidationError(_("Not a valid locale."), field_name)
+        elif required_locale and required_locale not in locales:
+            raise ValidationError(
+                _("Translation must be provided in English."), field_name
+            )
 
 
 class PersonOrOrganizationSchema(Schema):
@@ -233,13 +239,13 @@ class RightsSchema(Schema):
 
     @validates("title")
     def validate_title(self, value):
-        """Validates that title contains only one valid locale."""
-        locale_validation(value, "title")
+        """Validate that title contains English."""
+        locale_validation(value, "title", required_locale="en")
 
     @validates("description")
     def validate_description(self, value):
-        """Validates that description contains only one valid locale."""
-        locale_validation(value, "description")
+        """Validate that description contains English."""
+        locale_validation(value, "description", required_locale="en")
 
     @validates_schema
     def validate_rights(self, data, **kwargs):

--- a/tests/services/schemas/test_rights.py
+++ b/tests/services/schemas/test_rights.py
@@ -9,6 +9,8 @@
 
 """Test rights schema."""
 
+from contextlib import contextmanager
+
 import pytest
 from marshmallow import ValidationError
 
@@ -73,7 +75,7 @@ def test_invalid_title(running_app):
 def test_invalid_multiple_title(running_app):
     invalid_url = {
         "title": {
-            "en": "Creative Commons Attribution 4.0 International",
+            "sv": "Creative Commons Attribution 4.0 International SV",
             "es": "Creative Commons Attribution 4.0 International ES",
         },
         "description": {"en": "A description"},
@@ -96,7 +98,7 @@ def test_invalid_description(running_app):
 def test_invalid_multiple_description(running_app):
     invalid_url = {
         "title": {"en": "Creative Commons Attribution 4.0 International"},
-        "description": {"en": "A description", "es": "A description ES"},
+        "description": {"sv": "En beskrivning", "es": "A description ES"},
         "link": "creativecommons.org/licenses/by/4.0/",
     }
     with pytest.raises(ValidationError):
@@ -155,3 +157,79 @@ def test_valid_rights(running_app, rights, minimal_record):
     metadata["rights"] = rights
 
     assert metadata == MetadataSchema().load(metadata)
+
+
+@contextmanager
+def _secondary_locale(running_app):
+    """Temporarily add a secondary locale for schema tests."""
+    app = running_app.app
+    secondary_locale = "sv"
+    secondary_title = "Swedish"
+    previous_languages = list(app.config.get("I18N_LANGUAGES", []))
+    i18n_ext = app.extensions["invenio-i18n"]
+    previous_locales_cache = i18n_ext._locales_cache
+    previous_languages_cache = i18n_ext._languages_cache
+
+    if secondary_locale not in [lang for lang, _ in previous_languages]:
+        app.config["I18N_LANGUAGES"] = previous_languages + [
+            (secondary_locale, secondary_title)
+        ]
+
+    i18n_ext._locales_cache = None
+    i18n_ext._languages_cache = None
+
+    try:
+        yield secondary_locale
+    finally:
+        app.config["I18N_LANGUAGES"] = previous_languages
+        i18n_ext._locales_cache = previous_locales_cache
+        i18n_ext._languages_cache = previous_languages_cache
+
+
+def test_rights_title_requires_english(running_app):
+    with _secondary_locale(running_app) as secondary_locale:
+        valid_english_only = {
+            "title": {"en": "Creative Commons Attribution 4.0 International"}
+        }
+        valid_english_and_localized = {
+            "title": {
+                "en": "Copyright: KTH-Royal Institute of Technology",
+                secondary_locale: "Localized copyright statement",
+            }
+        }
+        invalid_localized_only = {
+            "title": {secondary_locale: "Localized copyright statement"}
+        }
+
+        assert valid_english_only == RightsSchema().load(valid_english_only)
+        assert valid_english_and_localized == RightsSchema().load(
+            valid_english_and_localized
+        )
+        with pytest.raises(ValidationError):
+            RightsSchema().load(invalid_localized_only)
+
+
+def test_rights_description_requires_english(running_app):
+    with _secondary_locale(running_app) as secondary_locale:
+        valid_english_only = {
+            "title": {"en": "Creative Commons Attribution 4.0 International"},
+            "description": {"en": "A description"},
+        }
+        valid_english_and_localized = {
+            "title": {"en": "Creative Commons Attribution 4.0 International"},
+            "description": {
+                "en": "A description",
+                secondary_locale: "Localized description",
+            },
+        }
+        invalid_localized_only = {
+            "title": {"en": "Creative Commons Attribution 4.0 International"},
+            "description": {secondary_locale: "Localized description"},
+        }
+
+        assert valid_english_only == RightsSchema().load(valid_english_only)
+        assert valid_english_and_localized == RightsSchema().load(
+            valid_english_and_localized
+        )
+        with pytest.raises(ValidationError):
+            RightsSchema().load(invalid_localized_only)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR updates rights metadata validation to require an English
translation for `title` and `description`.
cleses: https://github.com/inveniosoftware/invenio-app-rdm/issues/3394

AI was used to help generate many parts of this PR.

Could not reproduce it on latest...
still investigating it.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
