### PR TITLE
ui(translations): mark message as translatable

### DIFF
--- a/invenio_rdm_records/resources/errors.py
+++ b/invenio_rdm_records/resources/errors.py
@@ -13,12 +13,13 @@ import json
 from flask import g
 from flask_resources import HTTPJSONException as _HTTPJSONException
 from flask_resources.serializers.json import JSONEncoder
+from invenio_i18n import lazy_gettext as _
 
 
 class HTTPJSONValidationWithMessageAsListException(_HTTPJSONException):
     """HTTP exception serializing to JSON where errors are in a list."""
 
-    description = "A validation error occurred."
+    description = _("A validation error occurred.")
 
     def __init__(self, exception):
         """Constructor."""


### PR DESCRIPTION
### Description

Marked validation message as translatable that wasn't previously.


### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).