### PR TITLE
ui(translations): mark strings as translatable

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedbackSummary.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/errors/FormFeedbackSummary.js
@@ -6,6 +6,7 @@
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.
 
+import { i18next } from "@translations/invenio_rdm_records/i18next";
 import _isEmpty from "lodash/isEmpty";
 import React, { Component } from "react";
 import { Label } from "semantic-ui-react";
@@ -63,7 +64,7 @@ export class FormFeedbackSummary extends Component {
           const label =
             sectionElement?.getAttribute("data-label") ||
             sectionElement?.getAttribute("label") ||
-            "Unknown section";
+            i18next.t("Unknown section");
           errorSections.set(section, {
             label,
             count: (errorSections.get(section)?.count || 0) + 1,
@@ -88,7 +89,7 @@ export class FormFeedbackSummary extends Component {
         const label =
           sectionElement.getAttribute("data-label") ||
           sectionElement.getAttribute("label") ||
-          "Unknown section";
+          i18next.t("Unknown section");
         errorSections.set(sectionId, {
           label,
           count: (errorSections.get(sectionId)?.count || 0) + 1,


### PR DESCRIPTION
### Description

Marked two strings as translatable via i18next.t that were previously not


### Checklist

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).