### PR TITLE
feat(auditlog): Add audit logs for file create/delete

### DIFF
--- a/invenio_rdm_records/auditlog/actions.py
+++ b/invenio_rdm_records/auditlog/actions.py
@@ -18,7 +18,7 @@ from invenio_rdm_records.services.schemas.parent.access import (
     Grant,
 )
 
-from .context import LogChangesContext, ResourceDataContext
+from .context import FileContext, LogChangesContext, ResourceDataContext
 
 
 class ParentBaseAuditLog(BaseAuditLog):
@@ -127,4 +127,33 @@ class RDMDraftAccessSettingsAuditLog(RDMRecordAccessSettingsAuditLog):
     id = "draft.access_settings_update"
     message_template = _(
         "User {user_id} updated access settings of {resource_type} {resource_id} via draft."
+    )
+
+
+class FileCreateAuditLog(BaseAuditLog):
+    """Audit log for file create."""
+
+    resource_type = "draft"
+
+    context = BaseAuditLog.context + [
+        FileContext(),
+    ]
+
+    id = "file.create"
+    message_template = _(
+        "User {user_id} created file {file_key} of {resource_type} {resource_id}."
+    )
+
+    metadata_schema = {
+        **BaseAuditLog.metadata_schema,
+        "file_key": ma.fields.String(required=True),
+    }
+
+
+class FileDeleteAuditLog(FileCreateAuditLog):
+    """Audit log for file delete."""
+
+    id = "file.delete"
+    message_template = _(
+        "User {user_id} deleted file {file_key} of {resource_type} {resource_id}."
     )

--- a/invenio_rdm_records/auditlog/context.py
+++ b/invenio_rdm_records/auditlog/context.py
@@ -38,3 +38,12 @@ class ResourceDataContext(object):
             "type": "draft" if isinstance(resource, RDMDraft) else "record",
         }
         dict_set(data, "metadata.triggered_by", triggered_by)
+
+
+class FileContext(object):
+    """Payload generator for setting file data."""
+
+    def __call__(self, data, **kwargs):
+        """Update data with file data."""
+        file_key = kwargs.get("file_key", None)
+        dict_set(data, "metadata.file_key", file_key)

--- a/invenio_rdm_records/services/files/service.py
+++ b/invenio_rdm_records/services/files/service.py
@@ -7,8 +7,14 @@
 
 """File Service API."""
 
+from invenio_audit_logs.services.uow import AuditLogOp
 from invenio_records_resources.services import FileService
+from invenio_records_resources.services.uow import unit_of_work
 
+from invenio_rdm_records.auditlog.actions import (
+    FileCreateAuditLog,
+    FileDeleteAuditLog,
+)
 from invenio_rdm_records.services.errors import RecordDeletedException
 
 
@@ -32,3 +38,23 @@ class RDMFileService(FileService):
         self._check_record_deleted_permissions(record, identity)
 
         return record
+
+    @unit_of_work()
+    def commit_file(self, identity, id_, file_key, uow=None):
+        """Commit a file upload."""
+        result = super().commit_file(identity, id_, file_key, uow=uow)
+
+        uow.register(
+            AuditLogOp(FileCreateAuditLog.build(identity, id_, file_key=file_key))
+        )  # Added here as audit logs can't be added to invenio-records-resources
+        return result
+
+    @unit_of_work()
+    def delete_file(self, identity, id_, file_key, uow=None):
+        """Delete a file."""
+        result = super().delete_file(identity, id_, file_key, uow=uow)
+
+        uow.register(
+            AuditLogOp(FileDeleteAuditLog.build(identity, id_, file_key=file_key))
+        )  # Added here as audit logs can't be added to invenio-records-resources
+        return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -154,6 +154,8 @@ invenio_audit_logs.actions =
     draft.secret_link_update = invenio_rdm_records.auditlog.actions:RDMDraftSecretLinkAuditLog
     record.access_settings_update = invenio_rdm_records.auditlog.actions:RDMRecordAccessSettingsAuditLog
     draft.access_settings_update = invenio_rdm_records.auditlog.actions:RDMDraftAccessSettingsAuditLog
+    file.create = invenio_rdm_records.auditlog.actions:FileCreateAuditLog
+    file.delete = invenio_rdm_records.auditlog.actions:FileDeleteAuditLog
 
 [build_sphinx]
 source-dir = docs/


### PR DESCRIPTION
closes: https://github.com/CERNDocumentServer/cds-rdm/issues/681

For files, from what I've observed users can only delete and upload a new file. There aren't any changes done via the service layer on the same file (eg. metadata).

If there is, and maybe I have missed it, please let me know and we can add tracking for that as well.