### PR TITLE
Overridable added to tabs in community header search app

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
@@ -82,6 +82,7 @@ class CommunityHeaderComponent extends Component {
                         this.setState({ modalOpen: false });
                       }}
                       onModalChange={(value) => this.setState({ modalOpen: value })}
+                      handleClose={() => this.setState({ modalOpen: false })}
                       modalOpen={modalOpen}
                       chosenCommunity={community}
                       displaySelected

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
@@ -35,6 +35,7 @@ class CommunityHeaderComponent extends Component {
       record,
       showCommunityHeader,
       apiConfigs,
+      overriddenComponents,
     } = this.props;
     const { modalOpen } = this.state;
 
@@ -88,6 +89,7 @@ class CommunityHeaderComponent extends Component {
                       displaySelected
                       record={record}
                       apiConfigs={apiConfigs}
+                      overriddenComponents={overriddenComponents}
                       trigger={
                         <Overridable id="InvenioRdmRecords.CommunityHeader.CommunitySelectionButton.Container">
                           <Button
@@ -145,11 +147,13 @@ CommunityHeaderComponent.propTypes = {
   record: PropTypes.object.isRequired,
   userCanManageRecord: PropTypes.bool.isRequired,
   apiConfigs: PropTypes.object,
+  overriddenComponents: PropTypes.object,
 };
 
 CommunityHeaderComponent.defaultProps = {
   community: undefined,
   apiConfigs: undefined,
+  overriddenComponents: undefined,
 };
 
 const mapStateToProps = (state) => ({

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunityHeader/CommunityHeader.js
@@ -34,6 +34,7 @@ class CommunityHeaderComponent extends Component {
       userCanManageRecord,
       record,
       showCommunityHeader,
+      apiConfigs,
     } = this.props;
     const { modalOpen } = this.state;
 
@@ -85,6 +86,7 @@ class CommunityHeaderComponent extends Component {
                       chosenCommunity={community}
                       displaySelected
                       record={record}
+                      apiConfigs={apiConfigs}
                       trigger={
                         <Overridable id="InvenioRdmRecords.CommunityHeader.CommunitySelectionButton.Container">
                           <Button
@@ -141,10 +143,12 @@ CommunityHeaderComponent.propTypes = {
   changeSelectedCommunity: PropTypes.func.isRequired,
   record: PropTypes.object.isRequired,
   userCanManageRecord: PropTypes.bool.isRequired,
+  apiConfigs: PropTypes.object,
 };
 
 CommunityHeaderComponent.defaultProps = {
   community: undefined,
+  apiConfigs: undefined,
 };
 
 const mapStateToProps = (state) => ({

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionModal.js
@@ -70,6 +70,7 @@ export class CommunitySelectionModalComponent extends Component {
       handleClose,
       record,
       isInitialSubmission,
+      overriddenComponents,
     } = this.props;
 
     return (
@@ -98,6 +99,7 @@ export class CommunitySelectionModalComponent extends Component {
             apiConfigs={apiConfigs}
             record={record}
             isInitialSubmission={isInitialSubmission}
+            overriddenComponents={overriddenComponents}
           />
 
           {extraContentComponents && (
@@ -127,6 +129,7 @@ CommunitySelectionModalComponent.propTypes = {
   handleClose: PropTypes.func.isRequired,
   record: PropTypes.object,
   isInitialSubmission: PropTypes.bool,
+  overriddenComponents: PropTypes.object,
 };
 
 CommunitySelectionModalComponent.defaultProps = {
@@ -140,6 +143,7 @@ CommunitySelectionModalComponent.defaultProps = {
   apiConfigs: undefined,
   isInitialSubmission: true,
   record: null,
+  overriddenComponents: undefined,
 };
 
 const mapStateToProps = (state) => ({

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionSearch.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/CommunitySelectionModal/CommunitySelectionSearch.js
@@ -7,7 +7,7 @@
 
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import React, { Component } from "react";
-import { OverridableContext, parametrize } from "react-overridable";
+import Overridable, { OverridableContext, parametrize } from "react-overridable";
 import {
   EmptyResults,
   Error,
@@ -52,6 +52,7 @@ export class CommunitySelectionSearch extends Component {
       pagination,
       myCommunitiesEnabled,
       autofocus,
+      overriddenComponents: extraOverriddenComponents,
     } = this.props;
 
     const searchApi = new InvenioSearchApi(selectedSearchApi);
@@ -60,6 +61,7 @@ export class CommunitySelectionSearch extends Component {
         record,
         isInitialSubmission,
       }),
+      ...extraOverriddenComponents,
     };
 
     return (
@@ -74,51 +76,60 @@ export class CommunitySelectionSearch extends Component {
         >
           <>
             <Modal.Content as={Grid} className="m-0 pb-0 centered">
-              {myCommunitiesEnabled && (
-                <Grid.Column
-                  mobile={16}
-                  tablet={8}
-                  computer={8}
-                  textAlign="left"
-                  floated="left"
-                  className="pt-0 pl-0"
-                >
-                  <Menu role="tablist" className="theme-primary-menu" compact>
-                    <Menu.Item
-                      as="button"
-                      role="tab"
-                      id="all-communities-tab"
-                      aria-selected={selectedAppId === allCommunities.appId}
-                      aria-controls={allCommunities.appId}
-                      name="All"
-                      active={selectedAppId === allCommunities.appId}
-                      onClick={() =>
-                        this.setState({
-                          selectedConfig: allCommunities,
-                        })
-                      }
-                    >
-                      {i18next.t("All")}
-                    </Menu.Item>
-                    <Menu.Item
-                      as="button"
-                      role="tab"
-                      id="my-communities-tab"
-                      aria-selected={selectedAppId === myCommunities.appId}
-                      aria-controls={myCommunities.appId}
-                      name="My communities"
-                      active={selectedAppId === myCommunities.appId}
-                      onClick={() =>
-                        this.setState({
-                          selectedConfig: myCommunities,
-                        })
-                      }
-                    >
-                      {i18next.t("My communities")}
-                    </Menu.Item>
-                  </Menu>
-                </Grid.Column>
-              )}
+              <Overridable
+                id="InvenioRdmRecords.CommunityHeader.CommunitySelectionSearch.TabMenu.Container"
+                allCommunities={allCommunities}
+                myCommunities={myCommunities}
+                selectedAppId={selectedAppId}
+                onSelectConfig={(config) => this.setState({ selectedConfig: config })}
+                myCommunitiesEnabled={myCommunitiesEnabled}
+              >
+                {myCommunitiesEnabled && (
+                  <Grid.Column
+                    mobile={16}
+                    tablet={8}
+                    computer={8}
+                    textAlign="left"
+                    floated="left"
+                    className="pt-0 pl-0"
+                  >
+                    <Menu role="tablist" className="theme-primary-menu" compact>
+                      <Menu.Item
+                        as="button"
+                        role="tab"
+                        id="all-communities-tab"
+                        aria-selected={selectedAppId === allCommunities.appId}
+                        aria-controls={allCommunities.appId}
+                        name="All"
+                        active={selectedAppId === allCommunities.appId}
+                        onClick={() =>
+                          this.setState({
+                            selectedConfig: allCommunities,
+                          })
+                        }
+                      >
+                        {i18next.t("All")}
+                      </Menu.Item>
+                      <Menu.Item
+                        as="button"
+                        role="tab"
+                        id="my-communities-tab"
+                        aria-selected={selectedAppId === myCommunities.appId}
+                        aria-controls={myCommunities.appId}
+                        name="My communities"
+                        active={selectedAppId === myCommunities.appId}
+                        onClick={() =>
+                          this.setState({
+                            selectedConfig: myCommunities,
+                          })
+                        }
+                      >
+                        {i18next.t("My communities")}
+                      </Menu.Item>
+                    </Menu>
+                  </Grid.Column>
+                )}
+              </Overridable>
               <Grid.Column
                 mobile={16}
                 tablet={8}
@@ -184,6 +195,7 @@ CommunitySelectionSearch.propTypes = {
   pagination: PropTypes.bool,
   myCommunitiesEnabled: PropTypes.bool,
   autofocus: PropTypes.bool,
+  overriddenComponents: PropTypes.object,
 };
 
 CommunitySelectionSearch.defaultProps = {
@@ -193,6 +205,7 @@ CommunitySelectionSearch.defaultProps = {
   autofocus: true,
   CommunityListItem: CommunityListItem,
   record: null,
+  overriddenComponents: undefined,
   apiConfigs: {
     allCommunities: {
       initialQueryState: { size: 5, page: 1, sortBy: "bestmatch" },


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description
A few fixes related to community header. I've split it into logically related commits, so that you can more easily reject or accept some. The fixes are:

1. ability to pass search app config to community header as a prop (imo this was probably simply forgotten when component was originally written).
2. Modal close button not working (ditto).
3. The third change is the largest. We need a good way to override those tabs, because somewhere we could have different number of tabs (1 or 3). The use case for us, is that we have some repositories where it is much stricter who can submit to which community, so we require some flexibility here. I've decided to make the overrides passed to search app via prop, and contained to the component, instead of pasting overrideStore.getAll to the overridable provider, as I thought this would make it cleaner and contained to the component itself. Also in some repositories, we could have 5 or more forms, and using global override store is not a good idea for such a use case. 

Please let us know what you think. 

Thanks,

Dusan S
