### PR TITLE
fix: using only depositable resource type for fake data

### DIFF
--- a/invenio_rdm_records/fixtures/demo.py
+++ b/invenio_rdm_records/fixtures/demo.py
@@ -63,7 +63,8 @@ class CachedVocabularies:
             res_types = cls._read_vocabulary("resourcetypes")
 
             for res in res_types:
-                cls._resource_type_ids.append(res["id"])
+                if "depositable" in res.get("tags", []):
+                    cls._resource_type_ids.append(res["id"])
 
         random_id = random.choice(cls._resource_type_ids)
         return {"id": random_id}


### PR DESCRIPTION
* in case fake data ends up with resource type that is not
* depositable, relations check will fail and therefore the
* test using the fake data

:heart: Thank you for your contribution!

### Description

Coming from here https://github.com/inveniosoftware/invenio-rdm-records/issues/2315#issuecomment-4238709248