### PR TITLE
fix(vcs): avoid failing on unrecognised license; include warning messages in notifications

### DIFF
--- a/invenio_rdm_records/notifications/vcs.py
+++ b/invenio_rdm_records/notifications/vcs.py
@@ -64,10 +64,12 @@ class RepositoryReleaseSuccessNotificationBuilder(RepositoryReleaseNotificationB
         generic_repository: GenericRepository,
         generic_release: GenericRelease,
         record,
+        warnings: list[str],
     ):
         """Build the notification."""
         notification = super().build(provider, generic_repository, generic_release)
         notification.context["record"] = EntityResolverRegistry.reference_entity(record)
+        notification.context["warnings"] = warnings
         return notification
 
     context = [EntityResolve(key="record")]
@@ -150,6 +152,7 @@ class RepositoryReleaseCommunitySubmittedNotificationBuilder(
         generic_release: GenericRelease,
         request,
         community,
+        warnings: list[str],
     ):
         """Build the notification."""
         notification = super().build(provider, generic_repository, generic_release)
@@ -159,6 +162,7 @@ class RepositoryReleaseCommunitySubmittedNotificationBuilder(
         notification.context["community"] = EntityResolverRegistry.reference_entity(
             community
         )
+        notification.context["warnings"] = warnings
         return notification
 
     context = [EntityResolve(key="request"), EntityResolve(key="community")]

--- a/invenio_rdm_records/services/vcs/metadata.py
+++ b/invenio_rdm_records/services/vcs/metadata.py
@@ -85,15 +85,10 @@ class RDMReleaseMetadata(object):
             title=self.title,
             resource_type={"id": "software"},
             creators=self.contributors,
-            publisher=current_app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS").get(
+            publisher=current_app.config.get("APP_RDM_DEPOSIT_FORM_DEFAULTS", {}).get(
                 "publisher", "CERN"
             ),
         )
-
-    @property
-    def repo_license(self):
-        """Get license from repository, if any."""
-        return self.rdm_release.generic_repo.license_spdx
 
     @property
     def contributors(self):

--- a/invenio_rdm_records/services/vcs/release.py
+++ b/invenio_rdm_records/services/vcs/release.py
@@ -7,6 +7,8 @@
 # it under the terms of the MIT License; see LICENSE file for more details.
 """VCS release API implementation."""
 
+from __future__ import annotations
+
 from flask import current_app
 from invenio_access.permissions import authenticated_user, system_identity
 from invenio_access.utils import get_identity
@@ -14,10 +16,14 @@ from invenio_db import db
 from invenio_drafts_resources.resources.records.errors import DraftNotCreatedError
 from invenio_i18n import lazy_gettext as _
 from invenio_notifications.services.uow import NotificationOp
+from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_records_resources.services.uow import UnitOfWork
 from invenio_vcs.api import VCSRelease
 from invenio_vcs.errors import CustomVCSReleaseNoRetryError
-from invenio_vcs.models import ReleaseStatus
+from invenio_vcs.models import Release, ReleaseStatus
+from invenio_vcs.providers import RepositoryServiceProvider
+from invenio_vocabularies.proxies import current_service as current_vocabularies_service
+from sqlalchemy.exc import NoResultFound
 
 from invenio_rdm_records.notifications.vcs import (
     RepositoryReleaseCommunityRequiredNotificationBuilder,
@@ -62,22 +68,35 @@ class RDMVCSRelease(VCSRelease):
 
     metadata_cls = RDMReleaseMetadata
 
-    @property
-    def metadata(self):
+    def __init__(self, release: Release, provider: RepositoryServiceProvider):
+        """Constructor."""
+        super().__init__(release, provider)
+        self.warnings = []
+
+    def add_warning(self, warning: str):
+        """Add a new non-fatal warning."""
+        self.warnings.append(warning)
+
+    def build_metadata(self):
         """Extracts metadata to create an RDM draft."""
         metadata = self.metadata_cls(self)
-        output = metadata.default_metadata
+        output: dict = metadata.default_metadata
         output.update(metadata.extra_metadata)
-        output.update(metadata.citation_metadata)
+        citation_metadata = metadata.citation_metadata
+        if citation_metadata is not None:
+            output.update(citation_metadata)
 
         if not output.get("creators"):
-            # Get owner from Github API
             owner = self.get_owner()
             if owner:
                 output.update({"creators": [owner]})
 
         # Default to "Unkwnown"
         if not output.get("creators"):
+            self.add_warning(
+                "No contributors were found for the repository. "
+                "The record has been created without a list of creators; please edit it to specify them manually."
+            )
             output.update(
                 {
                     "creators": [
@@ -92,8 +111,9 @@ class RDMVCSRelease(VCSRelease):
             )
 
         # Add license if not yet added and available from the repo.
-        if not output.get("rights") and metadata.repo_license:
-            output.update({"rights": [{"id": metadata.repo_license.lower()}]})
+        license_pid = self.get_license_pid()
+        if not output.get("rights") and license_pid:
+            output.update({"rights": [{"id": license_pid}]})
         return output
 
     def get_custom_fields(self):
@@ -104,16 +124,35 @@ class RDMVCSRelease(VCSRelease):
         return ret
 
     def get_owner(self):
-        """Retrieves repository owner and its affiliation, if any."""
+        """Retrieves repository owner and its affiliation from the VCS API, if any."""
         # `owner.name` is not required, `owner.login` is.
         output = None
         if self.owner:
-            name = getattr(self.owner, "name", self.owner.login)
+            name = getattr(self.owner, "name", self.owner.path_name)
             company = getattr(self.owner, "company", None)
             output = {"person_or_org": {"type": "personal", "family_name": name}}
             if company:
                 output.update({"affiliations": [{"name": company}]})
         return output
+
+    def get_license_pid(self) -> str | None:
+        """Returns whether the repository's license SPDX (as returned by the VCS) is a valid RDM license."""
+        license_spdx_id = self.generic_repo.license_spdx
+        if license_spdx_id is None:
+            return None
+
+        try:
+            # Try reading from the vocab list; it may not exist since the VCS IDs do not map 1-to-1 with the vocabulary IDs
+            license_vocab = current_vocabularies_service.read(
+                identity=self.user_identity, id_=("licenses", license_spdx_id.lower())
+            )
+            return license_vocab.pid.id
+        except (PIDDoesNotExistError, NoResultFound):
+            self.add_warning(
+                f"The repository's license '{license_spdx_id}' is not recognised. The record has been created without "
+                "a license; please edit it to select one manually.",
+            )
+            return None
 
     def resolve_record(self):
         """Resolves an RDM record from a release."""
@@ -190,7 +229,7 @@ class RDMVCSRelease(VCSRelease):
         try:
             with UnitOfWork(db.session) as uow:
                 data = {
-                    "metadata": self.metadata,
+                    "metadata": self.build_metadata(),
                     "access": {"record": "public", "files": "public"},
                     "files": {"enabled": True},
                     "custom_fields": self.get_custom_fields(),
@@ -291,6 +330,7 @@ class RDMVCSRelease(VCSRelease):
                                 generic_repository=self.generic_repo,
                                 generic_release=self.generic_release,
                                 record=record,
+                                warnings=self.warnings,
                             )
                         )
                     )
@@ -311,6 +351,7 @@ class RDMVCSRelease(VCSRelease):
                                 generic_release=self.generic_release,
                                 request=review_request._record,
                                 community=review_request._record.receiver.resolve(),
+                                warnings=self.warnings,
                             )
                         )
                     )

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/repository-release.community-submitted.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/repository-release.community-submitted.jinja
@@ -2,6 +2,8 @@
 {% set release_tag = notification.context.release_tag %}
 {% set community_title = notification.context.community["metadata"]["title"] %}
 {% set request_link = notification.context.request["links"]["self_html"] %}
+{% set warnings = notification.context.warnings %}
+{% set has_warnings = warnings|length != 0 %}
 
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 
@@ -18,6 +20,22 @@
     <tr>
         <td>{{ _("No further action is needed right now. This only needs to be done for your repository's first release.") }}</td>
     </tr>
+
+    {% if has_warnings %}
+        <tr>
+            <td><strong>{{ _("However, some warnings were encountered during processing:") }}</strong></td>
+        </tr>
+        <tr>
+            <td>
+                <ul>
+                    {% for warning in warnings %}
+                        <li>{{ warning }}</li>
+                    {% endfor %}
+                </ul>
+            </td>
+        </tr>
+    {% endif %}
+
     <tr>
         <td><a href="{{ request_link }}" class="button">{{ _("View the review request") }}</a> {{ _("for more details.") }}</td>
     </tr>
@@ -35,6 +53,14 @@
 
 {{ _("No further action is needed right now. This only needs to be done for your repository's first release.") }}
 
+{% if has_warnings %}
+**{{ _("However, some warnings were encountered during processing:") }}**
+
+{% for warning in warnings %}
+- {{ warning }}
+{% endfor %}
+{% endif %}
+
 [{{ _("View the review request") }}]({{ request_link }}) {{ _("for more details.") }}
 
 {{ _("This is an auto-generated message. To manage notifications, visit your account settings") }}
@@ -45,6 +71,14 @@
 {{ _("Release %(release_tag)s of %(repository_name)s has been submitted for review to %(community_title)s.", release_tag=release_tag, repository_name=repository_full_name, community_title=community_title) }}
 
 {{ _("No further action is needed right now. This only needs to be done for your repository's first release.") }}
+
+{% if has_warnings %}
+**{{ _("However, some warnings were encountered during processing:") }}**
+
+{% for warning in warnings %}
+- {{ warning }}
+{% endfor %}
+{% endif %}
 
 [{{ _("View the review request") }}]({{ request_link }}) {{ _("for more details.") }}
 

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/repository-release.success.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/repository-release.success.jinja
@@ -1,20 +1,43 @@
 {% set repository_full_name = notification.context.repository_full_name %}
 {% set release_tag = notification.context.release_tag %}
 {% set record = notification.context.record %}
+{% set warnings = notification.context.warnings %}
+{% set has_warnings = warnings|length != 0 %}
 
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
 {% set record_link = record["links"]["self_html"] %}
 
 {%- block subject -%}
-    {{ _("A release from %(repository_name)s was published successfully", repository_name=repository_full_name) }}
+    {% if has_warnings %}
+        {{ _("A release from %(repository_name)s was published with warning(s)", repository_name=repository_full_name) }}
+    {% else %}
+        {{ _("A release from %(repository_name)s was published successfully", repository_name=repository_full_name) }}
+    {% endif %}
 {%- endblock subject -%}
 
 {%- block html_body -%}
 <table style="font-family:'Lato',Helvetica,Arial,sans-serif;border-spacing:15px">
     <tr>
-        <td>{{ _("Release %(release_tag)s of %(repository_name)s has been received and published successfully.", release_tag=release_tag, repository_name=repository_full_name) }}
+        <td>
+            {{ _("Release %(release_tag)s of %(repository_name)s has been received and published.", release_tag=release_tag, repository_name=repository_full_name) }}
         </td>
     </tr>
+
+    {% if has_warnings %}
+        <tr>
+            <td><strong>{{ _("Some warnings were encountered during processing:") }}</strong></td>
+        </tr>
+        <tr>
+            <td>
+                <ul>
+                    {% for warning in warnings %}
+                        <li>{{ warning }}</li>
+                    {% endfor %}
+                </ul>
+            </td>
+        </tr>
+    {% endif %}
+
     <tr>
         <td>{{ _("For more details,")}} <a href="{{ record_link }}" class="button">{{ _("view the published record.") }}</a></td>
     </tr>
@@ -28,7 +51,15 @@
 {%- endblock html_body -%}
 
 {%- block plain_body -%}
-{{ _("Release %(release_tag)s of %(repository_name)s has been received and published successfully.", release_tag=release_tag, repository_name=repository_full_name) }}
+{{ _("Release %(release_tag)s of %(repository_name)s has been received and published.", release_tag=release_tag, repository_name=repository_full_name) }}
+
+{% if has_warnings %}
+**{{ _("Some warnings were encountered during processing:") }}**
+
+{% for warning in warnings %}
+- {{ warning }}
+{% endfor %}
+{% endif %}
 
 {{ _("For more details,") }} [{{ _("view the published record.") }}]({{ record_link }})
 
@@ -37,7 +68,15 @@
 
 {# Markdown for Slack/Mattermost/chat #}
 {%- block md_body -%}
-{{ _("Release %(release_tag)s of %(repository_name)s has been received and published successfully.", release_tag=release_tag, repository_name=repository_full_name) }}
+{{ _("Release %(release_tag)s of %(repository_name)s has been received and published.", release_tag=release_tag, repository_name=repository_full_name) }}
+
+{% if has_warnings %}
+**{{ _("Some warnings were encountered during processing:") }}**
+
+{% for warning in warnings %}
+- {{ warning }}
+{% endfor %}
+{% endif %}
 
 {{ _("For more details,") }} [{{ _("view the published record.") }}]({{ record_link }})
 


### PR DESCRIPTION
Added a system of "warnings" that can be included in repository release notifications. To keep things simple, these are not stored in the DB for the release (unlike full errors), they are just included in the notification message. Right now they are only used for missing contributors and missing licenses, but more can be added later (e.g. if we improve the repository metadata extraction to support more features).