### PR TITLE
feat(reviews): add config for record version review policy

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -26,6 +26,7 @@ from invenio_records_resources.services.records.queryparser.transformer import (
 import invenio_rdm_records.services.communities.moderation as communities_moderation
 from invenio_rdm_records.services.components.pids import validate_optional_doi
 from invenio_rdm_records.services.components.verified import UserModerationHandler
+from invenio_rdm_records.services.review.policy import RecordVersionReviewPolicy
 
 from . import tokens
 from .requests.community_inclusion import CommunityInclusion
@@ -150,8 +151,12 @@ RDM_RECORDS_REVIEWS = [
     CommunitySubmission.type_id,
 ]
 """List of review request types."""
+
 RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = CommunitySubmission
 """Request type for community submission requests."""
+
+RDM_RECORD_VERSION_REVIEW_POLICY = RecordVersionReviewPolicy
+"""Policy for when to require a community review for new record versions."""
 
 #
 # Record files configuration

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -26,6 +26,7 @@ from invenio_records_resources.services.records.queryparser.transformer import (
 import invenio_rdm_records.services.communities.moderation as communities_moderation
 from invenio_rdm_records.services.components.pids import validate_optional_doi
 from invenio_rdm_records.services.components.verified import UserModerationHandler
+from invenio_rdm_records.services.review.policy import RecordVersionReviewPolicy
 
 from . import tokens
 from .requests.community_inclusion import CommunityInclusion
@@ -153,8 +154,12 @@ RDM_RECORDS_REVIEWS = [
     CommunitySubmission.type_id,
 ]
 """List of review request types."""
+
 RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = CommunitySubmission
 """Request type for community submission requests."""
+
+RDM_RECORD_VERSION_REVIEW_POLICY = RecordVersionReviewPolicy
+"""Policy for when to require a community review for new record versions."""
 
 #
 # Record files configuration

--- a/invenio_rdm_records/services/review/policy.py
+++ b/invenio_rdm_records/services/review/policy.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Invenio RDM Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Policy configuration to define which versions of records require community review."""
+
+
+class RecordVersionReviewPolicy:
+    """
+    Base class for defining a policy for whether new versions of records require community review.
+
+    A new record submitted to a community for the first time (via a community submission request) will always
+    require a review regardless of this policy (subject to the community's settings).
+    """
+
+    @classmethod
+    def requires_review(cls, identity, draft) -> bool:
+        """
+        Returns whether the draft needs to be submitted for a review.
+
+        If the first draft of a new parent record is submitted to a community, it will always trigger a review
+        (subject to the community's settings).
+        The return value of this method only applies to new version drafts created for existing records.
+
+        Review requests will only be made for the default community of a parent record.
+
+        The default behaviour is to return False, meaning new versions of existing records will never require
+        a community review.
+        """
+        return False

--- a/invenio_rdm_records/services/review/policy.py
+++ b/invenio_rdm_records/services/review/policy.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Invenio RDM Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Policy configuration to define which versions of records require community review."""
+
+
+class RecordVersionReviewPolicy:
+    """
+    Base class for defining a policy for which versions of records require community review.
+
+    A new record submitted to a community for the first time (via a community submission request) will always
+    require a review regardless of this policy (subject to the community's settings).
+    """
+
+    def __init__(self, draft, community, identity) -> None:
+        """
+        Constructor.
+
+        Is passed the current draft, the default community of the parent record, and the submitting user's identity.
+        """
+        self.draft = draft
+        self.community = community
+        self.identity = identity
+
+    def requires_review(self) -> bool:
+        """
+        Returns whether the draft needs to be submitted for a review.
+
+        If the first draft of a new parent record is submitted to a community, it will always trigger a review
+        (subject to the community's settings).
+        The return value of this method only applies to new version drafts created for existing records.
+
+        The default behaviour is to return False, meaning new versions of existing records will never require
+        a community review.
+        """
+        return False


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/2305

**I am happy to make changes to the structure of this config or the general approach to the task of allowing per-record-version reviews. We should try to make changes now before we "lock in" the structure of the config.**

See the [discussion](https://github.com/inveniosoftware/product-rdm/discussions/241) for more details.

---

* Added a new class to define a policy for whether a new version draft of an existing record should trigger a community submission request.
* The default behaviour is to never trigger a request for new versions (which is the current behaviour).
* The implementation of this policy is in https://github.com/inveniosoftware/invenio-rdm-records/pull/2325
* The configured policy can be changed easily using a new config variable by inheriting from the class and overriding the method.