### PR TITLE
per-record-version requests (model + service updates)

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/api/DepositRecordSerializer.js
@@ -267,6 +267,9 @@ export class RDMDepositRecordSerializer extends DepositRecordSerializer {
         serializedDefault: {},
         vocabularyFields: this.customFieldVocabularies,
       }),
+      review: new Field({
+        fieldpath: "review",
+      }),
     };
   }
 
@@ -326,6 +329,7 @@ export class RDMDepositRecordSerializer extends DepositRecordSerializer {
       "created",
       "updated",
       "revision_id",
+      "review",
     ]);
 
     // FIXME: move logic in a more sophisticated PIDField that allows empty values

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/DepositStatus/DepositStatusBox.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/components/DepositStatus/DepositStatusBox.js
@@ -11,56 +11,83 @@ import { Button, Grid, Icon, Popup } from "semantic-ui-react";
 import { DepositStatus } from "../../state/reducers/deposit";
 import PropTypes from "prop-types";
 
-const STATUSES = {
-  [DepositStatus.IN_REVIEW]: {
-    color: "warning",
-    title: i18next.t("In review"),
-    message: i18next.t(
-      "Community curators will review your upload. Once accepted, it will be published."
-    ),
-  },
-  [DepositStatus.DECLINED]: {
-    color: "negative",
-    title: i18next.t("Declined"),
-    message: i18next.t(
-      "The request to submit this upload to the community was declined."
-    ),
-  },
-  [DepositStatus.EXPIRED]: {
-    color: "expired",
-    title: i18next.t("Expired"),
-    message: i18next.t(
-      "The request to submit this upload to the community has expired."
-    ),
-  },
-  [DepositStatus.PUBLISHED]: {
-    color: "positive",
-    title: i18next.t("Published"),
-    message: i18next.t("Your upload is published."),
-  },
-  [DepositStatus.DRAFT_WITH_REVIEW]: {
-    color: "neutral",
-    title: i18next.t("Draft"),
-    message: i18next.t(
-      "Once your upload is complete, you can submit it for review to the community curators."
-    ),
-  },
-  [DepositStatus.DRAFT]: {
-    color: "neutral",
-    title: i18next.t("Draft"),
-    message: i18next.t(
-      "Once your upload is complete, you can publish or submit it for review to the community curators."
-    ),
-  },
-  [DepositStatus.NEW_VERSION_DRAFT]: {
-    color: "neutral",
-    title: i18next.t("New version draft"),
-    message: i18next.t("Once your upload is complete, you can publish it."),
-  },
+const getStatus = (depositStatus, requireDeletionForDeclinedDraft) => {
+  switch (depositStatus) {
+    case DepositStatus.IN_REVIEW:
+      return {
+        color: "warning",
+        title: i18next.t("In review"),
+        message: i18next.t(
+          "Community curators will review your upload. Once accepted, it will be published."
+        ),
+      };
+    case DepositStatus.DECLINED:
+      return {
+        color: "negative",
+        title: i18next.t("Declined"),
+        message: requireDeletionForDeclinedDraft
+          ? i18next.t(
+              "The request to submit this upload to the community was declined. Please discard this version and create a new one with the feedback from the review."
+            )
+          : i18next.t(
+              "The request to submit this upload to the community was declined."
+            ),
+      };
+    case DepositStatus.EXPIRED:
+      return {
+        color: "expired",
+        title: i18next.t("Expired"),
+        message: i18next.t(
+          "The request to submit this upload to the community has expired."
+        ),
+      };
+    case DepositStatus.PUBLISHED:
+      return {
+        color: "positive",
+        title: i18next.t("Published"),
+        message: i18next.t("Your upload is published."),
+      };
+    case DepositStatus.DRAFT_WITH_REVIEW:
+      return {
+        color: "neutral",
+        title: i18next.t("Draft"),
+        message: i18next.t(
+          "Once your upload is complete, you can submit it for review to the community curators."
+        ),
+      };
+    case DepositStatus.DRAFT:
+      return {
+        color: "neutral",
+        title: i18next.t("Draft"),
+        message: i18next.t(
+          "Once your upload is complete, you can publish or submit it for review to the community curators."
+        ),
+      };
+    case DepositStatus.NEW_VERSION_DRAFT:
+      return {
+        color: "neutral",
+        title: i18next.t("New version draft"),
+        message: i18next.t("Once your upload is complete, you can publish it."),
+      };
+    case DepositStatus.NEW_VERSION_DRAFT_WITH_REVIEW:
+      return {
+        color: "neutral",
+        title: i18next.t("New version draft"),
+        message: i18next.t(
+          "Once your upload is complete, you can submit it for review to the community curators."
+        ),
+      };
+    default:
+      return null;
+  }
 };
 
-const DepositStatusBoxComponent = ({ depositReview, depositStatus }) => {
-  const status = STATUSES[depositStatus];
+const DepositStatusBoxComponent = ({
+  depositReview,
+  depositStatus,
+  requireDeletionForDeclinedDraft,
+}) => {
+  const status = getStatus(depositStatus, requireDeletionForDeclinedDraft);
   if (!status) {
     throw new Error("Status is undefined");
   }
@@ -100,6 +127,7 @@ const DepositStatusBoxComponent = ({ depositReview, depositStatus }) => {
 DepositStatusBoxComponent.propTypes = {
   depositReview: PropTypes.bool,
   depositStatus: PropTypes.string.isRequired,
+  requireDeletionForDeclinedDraft: PropTypes.bool.isRequired,
 };
 
 DepositStatusBoxComponent.defaultProps = {
@@ -110,7 +138,9 @@ const mapStateToProps = (state) => ({
   depositStatus: state.deposit.record.status,
   depositReview:
     state.deposit.record.status !== DepositStatus.DRAFT &&
-    state.deposit.record.parent.review,
+    (state.deposit.record.parent.review ?? state.deposit.record.review),
+  requireDeletionForDeclinedDraft:
+    state.deposit.editorState.ui.requireDeletionForDeclinedDraft,
 });
 
 export const DepositStatusBox = connect(

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewOrPublishButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/PublishButton/SubmitReviewOrPublishButton.js
@@ -1,5 +1,5 @@
 // This file is part of Invenio-RDM-Records
-// Copyright (C) 2022-2023 CERN.
+// Copyright (C) 2022-2026 CERN.
 //
 // Invenio-RDM-Records is free software; you can redistribute it and/or modify it
 // under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
@@ -148,11 +148,7 @@ function getSelectedCommunityMetadata(record, selectedCommunity) {
  * @param {object} selectedCommunity: the selected community, `null` to deselect.
  * @returns a new state for the deposit form
  */
-export function computeDepositState(
-  record,
-  permissions,
-  selectedCommunity = undefined
-) {
+export function computeDepositState(record, selectedCommunity = undefined) {
   const depositStatusAllowsReviewDeletion = hasStatus(
     record,
     DepositStatus.allowsReviewDeletionStates
@@ -290,7 +286,6 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
-          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: {},
@@ -307,7 +302,6 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
-          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: {},
@@ -326,7 +320,6 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
-          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: { ...action.payload.errors },
@@ -366,11 +359,7 @@ const depositReducer = (state = {}, action) => {
       return {
         ...state,
         record: recordCopy,
-        editorState: computeDepositState(
-          recordCopy,
-          state.permissions,
-          action.payload.community
-        ),
+        editorState: computeDepositState(recordCopy, action.payload.community),
       };
     }
     case SET_DOI_NEEDED: {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
@@ -36,6 +36,7 @@ import {
 export class DepositStatus {
   static DRAFT = "draft";
   static NEW_VERSION_DRAFT = "new_version_draft";
+  static NEW_VERSION_DRAFT_WITH_REVIEW = "new_version_draft_with_review";
   static DRAFT_WITH_REVIEW = "draft_with_review";
   static IN_REVIEW = "in_review";
   static DECLINED = "declined";
@@ -58,7 +59,6 @@ export class DepositStatus {
   static disallowsSubmitForReviewStates = [
     DepositStatus.PUBLISHED,
     DepositStatus.IN_REVIEW,
-    DepositStatus.NEW_VERSION_DRAFT,
   ];
 }
 
@@ -66,11 +66,20 @@ function hasStatus(record, statuses = []) {
   return statuses.includes(record.status);
 }
 
+// Returns true if the current record version is published, or if this is not the first version record
+// within its parent.
+// This essentially corresponds to whether the parent record has been published.
+function isParentAlreadyPublished(record) {
+  return hasStatus(record, [DepositStatus.PUBLISHED]) || record.versions?.index !== 1;
+}
+
 function getSelectedCommunityMetadata(record, selectedCommunity) {
   switch (selectedCommunity) {
     case undefined: {
       // when `undefined`, retrieve the community from the record, if previously selected
-      const reviewCommunityId = record.parent?.review?.receiver?.community;
+      const reviewCommunityId =
+        record.parent?.review?.receiver?.community ??
+        record.review?.receiver?.community;
       const defaultCommunityId = record.parent?.communities?.default;
       const hasCommunity = reviewCommunityId || defaultCommunityId;
       if (!hasCommunity) {
@@ -78,13 +87,8 @@ function getSelectedCommunityMetadata(record, selectedCommunity) {
         return undefined;
       }
 
-      const alreadyPublished = hasStatus(record, [
-        DepositStatus.PUBLISHED,
-        DepositStatus.NEW_VERSION_DRAFT,
-      ]);
-
       // record should be expanded
-      return alreadyPublished
+      return isParentAlreadyPublished(record)
         ? record.expanded.parent.communities.default
         : record.expanded.parent.review.receiver;
     }
@@ -112,10 +116,15 @@ function getSelectedCommunityMetadata(record, selectedCommunity) {
  *     - user has deselected a community
  *     - the draft status is one of `DepositStatus.allowsReviewDeletionStates`
  * - `actions.communityStateMustBeChecked`: true if one of the `shouldUpdateReview` or `shouldDeleteReview` is true
- * - `ui.showSubmitForReviewButton`: true if all of the following are true:
- *     - user has selected a community
- *     - the associated review for the selected community is not declined/expired
- *     - the record is not published
+ * - `ui.showSubmitForReviewButton`:
+ *     - true if all of the following are true:
+ *         - user has selected a community
+ *         - the associated review for the selected community is not declined/expired
+ *         - the record is not published
+ *     - OR true if all of the following are true:
+ *         - parent record belongs to a community
+ *         - record is a new version draft
+ *         - user does not have permission to skip community review for a new record version
  * - `ui.showDirectPublishButton`: true if all of the following are true:
  *     - user has selected a community
  *     - user can direct publish to a community
@@ -139,7 +148,11 @@ function getSelectedCommunityMetadata(record, selectedCommunity) {
  * @param {object} selectedCommunity: the selected community, `null` to deselect.
  * @returns a new state for the deposit form
  */
-export function computeDepositState(record, selectedCommunity = undefined) {
+export function computeDepositState(
+  record,
+  permissions,
+  selectedCommunity = undefined
+) {
   const depositStatusAllowsReviewDeletion = hasStatus(
     record,
     DepositStatus.allowsReviewDeletionStates
@@ -157,7 +170,10 @@ export function computeDepositState(record, selectedCommunity = undefined) {
   const _selectedCommunity = getSelectedCommunityMetadata(record, selectedCommunity);
   const communityIsSelected = !_isEmpty(_selectedCommunity);
 
-  const draftReview = record?.parent?.review;
+  const parentAlreadyPublished = isParentAlreadyPublished(record);
+  // If the parent is already published, the review can only be on the record itself (for new-version reviews).
+  // Otherwise, the review must be on the parent.
+  const draftReview = parentAlreadyPublished ? record?.review : record?.parent?.review;
 
   // check if the selected community has a request created
   const isReviewForSelectedCommunityCreated =
@@ -181,25 +197,28 @@ export function computeDepositState(record, selectedCommunity = undefined) {
   const _showDirectPublishButton =
     communityIsSelected &&
     !hasStatus(record, [DepositStatus.PUBLISHED, DepositStatus.NEW_VERSION_DRAFT]) &&
-    _selectedCommunity.ui.permissions.can_include_directly;
+    _selectedCommunity.ui?.permissions.can_include_directly;
 
   // show submit for review button conditions extracted to be reused
   const _showSubmitReviewButton =
     communityIsSelected &&
-    !isReviewForSelectedCommunityDeclinedOrExpired &&
+    (!isReviewForSelectedCommunityDeclinedOrExpired || parentAlreadyPublished) &&
     !hasStatus(record, [DepositStatus.PUBLISHED, DepositStatus.NEW_VERSION_DRAFT]);
 
   // show community selection button conditions extracted to be reused
-  const _showCommunitySelectionButton = !hasStatus(record, [
-    DepositStatus.PUBLISHED,
-    DepositStatus.NEW_VERSION_DRAFT,
-  ]);
+  const _showCommunitySelectionButton =
+    !hasStatus(record, [
+      DepositStatus.PUBLISHED,
+      DepositStatus.NEW_VERSION_DRAFT,
+      DepositStatus.NEW_VERSION_DRAFT_WITH_REVIEW,
+    ]) && !(isReviewForSelectedCommunityDeclinedOrExpired && parentAlreadyPublished);
 
   const shouldUpdateReview =
     communityIsSelected &&
     depositStatusAllowsReviewUpdate &&
     !isReviewForSelectedCommunityCreated &&
-    !isReviewForSelectedCommunityDeclinedOrExpired;
+    !isReviewForSelectedCommunityDeclinedOrExpired &&
+    !parentAlreadyPublished;
 
   const shouldDeleteReview = !communityIsSelected && depositStatusAllowsReviewDeletion;
 
@@ -215,8 +234,14 @@ export function computeDepositState(record, selectedCommunity = undefined) {
       showSubmitForReviewButton: _showSubmitReviewButton,
       showDirectPublishButton: _showDirectPublishButton,
       disableSubmitForReviewButton:
-        _showSubmitReviewButton && depositStatusDisallowsSubmitForReview,
-      showChangeCommunityButton: isReviewForSelectedCommunityDeclinedOrExpired,
+        _showSubmitReviewButton &&
+        (depositStatusDisallowsSubmitForReview ||
+          isReviewForSelectedCommunityDeclinedOrExpired),
+      // Can only change the community if the parent record isn't already published.
+      showChangeCommunityButton:
+        isReviewForSelectedCommunityDeclinedOrExpired && record.versions.index === 1,
+      requireDeletionForDeclinedDraft:
+        isReviewForSelectedCommunityDeclinedOrExpired && record.versions.index !== 1,
       showCommunitySelectionButton: _showCommunitySelectionButton,
       showCommunityHeader: !isRecordPublishedWithoutOrUnresolvedCommunity,
       disableCommunitySelectionButton: _disableCommunitySelectionButton,
@@ -265,6 +290,7 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
+          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: {},
@@ -281,6 +307,7 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
+          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: {},
@@ -299,6 +326,7 @@ const depositReducer = (state = {}, action) => {
         },
         editorState: computeDepositState(
           action.payload.data,
+          state.permissions,
           state.editorState.selectedCommunity
         ),
         errors: { ...action.payload.errors },
@@ -338,7 +366,11 @@ const depositReducer = (state = {}, action) => {
       return {
         ...state,
         record: recordCopy,
-        editorState: computeDepositState(recordCopy, action.payload.community),
+        editorState: computeDepositState(
+          recordCopy,
+          state.permissions,
+          action.payload.community
+        ),
       };
     }
     case SET_DOI_NEEDED: {

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.test.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.test.js
@@ -26,6 +26,9 @@ const initialRecord = {
     files: "public",
   },
   is_published: false,
+  versions: {
+    index: 1,
+  },
 };
 
 const fakeSelectedCommunities = [
@@ -217,6 +220,32 @@ const publishedRecordWithoutCommunity = {
   },
 };
 
+const newVersionRecordWithReview = {
+  ...publishedRecordInCommunity,
+  status: DepositStatus.NEW_VERSION_DRAFT_WITH_REVIEW,
+  review: {
+    id: "1234",
+    receiver: {
+      community: fakeSelectedCommunities[0].id,
+    },
+    type: "community-submission",
+  },
+  expanded: {
+    ...publishedRecordInCommunity.expanded,
+    review: {
+      receiver: fakeSelectedCommunities[0],
+    },
+  },
+  versions: {
+    index: 2,
+  },
+};
+
+const newVersionRecordWithDeclinedReview = {
+  ...newVersionRecordWithReview,
+  status: DepositStatus.DECLINED,
+};
+
 describe("Test deposit reducer", () => {
   describe("Test deposit state when no draft has been created.", () => {
     it("user selects a community", async () => {
@@ -230,6 +259,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -253,6 +283,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -276,6 +307,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: false,
@@ -299,6 +331,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -322,6 +355,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -345,6 +379,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: false,
@@ -368,6 +403,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -391,6 +427,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -414,6 +451,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: true,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: false,
@@ -437,6 +475,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: true,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: false,
@@ -461,6 +500,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: true,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: false,
@@ -485,6 +525,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -509,6 +550,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -533,6 +575,7 @@ describe("Test deposit reducer", () => {
           showCommunitySelectionButton: true,
           disableCommunitySelectionButton: false,
           showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
         },
         actions: {
           shouldUpdateReview: true,
@@ -558,6 +601,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: true,
         disableCommunitySelectionButton: true,
         showCommunityHeader: true,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: false,
@@ -585,6 +629,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: true,
         disableCommunitySelectionButton: false,
         showCommunityHeader: true,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: true,
@@ -609,6 +654,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: true,
         disableCommunitySelectionButton: false,
         showCommunityHeader: true,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: false,
@@ -633,6 +679,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: false,
         disableCommunitySelectionButton: false,
         showCommunityHeader: false,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: false,
@@ -657,6 +704,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: false,
         disableCommunitySelectionButton: false,
         showCommunityHeader: true,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: false,
@@ -680,6 +728,7 @@ describe("Test deposit reducer", () => {
         showCommunitySelectionButton: false,
         disableCommunitySelectionButton: false,
         showCommunityHeader: false,
+        requireDeletionForDeclinedDraft: false,
       },
       actions: {
         shouldUpdateReview: false,
@@ -691,5 +740,57 @@ describe("Test deposit reducer", () => {
     expect(computeDepositState(publishedRecordInDeletedCommunity, undefined)).toEqual(
       expectedDepositState
     );
+  });
+
+  describe("Test deposit state when handling new record version drafts", () => {
+    it("user creates a new version draft with a created/pending review", () => {
+      const expectedDepositState = {
+        selectedCommunity: fakeSelectedCommunities[0],
+        ui: {
+          showSubmitForReviewButton: true,
+          showDirectPublishButton: false,
+          disableSubmitForReviewButton: false,
+          showChangeCommunityButton: false,
+          showCommunitySelectionButton: false,
+          disableCommunitySelectionButton: false,
+          showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: false,
+        },
+        actions: {
+          shouldUpdateReview: false,
+          shouldDeleteReview: false,
+          communityStateMustBeChecked: false,
+        },
+      };
+
+      expect(computeDepositState(newVersionRecordWithReview, undefined)).toEqual(
+        expectedDepositState
+      );
+    });
+
+    it("user views a new version draft with a declined review", () => {
+      const expectedDepositState = {
+        selectedCommunity: fakeSelectedCommunities[0],
+        ui: {
+          showSubmitForReviewButton: true,
+          showDirectPublishButton: false,
+          disableSubmitForReviewButton: true,
+          showChangeCommunityButton: false,
+          showCommunitySelectionButton: false,
+          disableCommunitySelectionButton: false,
+          showCommunityHeader: true,
+          requireDeletionForDeclinedDraft: true,
+        },
+        actions: {
+          shouldUpdateReview: false,
+          shouldDeleteReview: false,
+          communityStateMustBeChecked: false,
+        },
+      };
+
+      expect(
+        computeDepositState(newVersionRecordWithDeclinedReview, undefined)
+      ).toEqual(expectedDepositState);
+    });
   });
 });

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
@@ -51,7 +51,7 @@ export function configureStore(appConfig) {
   const initialDepositState = {
     record,
     errors: errors || {},
-    editorState: computeDepositState(record, permissions, _preselectedCommunity),
+    editorState: computeDepositState(record, _preselectedCommunity),
     config,
     permissions,
     actionState: errors ? DRAFT_LOADED_WITH_VALIDATION_ERRORS : null,

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/store.js
@@ -51,7 +51,7 @@ export function configureStore(appConfig) {
   const initialDepositState = {
     record,
     errors: errors || {},
-    editorState: computeDepositState(record, _preselectedCommunity),
+    editorState: computeDepositState(record, permissions, _preselectedCommunity),
     config,
     permissions,
     actionState: errors ? DRAFT_LOADED_WITH_VALIDATION_ERRORS : null,

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -27,7 +27,7 @@ from invenio_records_resources.services.records.queryparser.transformer import (
 import invenio_rdm_records.services.communities.moderation as communities_moderation
 from invenio_rdm_records.services.components.pids import validate_optional_doi
 from invenio_rdm_records.services.components.verified import UserModerationHandler
-from invenio_rdm_records.services.review.policy import RecordVersionReviewPolicy
+from invenio_rdm_records.services.review.policy import NewRecordVersionReviewPolicy
 
 from . import tokens
 from .requests.community_inclusion import CommunityInclusion
@@ -159,7 +159,7 @@ RDM_RECORDS_REVIEWS = [
 RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = CommunitySubmission
 """Request type for community submission requests."""
 
-RDM_RECORD_VERSION_REVIEW_POLICY = RecordVersionReviewPolicy
+RDM_NEW_RECORD_VERSION_REVIEW_POLICY = NewRecordVersionReviewPolicy
 """Policy for when to require a community review for new record versions."""
 
 #

--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -27,6 +27,7 @@ from invenio_records_resources.services.records.queryparser.transformer import (
 import invenio_rdm_records.services.communities.moderation as communities_moderation
 from invenio_rdm_records.services.components.pids import validate_optional_doi
 from invenio_rdm_records.services.components.verified import UserModerationHandler
+from invenio_rdm_records.services.review.policy import RecordVersionReviewPolicy
 
 from . import tokens
 from .requests.community_inclusion import CommunityInclusion
@@ -154,8 +155,12 @@ RDM_RECORDS_REVIEWS = [
     CommunitySubmission.type_id,
 ]
 """List of review request types."""
+
 RDM_COMMUNITY_SUBMISSION_REQUEST_CLS = CommunitySubmission
 """Request type for community submission requests."""
+
+RDM_RECORD_VERSION_REVIEW_POLICY = RecordVersionReviewPolicy
+"""Policy for when to require a community review for new record versions."""
 
 #
 # Record files configuration

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -93,6 +93,12 @@ class RDMParent(ParentRecordBase):
         Request,
         keys=["type", "receiver", "status"],
     )
+    """
+    Deprecated: We have now moved to storing the review on the draft record, in order to support reviews per-record-version.
+    This field is retained for backward-compatibility.
+
+    The field will remain for existing records but will not be set for new ones.
+    """
 
     communities = CommunitiesField(models.RDMParentCommunity)
 
@@ -284,6 +290,22 @@ class CommonFieldsMixin:
 
     #: Custom fields system field.
     custom_fields = DictField(clear_none=True, create_if_missing=True)
+
+    review = RelatedRecord(
+        Request,
+        keys=["type", "receiver", "status"],
+    )
+
+    def get_review(self):
+        """
+        We used to store the review relation on the parent record, and we still do for existing/old records.
+
+        New records store it on the draft directly.
+        This method returns the review on the draft, or on the parent if it doesn't exist.
+
+        If the review does not exist on the record or the parent, None is returned.
+        """
+        return self.review if self.review is not None else self.parent.review
 
 
 #

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -45,6 +45,7 @@ from invenio_vocabularies.records.systemfields.relations import CustomFieldsRela
 from invenio_rdm_records.records.systemfields.deletion_status import (
     RecordDeletionStatusEnum,
 )
+from invenio_rdm_records.services.errors import ReviewStateError
 
 from . import models
 from .dumpers import (
@@ -94,10 +95,8 @@ class RDMParent(ParentRecordBase):
         keys=["type", "receiver", "status"],
     )
     """
-    Deprecated: We have now moved to storing the review on the draft record, in order to support reviews per-record-version.
-    This field is retained for backward-compatibility.
-
-    The field will remain for existing records but will not be set for new ones.
+    This is only used for the review of the first version of a record being submitted to its default community.
+    If subsequent versions of the record undergo a review, that is stored directly on `record.review`.
     """
 
     communities = CommunitiesField(models.RDMParentCommunity)
@@ -295,17 +294,29 @@ class CommonFieldsMixin:
         Request,
         keys=["type", "receiver", "status"],
     )
+    """
+    If this record/draft is the new version of an already-published record, the corresponding community submission
+    request for the default community is stored in this field.
+    """
 
     def get_review(self):
         """
-        We used to store the review relation on the parent record, and we still do for existing/old records.
+        Returns the review on the parent, or on the draft/record if it doesn't exist.
 
-        New records store it on the draft directly.
-        This method returns the review on the draft, or on the parent if it doesn't exist.
+        We store the review on the parent record for new unpublished records, and on the record for new versions of
+        already published records.
 
-        If the review does not exist on the record or the parent, None is returned.
+        If the review does not exist on the parent or the record, None is returned.
         """
-        return self.review if self.review is not None else self.parent.review
+        parent_review = self.parent.review
+        own_review = self.review
+
+        if parent_review is not None and own_review is not None:
+            raise ReviewStateError(
+                "A record shouldn't have a review on both its parent and itself."
+            )
+
+        return parent_review if parent_review is not None else own_review
 
 
 #

--- a/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
+++ b/invenio_rdm_records/records/jsonschemas/records/record-v6.0.0.json
@@ -466,6 +466,9 @@
       "items": {
         "type": "string"
       }
+    },
+    "review": {
+      "$ref": "local://requests/request-v1.0.0.json"
     }
   }
 }

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -1621,6 +1621,49 @@
             }
           }
         }
+      },
+      "review": {
+        "type": "object",
+        "properties": {
+          "$schema": {
+            "type": "keyword",
+            "index": false
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "payload": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "topic": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "receiver": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "created_by": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "@v": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -1643,6 +1643,49 @@
             }
           }
         }
+      },
+      "review": {
+        "type": "object",
+        "properties": {
+          "$schema": {
+            "type": "keyword",
+            "index": false
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "payload": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "topic": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "receiver": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "created_by": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "@v": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
@@ -1581,6 +1581,49 @@
             "type": "boolean"
           }
         }
+      },
+      "review": {
+        "type": "object",
+        "properties": {
+          "$schema": {
+            "type": "keyword",
+            "index": false
+          },
+          "id": {
+            "type": "keyword"
+          },
+          "type": {
+            "type": "keyword"
+          },
+          "title": {
+            "type": "text"
+          },
+          "description": {
+            "type": "text"
+          },
+          "status": {
+            "type": "keyword"
+          },
+          "payload": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "topic": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "receiver": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "created_by": {
+            "type": "object",
+            "dynamic": "true"
+          },
+          "@v": {
+            "type": "keyword"
+          }
+        }
       }
     }
   }

--- a/invenio_rdm_records/records/models.py
+++ b/invenio_rdm_records/records/models.py
@@ -9,7 +9,6 @@
 """Record and draft database models."""
 
 import uuid
-from datetime import datetime, timezone
 
 from invenio_accounts.models import User
 from invenio_communities.records.records.models import CommunityRelationMixin

--- a/invenio_rdm_records/records/systemfields/draft_status.py
+++ b/invenio_rdm_records/records/systemfields/draft_status.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2026 CERN.
 # Copyright (C) 2020 Northwestern University.
 # Copyright (C) 2023 Graz University of Technology.
 #
@@ -41,6 +41,12 @@ class DraftStatus(SystemField):
     """Available statuses that a draft can have. It maps review status to
     draft."""
 
+    new_version_review_to_draft_statuses = {
+        **review_to_draft_statuses,
+        "created": "new_version_draft_with_review",
+    }
+    """Same as `review_to_draft_statuses` but for new version drafts."""
+
     def __init__(self, draft_cls=None, key=None):
         """Initialize the DraftStatus.
 
@@ -60,30 +66,39 @@ class DraftStatus(SystemField):
         if record is None:
             return self  # returns the field itself.
 
-        review = getattr(record.parent, "review")
-        is_published = getattr(record, "is_published")
+        is_first_version = record.versions.index == 1
+        # `record.parent.review` is used for the first draft of a new parent.
+        # `record.review` is used for reviews of all subsequent record versions.
+        review = (
+            getattr(record.parent, "review")
+            if is_first_version
+            else getattr(record, "review")
+        )
 
+        # If this specific record is published (i.e. NOT whether at least one published record exists within the parent)
+        is_published = getattr(record, "is_published")
         if is_published:
             return "published"
 
-        is_new_version_draft = not is_published and record.versions.index > 1
-        if is_new_version_draft:
-            return "new_version_draft"
+        # The record is a draft...
 
-        is_draft = not is_published and record.versions.index == 1
-        if is_draft:
-            if review is None:
-                return "draft"
+        if review is None:
+            # If the record is the first draft (i.e. the parent record is not published),
+            # record.versions.index will be 1.
+            return "draft" if record.versions.index == 1 else "new_version_draft"
 
-            try:
-                return self.review_to_draft_statuses[review.status]
-            except KeyError:
-                raise ReviewStateError(
-                    _(
-                        "Unknown draft status for review: {reviewstatus}.".format(
-                            reviewstatus=review.status
-                        )
+        try:
+            # The status depends on whether the record is the first version or not
+            return (
+                self.review_to_draft_statuses[review.status]
+                if is_first_version
+                else self.new_version_review_to_draft_statuses[review.status]
+            )
+        except KeyError:
+            raise ReviewStateError(
+                _(
+                    "Unknown draft status for review: {reviewstatus}.".format(
+                        reviewstatus=review.status
                     )
                 )
-
-        raise RDMRecordsException(_("Unknown draft status."))
+            )

--- a/invenio_rdm_records/requests/community_submission.py
+++ b/invenio_rdm_records/requests/community_submission.py
@@ -11,6 +11,7 @@
 from invenio_drafts_resources.services.records.uow import ParentRecordCommitOp
 from invenio_i18n import lazy_gettext as _
 from invenio_notifications.services.uow import NotificationOp
+from invenio_records_resources.services.uow import RecordCommitOp
 from invenio_requests.customizations import actions
 
 from ..notifications.builders import (
@@ -59,7 +60,14 @@ class AcceptAction(actions.AcceptAction):
         # The curator (receiver) should still have access, via the community
         # The creator (uploader) should also still have access, because
         # they're the uploader
-        draft.parent.review = None
+        parent_needs_commit = False
+        if draft.review is not None:
+            draft.review = None
+            uow.register(RecordCommitOp(draft, indexer=service.draft_indexer))
+
+        if draft.parent.review is not None:
+            draft.parent.review = None
+            parent_needs_commit = True
 
         # TODO:
         # - Put below into a service method
@@ -67,16 +75,23 @@ class AcceptAction(actions.AcceptAction):
 
         # Add community to record.
         is_default = self.request.type.set_as_default
-        draft.parent.communities.add(
-            community, request=self.request, default=is_default
-        )
+        # Only add to the parent record's community list if the draft is the first version.
+        # If this request is for a new version of an existing published record, the parent record
+        # will already belong to the community, so we don't want to add it again.
+        if draft.versions.index == 1:
+            draft.parent.communities.add(
+                community, request=self.request, default=is_default
+            )
+            if getattr(community, "parent", None):
+                draft.parent.communities.add(community.parent, request=self.request)
+            parent_needs_commit = True
 
-        if getattr(community, "parent", None):
-            draft.parent.communities.add(community.parent, request=self.request)
-
-        uow.register(
-            ParentRecordCommitOp(draft.parent, indexer_context=dict(service=service))
-        )
+        if parent_needs_commit:
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent, indexer_context=dict(service=service)
+                )
+            )
 
         # Publish the record
         # TODO: Ensure that the accepting user has permissions to publish.
@@ -109,10 +124,17 @@ class DeclineAction(actions.DeclineAction):
         # TODO: this shouldn't be required BUT because of the caching mechanism
         # in the review systemfield, the review should be set with the updated
         # request object
-        draft.parent.review = self.request
-        uow.register(
-            ParentRecordCommitOp(draft.parent, indexer_context=dict(service=service))
-        )
+        if draft.parent.review is not None:
+            draft.parent.review = self.request
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent, indexer_context=dict(service=service)
+                )
+            )
+        elif draft.review is not None:
+            draft.review = self.request
+            uow.register(RecordCommitOp(draft, indexer=service.draft_indexer))
+
         uow.register(
             NotificationOp(
                 CommunityInclusionDeclineNotificationBuilder.build(
@@ -130,11 +152,19 @@ class CancelAction(actions.CancelAction):
         # Remove draft from request
         # Same reasoning as in 'decline'
         draft = self.request.topic.resolve()
-        draft.parent.review = None
-        uow.register(
-            ParentRecordCommitOp(draft.parent, indexer_context=dict(service=service))
-        )
         super().execute(identity, uow)
+
+        if draft.parent.review is not None:
+            draft.parent.review = None
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent, indexer_context=dict(service=service)
+                )
+            )
+        elif draft.review is not None:
+            draft.review = None
+            uow.register(RecordCommitOp(draft, indexer=service.draft_indexer))
+
         uow.register(
             NotificationOp(
                 CommunityInclusionCancelNotificationBuilder.build(
@@ -159,10 +189,17 @@ class ExpireAction(actions.ExpireAction):
         # TODO: this shouldn't be required BUT because of the caching mechanism
         # in the review systemfield, the review should be set with the updated
         # request object
-        draft.parent.review = self.request
-        uow.register(
-            ParentRecordCommitOp(draft.parent, indexer_context=dict(service=service))
-        )
+        if draft.parent.review is not None:
+            draft.parent.review = self.request
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent, indexer_context=dict(service=service)
+                )
+            )
+        elif draft.review is not None:
+            draft.review = self.request
+            uow.register(RecordCommitOp(draft, indexer=service.draft_indexer))
+
         uow.register(
             NotificationOp(
                 CommunityInclusionExpireNotificationBuilder.build(

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -353,6 +353,20 @@ class TombstoneSchema(Schema):
         return RDMRecordDeletionPolicy.get_policy_description(policy_id)
 
 
+def set_community_ui_permissions(community):
+    """Set the `ui.permissions` field of a community."""
+    can_include_directly = _community_permission_check(
+        "include_directly",
+        community=community,
+        identity=g.identity,
+    )
+    # use `ui` key to indicate that the extra information is injected only on
+    # UIJSONSerializer
+    community.setdefault("ui", {})["permissions"] = {
+        "can_include_directly": can_include_directly
+    }
+
+
 class UIRecordSchema(BaseObjectSchema):
     """Schema for dumping extra information for the UI."""
 
@@ -449,20 +463,14 @@ class UIRecordSchema(BaseObjectSchema):
 
     @pre_dump
     def add_communities_permissions_and_roles(self, obj, **kwargs):
-        """Inject current user's permission to community receiver."""
-        receiver = (
-            obj.get("expanded", {}).get("parent", {}).get("review", {}).get("receiver")
-        )
-        if receiver:
-            can_include_directly = _community_permission_check(
-                "include_directly", community=receiver, identity=g.identity
-            )
+        """Inject current user's permission to community receiver and the parent default community."""
+        receiver = obj.get("expanded", {}).get("parent", {}).get("review", {}).get(
+            "receiver"
+        ) or obj.get("expanded", {}).get("review", {}).get("receiver")
 
-            # use `ui` key to indicate that the extra information is injected only on
-            # UIJSONSerializer
-            receiver.setdefault("ui", {})["permissions"] = {
-                "can_include_directly": can_include_directly
-            }
+        if receiver:
+            set_community_ui_permissions(receiver)
+
         return obj
 
     @post_dump

--- a/invenio_rdm_records/services/access/service.py
+++ b/invenio_rdm_records/services/access/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020-2024 CERN.
+# Copyright (C) 2020-2026 CERN.
 # Copyright (C) 2020-2021 Northwestern University.
 # Copyright (C) 2021 TU Wien.
 # Copyright (C) 2023-2025 Graz University of Technology.
@@ -118,11 +118,11 @@ class RecordAccessService(RecordService):
     # Update parent request on access changes
     #
 
-    def _update_parent_request(self, parent, uow):
-        """Update the parent record request."""
-        if parent.review:
-            request = parent.review.get_object()
-            uow.register(RecordCommitOp(request, indexer=self.indexer))
+    def _update_record_request(self, record, uow):
+        """Update the review request on the record or its parent."""
+        request = record.get_review()
+        if request is not None:
+            uow.register(RecordCommitOp(request.get_object(), indexer=self.indexer))
 
     #
     # Secret links
@@ -229,7 +229,7 @@ class RecordAccessService(RecordService):
             )
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordSecretLinkAuditLog
@@ -347,7 +347,7 @@ class RecordAccessService(RecordService):
         link.description = data.get("description", link.description)
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordSecretLinkAuditLog
@@ -393,7 +393,7 @@ class RecordAccessService(RecordService):
         link.revoke()
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordSecretLinkAuditLog
@@ -503,7 +503,7 @@ class RecordAccessService(RecordService):
             new_grants.append(new_grant)
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordGrantAuditLog
@@ -614,7 +614,7 @@ class RecordAccessService(RecordService):
         parent.access.grants[grant_id] = new_grant
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordGrantAuditLog
@@ -689,7 +689,7 @@ class RecordAccessService(RecordService):
         deleted_grant = parent.access.grants.pop(grant_id)
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordGrantAuditLog
@@ -1086,7 +1086,7 @@ class RecordAccessService(RecordService):
         parent.access.grants[grant_index] = new_grant
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordGrantAuditLog
@@ -1133,7 +1133,7 @@ class RecordAccessService(RecordService):
             raise LookupError(subject_id)
 
         uow.register(ParentRecordCommitOp(parent, indexer_context=dict(service=self)))
-        self._update_parent_request(parent, uow)
+        self._update_record_request(record, uow)
 
         audit_log_builder = (
             RDMRecordGrantAuditLog

--- a/invenio_rdm_records/services/components/review.py
+++ b/invenio_rdm_records/services/components/review.py
@@ -77,14 +77,13 @@ class ReviewComponent(ServiceComponent):
             self.service.config.new_version_review_policy
         )
         if policy.requires_review(identity, draft):
-            request = current_requests_service.create(
+            self.service.review.create(
                 identity,
-                request_type=CommunitySubmission,
-                topic=draft,
-                creator=identity.user,
-                receiver=default_community,
-                data={},
+                {
+                    "type": CommunitySubmission.type_id,
+                    "receiver": {"community": default_community.id},
+                },
+                draft,
                 uow=self.uow,
                 allow_new_record_version_review=True,
             )
-            draft.review = request._request

--- a/invenio_rdm_records/services/components/review.py
+++ b/invenio_rdm_records/services/components/review.py
@@ -12,6 +12,10 @@ from invenio_drafts_resources.services.records.components import ServiceComponen
 from invenio_i18n import lazy_gettext as _
 from invenio_requests import current_requests_service
 
+from invenio_rdm_records.services.review.policy import NewRecordVersionReviewPolicy
+
+from ...proxies import current_rdm_records_service
+from ...requests.community_submission import CommunitySubmission
 from ..errors import ReviewExistsError, ReviewStateError
 
 
@@ -20,13 +24,13 @@ class ReviewComponent(ServiceComponent):
 
     def create(self, identity, data=None, record=None, **kwargs):
         """Create the review if requested."""
-        data = data.get("parent", {}).get("review")
-        if data is not None:
-            self.service.review.create(identity, data, record, uow=self.uow)
+        parent_review = data.get("parent", {}).get("review")
+        if parent_review is not None:
+            self.service.review.create(identity, parent_review, record, uow=self.uow)
 
     def delete_draft(self, identity, draft=None, record=None, force=False):
         """Delete a draft."""
-        review = draft.parent.review
+        review = draft.get_review()
         if review is None:
             return
         # TODO: once draft status has been changed to not be considered open
@@ -39,16 +43,14 @@ class ReviewComponent(ServiceComponent):
                 )
             )
 
-        # Delete draft request's. A request in any other state is left as-is,
+        # Delete draft's request. A request in any other state is left as-is,
         # to allow users to see the request even if it was removed.
         if review.status == "created":
-            current_requests_service.delete(
-                identity, draft.parent.review.id, uow=self.uow
-            )
+            current_requests_service.delete(identity, review.id, uow=self.uow)
 
     def publish(self, identity, draft=None, record=None, **kwargs):
         """Block publishing if required.."""
-        review = draft.parent.review
+        review = draft.get_review()
         if review is None:
             return
         if getattr(review.type, "block_publish", True) and not review.is_closed:
@@ -57,3 +59,32 @@ class ReviewComponent(ServiceComponent):
                     "You cannot publish a draft with an open review request. Please cancel the review request first."
                 )
             )
+
+    def new_version(self, identity, draft=None, record=None):
+        """
+        Create a review for a new record version if required for the identity.
+
+        If the identity does not have the `skip_review_for_new_version` permission, each new version of existing published records
+        they create must go through a review by the parent record's default community.
+        """
+        assert draft is not None and record is not None
+        # If the parent record does not have a default community, we do not need to create a review.
+        default_community = record.parent.communities.default
+        if default_community is None:
+            return
+
+        policy: NewRecordVersionReviewPolicy = (
+            self.service.config.new_version_review_policy
+        )
+        if policy.requires_review(identity, draft):
+            request = current_requests_service.create(
+                identity,
+                request_type=CommunitySubmission,
+                topic=draft,
+                creator=identity.user,
+                receiver=default_community,
+                data={},
+                uow=self.uow,
+                allow_new_record_version_review=True,
+            )
+            draft.review = request._request

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -69,6 +69,7 @@ from requests import Request
 from werkzeug.local import LocalProxy
 
 from invenio_rdm_records.records.processors.tiles import TilesProcessor
+from invenio_rdm_records.services.review.policy import NewRecordVersionReviewPolicy
 
 from ..records import RDMDraft, RDMRecord
 from ..records.api import RDMDraftMediaFiles, RDMRecordMediaFiles
@@ -108,8 +109,8 @@ from .sort import VerifiedRecordsSortParam
 
 
 def is_draft_and_has_review(record, ctx):
-    """Determine if draft has doi."""
-    return is_draft(record, ctx) and record.parent.review is not None
+    """Determine if draft has a review."""
+    return is_draft(record, ctx) and record.get_review()
 
 
 def is_record_and_has_doi(record, ctx):
@@ -613,6 +614,9 @@ class RDMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
     )
     quota_increase_policy = FromConfig(
         "RDM_QUOTA_INCREASE_POLICY", default=QuotaIncreasePolicyEvaluator
+    )
+    new_version_review_policy = FromConfig(
+        "RDM_NEW_RECORD_VERSION_REVIEW_POLICY", default=NewRecordVersionReviewPolicy
     )
 
     # Result classes

--- a/invenio_rdm_records/services/generators.py
+++ b/invenio_rdm_records/services/generators.py
@@ -275,13 +275,13 @@ class SubmissionReviewer(Generator):
 
     def needs(self, record=None, **kwargs):
         """Set of Needs granting permission."""
-        if record is None or record.parent.review is None:
+        request = record.get_review()
+        if record is None or request is None:
             return []
 
         # we only expect submission review requests here
         # and as such, we expect the receiver to be a community
         # and the topic to be a record
-        request = record.parent.review
         receiver = request.receiver
         if receiver is not None:
             return receiver.get_needs(ctx=request.type.needs_context)
@@ -301,11 +301,11 @@ class RequestReviewers(Generator):
         if not self._reviewers_enabled():
             return []
 
-        if record is None or record.parent.review is None:
+        request = record.get_review()
+        if record is None or request is None:
             return []
 
         _needs = []
-        request = record.parent.review
         reviewers = request.reviewers
         if reviewers is not None:
             for reviewer in reviewers:

--- a/invenio_rdm_records/services/pids/service.py
+++ b/invenio_rdm_records/services/pids/service.py
@@ -37,6 +37,7 @@ class PIDsService(RecordService):
         Expand community field to return community details.
         """
         return [
+            EntityResolverExpandableField("review.receiver"),
             EntityResolverExpandableField("parent.review.receiver"),
             ParentCommunitiesExpandableField("parent.communities.default"),
             EntityResolverExpandableField("parent.access.owned_by"),

--- a/invenio_rdm_records/services/review/__init__.py
+++ b/invenio_rdm_records/services/review/__init__.py
@@ -7,6 +7,10 @@
 
 """Review service."""
 
+from .policy import NewRecordVersionReviewPolicy
 from .service import ReviewService
 
-__all__ = ("ReviewService",)
+__all__ = (
+    "ReviewService",
+    "NewRecordVersionReviewPolicy",
+)

--- a/invenio_rdm_records/services/review/policy.py
+++ b/invenio_rdm_records/services/review/policy.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Invenio RDM Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Policy configuration to define which versions of records require community review."""
+
+
+class RecordVersionReviewPolicy:
+    """
+    Base class for defining a policy for whether new versions of records require community review.
+
+    A new record submitted to a community for the first time (via a community submission request) will always
+    require a review regardless of this policy (subject to the community's settings).
+    """
+
+    @classmethod
+    def requires_review(cls, identity, draft) -> bool:
+        """
+        Returns whether the draft needs to be submitted for a review.
+
+        If the first draft of a new parent record is submitted to a community, it will always trigger a review
+        (subject to the community's settings).
+        The return value of this method only applies to new version drafts created for existing records.
+
+        The default behaviour is to return False, meaning new versions of existing records will never require
+        a community review.
+        """
+        return False

--- a/invenio_rdm_records/services/review/policy.py
+++ b/invenio_rdm_records/services/review/policy.py
@@ -8,7 +8,7 @@
 """Policy configuration to define which versions of records require community review."""
 
 
-class RecordVersionReviewPolicy:
+class NewRecordVersionReviewPolicy:
     """
     Base class for defining a policy for whether new versions of records require community review.
 

--- a/invenio_rdm_records/services/review/service.py
+++ b/invenio_rdm_records/services/review/service.py
@@ -14,7 +14,11 @@ from invenio_drafts_resources.services.records import RecordService
 from invenio_drafts_resources.services.records.uow import ParentRecordCommitOp
 from invenio_i18n import lazy_gettext as _
 from invenio_notifications.services.uow import NotificationOp
-from invenio_records_resources.services.uow import RecordIndexOp, unit_of_work
+from invenio_records_resources.services.uow import (
+    RecordCommitOp,
+    RecordIndexOp,
+    unit_of_work,
+)
 from invenio_requests import current_request_type_registry, current_requests_service
 from invenio_requests.resolvers.registry import ResolverRegistry
 from marshmallow import ValidationError
@@ -59,14 +63,31 @@ class ReviewService(RecordService):
         return type_
 
     @unit_of_work()
-    def create(self, identity, data, record, uow=None):
-        """Create a new review request in draft state (to be completed."""
-        if record.parent.review is not None:
+    def create(
+        self, identity, data, record, uow=None, allow_new_record_version_review=False
+    ):
+        """
+        Create a new review request in draft state (to be completed).
+
+        By default, a review can only be created for a first-version unpublished draft of a new
+        parent record. Attempting to create a review for a new version draft will raise a `ReviewStateError`.
+
+        If `allow_new_record_version_review` is `True`, however, new versions can also have reviews created.
+        For first versions, the review is always stored in `record.parent.review`, and for new versions it is
+        stored in `record.review`.
+        """
+        if record.review is not None or record.parent.review is not None:
             raise ReviewExistsError(_("A review already exists for this record"))
         # Validate that record has not been published.
-        if record.is_published or record.versions.index > 1:
+        if record.is_published:
             raise ReviewStateError(
                 _("You cannot create a review for an already published record.")
+            )
+        # Additionally, either `allow_new_record_version_review` must be true, or the record must be
+        # the first version.
+        if record.versions.index > 1 and not allow_new_record_version_review:
+            raise ReviewStateError(
+                _("You cannot create a review for a new version of a published record.")
             )
 
         # Validate the review type (only review requests are valid)
@@ -87,9 +108,17 @@ class ReviewService(RecordService):
             uow=uow,
         )
 
-        # Set the request on the record and commit the record
-        record.parent.review = request_item._request
-        uow.register(ParentRecordCommitOp(record.parent))
+        # Set the request on the record/parent and commit
+        if record.versions.index == 1:
+            # If this is the first version (i.e. the parent record is not yet published),
+            # we set the review on the parent.
+            record.parent.review = request_item._request
+            uow.register(ParentRecordCommitOp(record.parent))
+            uow.register(RecordIndexOp(record, indexer=self.indexer))
+        else:
+            # If this is a new version draft, we set the review on the record/draft itself.
+            record.review = request_item._request
+            uow.register(RecordCommitOp(record, indexer=self.indexer))
 
         return request_item
 
@@ -99,26 +128,46 @@ class ReviewService(RecordService):
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
         self.require_permission(identity, "read_draft", record=draft)
 
-        if draft.parent.review is None:
+        review = draft.get_review()
+        if review is None:
             raise ReviewNotFoundError()
 
-        request_type = draft.parent.review.get_object()["type"]
+        request_type = review.get_object()["type"]
         self._validate_request_type(request_type)
 
-        return current_requests_service.read(identity, draft.parent.review.id)
+        return current_requests_service.read(identity, review.id)
 
     @unit_of_work()
-    def update(self, identity, id_, data, revision_id=None, uow=None):
-        """Create or update an existing review."""
+    def update(
+        self,
+        identity,
+        id_,
+        data,
+        revision_id=None,
+        uow=None,
+        allow_new_record_version_review=False,
+    ):
+        """
+        Create or update an existing review.
+
+        For details on the behaviour of `assign_request_to_record`, see the `create` method.
+        """
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
         self.require_permission(identity, "manage", record=draft)
 
         # If an existing review exists, delete it.
-        if draft.parent.review is not None:
+        review = draft.get_review()
+        if review is not None:
             self.delete(identity, id_, uow=uow)
             draft = self.draft_cls.pid.resolve(id_, registered_only=False)
 
-        return self.create(identity, data, draft, uow=uow)
+        return self.create(
+            identity,
+            data,
+            draft,
+            uow=uow,
+            allow_new_record_version_review=allow_new_record_version_review,
+        )
 
     @unit_of_work()
     def delete(self, identity, id_, revision_id=None, uow=None):
@@ -127,9 +176,10 @@ class ReviewService(RecordService):
         self.require_permission(identity, "manage", record=draft)
 
         # Preconditions
-        if draft.parent.review is None:
+        review = draft.get_review()
+        if review is None:
             raise ReviewNotFoundError()
-        request_type = draft.parent.review.get_object()["type"]
+        request_type = review.get_object()["type"]
         self._validate_request_type(request_type)
 
         if draft.is_published:
@@ -140,18 +190,28 @@ class ReviewService(RecordService):
                 )
             )
 
-        if draft.parent.review.is_open:
+        if review.is_open:
             raise ReviewStateError(_("An open review cannot be deleted."))
 
         # Keep the request when not open or not closed so that the user can see
         # the request's events. The request is deleted only when in `draft`
         # status
-        if not (draft.parent.review.is_closed or draft.parent.review.is_open):
-            current_requests_service.delete(identity, draft.parent.review.id, uow=uow)
+        if not (review.is_closed or review.is_open):
+            current_requests_service.delete(identity, review.id, uow=uow)
+
         # Unset on record
-        draft.parent.review = None
-        uow.register(ParentRecordCommitOp(draft.parent))
-        uow.register(RecordIndexOp(draft, indexer=self.indexer))
+        if draft.review is not None:
+            draft.review = None
+        elif draft.parent.review is not None:
+            draft.parent.review = None
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent,
+                    indexer_context=dict(service=current_rdm_records.records_service),
+                )
+            )
+        uow.register(RecordCommitOp(draft, indexer=self.indexer))
+
         return True
 
     @request_next_link()
@@ -165,22 +225,21 @@ class ReviewService(RecordService):
             )
 
         draft = self.draft_cls.pid.resolve(id_, registered_only=False)
+        review = draft.get_review()
         # Preconditions
-        if draft.parent.review is None:
+        if review is None:
             raise ReviewNotFoundError()
 
-        request_type = draft.parent.review.get_object()["type"]
+        request_type = review.get_object()["type"]
         self._validate_request_type(request_type)
 
         # since it is submit review action, assume the receiver is community
-        community = draft.parent.review.receiver.resolve()
+        community = review.receiver.resolve()
 
         # Check permission
         self.require_permission(identity, "manage", record=draft)
 
-        community_id = (
-            draft.parent.review.get_object().get("receiver", {}).get("community", "")
-        )
+        community_id = review.get_object().get("receiver", {}).get("community", "")
         can_submit_record = current_communities.service.config.permission_policy_cls(
             "submit_record",
             community_id=community_id,
@@ -195,16 +254,25 @@ class ReviewService(RecordService):
 
         # create review request
         request_item = current_rdm_records.community_inclusion_service.submit(
-            identity, draft, community, draft.parent.review, data, uow
+            identity, draft, community, review, data, uow
         )
         request = request_item._request
 
         # This shouldn't be required BUT because of the caching mechanism
         # in the review systemfield, the review should be set with the updated
         # request object
-        draft.parent.review = request
-        uow.register(ParentRecordCommitOp(draft.parent))
-        uow.register(RecordIndexOp(draft, indexer=self.indexer))
+        if draft.review is not None:
+            draft.review = request
+            uow.register(RecordCommitOp(draft, indexer=self.indexer))
+        elif draft.parent.review is not None:
+            draft.parent.review = request
+            uow.register(
+                ParentRecordCommitOp(
+                    draft.parent,
+                    indexer_context=dict(service=current_rdm_records.records_service),
+                )
+            )
+            uow.register(RecordIndexOp(draft, indexer=self.indexer))
 
         if not require_review:
             request_item = current_rdm_records.community_inclusion_service.include(

--- a/invenio_rdm_records/services/schemas/parent/__init__.py
+++ b/invenio_rdm_records/services/schemas/parent/__init__.py
@@ -13,11 +13,12 @@ from flask import current_app
 from invenio_drafts_resources.services.records.schema import ParentSchema
 from invenio_i18n import lazy_gettext as _
 from invenio_requests.services.schemas import GenericRequestSchema
-from marshmallow import ValidationError, fields, post_dump, pre_load
+from marshmallow import ValidationError, fields, pre_load
 from marshmallow_utils.fields import NestedAttribute, SanitizedUnicode
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
 from ..pids import PIDSchema
+from ..review import CleanReviewMixin
 from .access import ParentAccessSchema
 from .communities import CommunitiesSchema
 
@@ -30,7 +31,7 @@ def validate_scheme(scheme):
         )
 
 
-class RDMParentSchema(ParentSchema, FieldPermissionsMixin):
+class RDMParentSchema(ParentSchema, FieldPermissionsMixin, CleanReviewMixin):
     """Record schema."""
 
     field_dump_permissions = {
@@ -62,23 +63,6 @@ class RDMParentSchema(ParentSchema, FieldPermissionsMixin):
         for name, field in self.fields.items():
             if field.dump_only:
                 data.pop(name, None)
-        return data
-
-    @pre_load
-    def clean_review(self, data, **kwargs):
-        """Clear review if None."""
-        # draft.parent.review returns None when not set, causing the serializer
-        # to dump {'review': None}. As a workaround we pop it if it's none
-        # here.
-        if data.get("review", None) is None:
-            data.pop("review", None)
-        return data
-
-    @post_dump()
-    def pop_review_if_none(self, data, many, **kwargs):
-        """Clear review if None."""
-        if data.get("review", None) is None:
-            data.pop("review", None)
         return data
 
 

--- a/invenio_rdm_records/services/schemas/record.py
+++ b/invenio_rdm_records/services/schemas/record.py
@@ -10,20 +10,18 @@
 
 """RDM record schemas."""
 
-from datetime import datetime, timezone
 from functools import partial
 
 from flask import current_app
 from invenio_drafts_resources.services.records.schema import RecordSchema
 from invenio_i18n import lazy_gettext as _
-from invenio_pidstore.providers.recordid_v2 import RecordIdProviderV2
 from invenio_records_resources.services.custom_fields import CustomFieldsSchema
-from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_dump, pre_load
+from invenio_requests.services.schemas import GenericRequestSchema
+from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_dump
 from marshmallow_utils.fields import (
     EDTFDateTimeString,
     NestedAttribute,
     SanitizedUnicode,
-    TZDateTime,
 )
 from marshmallow_utils.permissions import FieldPermissionsMixin
 
@@ -34,6 +32,7 @@ from .metadata import MetadataSchema
 from .parent import RDMParentSchema
 from .parent.access import Agent
 from .pids import PIDSchema
+from .review import CleanReviewMixin
 from .stats import StatsSchema
 from .tombstone import DeletionStatusSchema, TombstoneSchema
 from .versions import VersionsSchema
@@ -59,7 +58,7 @@ class InternalNoteSchema(Schema):
         unknown = EXCLUDE
 
 
-class RDMRecordSchema(RecordSchema, FieldPermissionsMixin):
+class RDMRecordSchema(RecordSchema, FieldPermissionsMixin, CleanReviewMixin):
     """Record schema."""
 
     class Meta:
@@ -93,6 +92,7 @@ class RDMRecordSchema(RecordSchema, FieldPermissionsMixin):
     deletion_status = fields.Nested(DeletionStatusSchema, dump_only=True)
     internal_notes = fields.List(fields.Nested(InternalNoteSchema))
     stats = NestedAttribute(StatsSchema, dump_only=True)
+    review = fields.Nested(GenericRequestSchema, allow_none=False)
     # schema_version = fields.Integer(dump_only=True)
 
     field_dump_permissions = {

--- a/invenio_rdm_records/services/schemas/review.py
+++ b/invenio_rdm_records/services/schemas/review.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Mixin for cleaning the `review` field on parent/draft records."""
+
+from marshmallow import post_dump, pre_load
+
+
+class CleanReviewMixin:
+    """Clean the `review` field from dumped/loaded schemas if it is None."""
+
+    @pre_load
+    def clean_review(self, data, **kwargs):
+        """Clear review if None."""
+        # draft.review/draft.parent.review returns None when not set, causing the serializer
+        # to dump {'review': None}. As a workaround we pop it if it's none
+        # here.
+        if data.get("review", None) is None:
+            data.pop("review", None)
+        return data
+
+    @post_dump()
+    def pop_review_if_none(self, data, many, **kwargs):
+        """Clear review if None."""
+        if data.get("review", None) is None:
+            data.pop("review", None)
+        return data

--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -98,6 +98,7 @@ class RDMRecordService(RecordService):
         Expand community field to return community details.
         """
         return [
+            EntityResolverExpandableField("review.receiver"),
             EntityResolverExpandableField("parent.review.receiver"),
             ParentCommunitiesExpandableField("parent.communities.default"),
             EntityResolverExpandableField("parent.access.owned_by"),

--- a/invenio_rdm_records/services/vcs/release.py
+++ b/invenio_rdm_records/services/vcs/release.py
@@ -319,7 +319,7 @@ class RDMVCSRelease(VCSRelease):
 
         try:
             with UnitOfWork(db.session) as uow:
-                if draft._record.parent.review is None:
+                if draft._record.get_review() is None:
                     record = current_rdm_records_service.publish(
                         identity, draft.id, uow=uow
                     )

--- a/tests/resources/test_resources_review.py
+++ b/tests/resources/test_resources_review.py
@@ -184,7 +184,10 @@ def test_review_errors(
 
     # Invalid request type
     minimal_record["parent"] = {
-        "review": {"type": "invalid", "receiver": {"community": community.data["id"]}}
+        "review": {
+            "type": "invalid",
+            "receiver": {"community": community.data["id"]},
+        }
     }
     draft = client.post("/records", headers=headers, json=minimal_record)
     assert draft.status_code == 400

--- a/tests/services/test_service_review.py
+++ b/tests/services/test_service_review.py
@@ -36,6 +36,7 @@ from invenio_rdm_records.services.errors import (
     ReviewNotFoundError,
     ReviewStateError,
 )
+from invenio_rdm_records.services.review.policy import NewRecordVersionReviewPolicy
 
 
 def get_community_owner_identity(community):
@@ -59,13 +60,31 @@ def service():
 
 
 @pytest.fixture()
+def service_with_restrictive_review_policy(running_app):
+    """Get the current RDM records service with the review policy set to a restrictive one."""
+
+    class RestrictiveReviewPolicy(NewRecordVersionReviewPolicy):
+        """A more restrictive record version review policy."""
+
+        @classmethod
+        def requires_review(cls, identity, draft):
+            """Requires review for all new versions of records."""
+            return True
+
+    running_app.app.config["RDM_NEW_RECORD_VERSION_REVIEW_POLICY"] = (
+        RestrictiveReviewPolicy
+    )
+    return current_rdm_records.records_service
+
+
+@pytest.fixture()
 def requests_service():
     """Get the current RDM requests service."""
     return current_requests_service
 
 
 @pytest.fixture()
-def draft(minimal_record, community, service, running_app, db):
+def draft(minimal_record, community, service, running_app, db, uploader):
     minimal_record["parent"] = {
         "review": {
             "type": CommunitySubmission.type_id,
@@ -74,7 +93,7 @@ def draft(minimal_record, community, service, running_app, db):
     }
 
     # Create draft with review
-    return service.create(running_app.superuser_identity, minimal_record)
+    return service.create(uploader.identity, minimal_record)
 
 
 @pytest.fixture()
@@ -324,27 +343,27 @@ def test_direct_include_to_closed_review_community(
     assert req["is_open"] is True
 
 
-def test_creation(draft, running_app, community, service, requests_service):
+def test_creation(draft, running_app, community, service, requests_service, uploader):
     """Test basic creation with review."""
     # See the draft fixture for the actual creation
     record_id = draft.id
-    parent = draft.to_dict()["parent"]
 
-    assert "id" in parent["review"]
-    assert parent["review"]["type"] == CommunitySubmission.type_id
-    assert parent["review"]["receiver"] == {"community": community.data["id"]}
-    assert "@v" not in parent["review"]  # internals should not be exposed
+    review_dict = draft.to_dict()["parent"]["review"]
+    assert "id" in review_dict
+    assert review_dict["type"] == CommunitySubmission.type_id
+    assert review_dict["receiver"] == {"community": community.data["id"]}
+    assert "@v" not in review_dict  # internals should not be exposed
 
     # Read review request (via request service)
     review = requests_service.read(
-        running_app.superuser_identity, parent["review"]["id"]
+        running_app.superuser_identity, review_dict["id"]
     ).to_dict()
 
-    assert review["id"] == parent["review"]["id"]
+    assert review["id"] == review_dict["id"]
     assert review["status"] == "created"
     assert review["type"] == CommunitySubmission.type_id
     assert review["receiver"] == {"community": community.data["id"]}
-    assert review["created_by"] == {"user": str(running_app.superuser_identity.id)}
+    assert review["created_by"] == {"user": str(uploader.identity.id)}
     assert review["topic"] == {"record": record_id}
 
     # Read review request (via record review subservice)
@@ -352,7 +371,7 @@ def test_creation(draft, running_app, community, service, requests_service):
         running_app.superuser_identity,
         record_id,
     ).to_dict()
-    assert review["id"] == parent["review"]["id"]
+    assert review["id"] == review_dict["id"]
 
     # TODO: Test that curator cannot see it yet
 
@@ -459,8 +478,13 @@ def test_create_when_already_published(minimal_record, running_app, community, s
         )
 
 
-def test_create_with_new_version(minimal_record, running_app, community, service):
-    """Review creation should fail for unpublished new version."""
+def test_create_with_new_version_no_review(
+    minimal_record, running_app, community, service
+):
+    """
+    Review creation should succeed for unpublished new version, where the first published version
+    did not have a community.
+    """
     # Create draft
     draft = service.create(running_app.superuser_identity, minimal_record)
     # Publish and create new version of the record.
@@ -471,13 +495,63 @@ def test_create_with_new_version(minimal_record, running_app, community, service
         "type": CommunitySubmission.type_id,
         "receiver": {"community": community.data["id"]},
     }
-    with pytest.raises(ReviewStateError):
-        service.review.update(
-            running_app.superuser_identity,
-            draft.id,
-            data,
-            revision_id=draft.data["revision_id"],
-        )
+    req = service.review.update(
+        running_app.superuser_identity,
+        draft.id,
+        data,
+        revision_id=draft.data["revision_id"],
+        allow_new_record_version_review=True,
+    )
+
+    assert req["status"] == "created"
+    assert req["topic"] == {"record": draft.id}
+    assert req["receiver"] == {"community": community.data["id"]}
+
+
+def test_create_with_new_version_with_review(
+    draft,
+    running_app,
+    requests_service,
+    service_with_restrictive_review_policy,
+    uploader,
+):
+    """
+    Review creation should succeed for unpublished new version, where the first published version
+    was successfully accepted into a community.
+    """
+    # Submit and accept review, thereby including record in community
+    service_with_restrictive_review_policy.review.submit(uploader.identity, draft.id)
+    requests_service.execute_action(
+        running_app.superuser_identity, draft["parent"]["review"]["id"], "accept", {}
+    )
+
+    # Create a new version.
+    new_version_draft = service_with_restrictive_review_policy.new_version(
+        uploader.identity, draft.id
+    )
+
+    # The component should have auto-created a review since the community requires it for new versions
+    assert new_version_draft._record.review is not None
+    assert new_version_draft._record.review.status == "created"
+
+    # Submit the review and accept it to ensure no exceptions are raised.
+    service_with_restrictive_review_policy.review.submit(
+        uploader.identity, new_version_draft.id
+    )
+    requests_service.execute_action(
+        running_app.superuser_identity,
+        new_version_draft["review"]["id"],
+        "accept",
+        {},
+    )
+
+    # Make sure the record is published and has no review on it anymore
+    published_record = service_with_restrictive_review_policy.read(
+        uploader.identity,
+        new_version_draft.id,
+    )
+    assert published_record._record.review is None
+    assert published_record._record.versions.index == 2
 
 
 def test_update(draft, running_app, community2, service, db):
@@ -563,7 +637,7 @@ def test_delete_draft_unsubmitted(draft, running_app, service, requests_service)
     """Draft request should be deleted when the draft is deleted."""
     # Delete the draft
     req_id = draft.data["parent"]["review"]["id"]
-    res = service.delete_draft(running_app.superuser_identity, draft.id)
+    service.delete_draft(running_app.superuser_identity, draft.id)
 
     # Request was also deleted
     with pytest.raises(NoResultFound):


### PR DESCRIPTION
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/2312
Closes https://github.com/inveniosoftware/invenio-rdm-records/issues/2323

Also includes commit from https://github.com/inveniosoftware/invenio-rdm-records/pull/2324 (unmerged right now).

---

- Updated the data models to include a `review` field on the record. The existing `review` field on the parent record is retained, and a new method `get_own_or_parent_review` on the record is used (nearly) everywhere the review was referenced. This method prefers to return the record's review, but returns the parent's review if it doesn't exist. This way we retain compatibility with existing records.
- Updated all methods that reference the review to ensure compatibility with the parent/record review.
- Added the `new_version` method to the review service component, so that a draft community submission request is always added to a new version draft when the policy requires it. This review can be submitted via the frontend.
- Updated the frontend deposit form components so that a "submit review" button is shown for a new-version draft instead of a "publish" button where the policy requires a review.
  - If the draft is a new version and the draft has a review on it, we assume that the "submit review" button should be shown. If no review is present, the "publish" button continues to be shown.
- Added unit tests

---

**I have _not_ tested the migration** from having the `review` on the parent to on the record. I have also not tested support for existing parent's with `review`s with the new code.