### PR TITLE
fix(vcs): extract license ID when returning

### DIFF
--- a/invenio_rdm_records/services/vcs/release.py
+++ b/invenio_rdm_records/services/vcs/release.py
@@ -151,7 +151,7 @@ class RDMVCSRelease(VCSRelease):
             license_vocab = current_vocabularies_service.read(
                 identity=self.user_identity, id_=("licenses", license_spdx_id.lower())
             )
-            return {"id": license_vocab.pid.id}
+            return {"id": license_vocab.id}
         except (PIDDoesNotExistError, NoResultFound):
             self.add_warning(
                 f"The repository's license '{license_spdx_id}' is not recognised and has been added as a custom license. "


### PR DESCRIPTION
* The user might not have permission to read the license vocabulary directly, resulting in a PermissionDeniedError when extracting the repository metadata.

* Since the list of licenses is non-sensitive (and is queried already on the deposit page), it is safe to use the system identity for this query.