### PR TITLE
Zerbe/fix vocabulary id keyword

### DIFF
--- a/invenio-vocabularies-id-mapping-issue.md
+++ b/invenio-vocabularies-id-mapping-issue.md
@@ -1,0 +1,88 @@
+# Bug: Vocabulary `id` field is mapped as `text` in OpenSearch, causing term queries to fail for non-lowercase IDs
+
+## Summary
+
+The OpenSearch mapping for the vocabulary index maps the `id` field as `type: text` (with a `keyword` sub-field). The `get_vocabulary_props` function in `invenio-rdm-records` searches for vocabulary terms using `dsl.Q("term", id=id_)` — a term query on the text field. For IDs that contain uppercase letters or are split by the text analyzer (e.g., `EHVM-H119`), the term query returns zero hits and raises `VocabularyItemNotFoundError`, even though the record exists in both the database and the OpenSearch index.
+
+## Affected versions
+
+- `invenio-rdm-records` (query side — uses `dsl.Q("term", id=...)` on a text field)
+- `invenio-vocabularies` (mapping side — defines `id` as `text`)
+
+## Steps to reproduce
+
+1. Load a vocabulary type that contains terms with non-lowercase IDs (e.g., CCMM resource types, which use identifiers like `EHVM-H119`).
+2. Create a dataset record that references one of these terms as its `resource_type`.
+3. Navigate to the dataset record's detail page in the UI.
+
+**Result:**
+```
+invenio_rdm_records.resources.serializers.errors.VocabularyItemNotFoundError:
+  The 'resourcetypes' vocabulary item 'EHVM-H119' was not found.
+```
+
+## Root cause
+
+### Mapping side (`invenio-vocabularies`)
+
+The vocabulary index mapping defines the `id` field as:
+```json
+{"type": "text", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}}
+```
+
+When the standard OpenSearch text analyzer processes `EHVM-H119`, it produces lowercase tokens (e.g., `ehvm` and `h119` after hyphen splitting). The original string `EHVM-H119` is not preserved as an exact token in the text field's inverted index.
+
+### Query side (`invenio-rdm-records`)
+
+`get_vocabulary_props` in `invenio_rdm_records/resources/serializers/utils.py`:
+
+```python
+results = vocabulary_service.read_all(
+    system_identity,
+    ["id"] + fields,
+    vocabulary,
+    extra_filter=dsl.Q("term", id=id_),  # <-- term query on text field
+)
+```
+
+A `term` query on a text field matches analyzed tokens exactly. Because `EHVM-H119` is not stored as an exact token, the query returns zero hits, and the function raises `VocabularyItemNotFoundError`.
+
+Standard InvenioRDM resource type IDs (e.g., `dataset`, `publication`, `software`) are lowercase and single-word, so they survive text analysis. This bug is invisible until a vocabulary type with uppercase or hyphenated IDs is loaded.
+
+## Impact
+
+Any vocabulary term whose ID contains uppercase letters or other characters that the text analyzer transforms will be unreachable by `get_vocabulary_props`. This causes the DataCite serializer (called during signposting on every record detail page) to crash with a 500 error for any record using such a term.
+
+Triggered by the CCMM resource type vocabulary, which uses COAR IDs such as `EHVM-H119`, `c_18cc`, `C_dcae04ef`, etc.
+
+## Proposed fix
+
+**Option A — Fix the mapping** (`invenio-vocabularies`): Change the `id` field to `type: keyword` so term queries work as exact matches regardless of case or character content.
+
+**Option B — Fix the query** (`invenio-rdm-records`): Change `dsl.Q("term", id=id_)` to `dsl.Q("term", **{"id.keyword": id_})` in `get_vocabulary_props`.
+
+Option B is a one-line change and does not require an index migration.
+
+## Workaround (applied in this repository)
+
+Recreate the vocabulary index with `id` as a `keyword` field:
+
+```python
+from invenio_search import current_search_client
+
+mapping = current_search_client.indices.get_mapping(index='frozen_testing-vocabularies-vocabulary-v1.0.0')
+m = list(mapping.values())[0]['mappings']
+m['properties']['id'] = {'type': 'keyword', 'ignore_above': 256}
+
+current_search_client.indices.delete(index='frozen_testing-vocabularies-vocabulary-v1.0.0')
+current_search_client.indices.create(
+    index='frozen_testing-vocabularies-vocabulary-v1.0.0',
+    body={'mappings': m}
+)
+current_search_client.indices.update_aliases({'actions': [
+    {'add': {'index': 'frozen_testing-vocabularies-vocabulary-v1.0.0',
+             'alias': 'frozen_testing-vocabularies'}}
+]})
+```
+
+Then reindex all vocabulary records from the database.

--- a/invenio_rdm_records/resources/serializers/utils.py
+++ b/invenio_rdm_records/resources/serializers/utils.py
@@ -27,7 +27,7 @@ def get_vocabulary_props(vocabulary, fields, id_):
         system_identity,
         ["id"] + fields,
         vocabulary,
-        extra_filter=dsl.Q("term", id=id_),
+        extra_filter=dsl.Q("term", **{"id.keyword": id_}),
     )
 
     for h in results.hits:

--- a/tests/resources/serializers/test_utils.py
+++ b/tests/resources/serializers/test_utils.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2024 CERN.
+#
+# Invenio-RDM-Records is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License; see LICENSE file for more details.
+
+"""Tests for serializer utility functions."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from invenio_rdm_records.resources.serializers.errors import VocabularyItemNotFoundError
+from invenio_rdm_records.resources.serializers.utils import get_vocabulary_props
+
+
+def _make_hit(**props):
+    h = MagicMock()
+    h.get = lambda k, default=None: props.get(k, default)
+    return h
+
+
+def _make_results(*hits):
+    r = MagicMock()
+    r.hits = list(hits)
+    return r
+
+
+def _make_mock_svc(results):
+    """Return a MagicMock service stub without accessing Flask-proxied original."""
+    mock_svc = MagicMock()
+    mock_svc.read_all.return_value = results
+    return mock_svc
+
+
+class TestGetVocabularyProps:
+    """Tests for get_vocabulary_props helper."""
+
+    def test_query_uses_id_keyword_subfield(self):
+        """Term query must target id.keyword, not the text-analyzed id field.
+
+        Vocabulary IDs such as EHVM-H119 are tokenised by the text analyser
+        (lowercased, hyphen-split) and would not match a term query on `id`.
+        The `.keyword` sub-field stores the original string verbatim.
+        """
+        hit = _make_hit(props={"datacite": "Dataset"})
+        results = _make_results(hit)
+        mock_svc = _make_mock_svc(results)
+
+        with patch(
+            "invenio_rdm_records.resources.serializers.utils.vocabulary_service",
+            new=mock_svc,
+        ):
+            get_vocabulary_props("resourcetypes", ["datacite"], "EHVM-H119")
+
+        extra_filter = mock_svc.read_all.call_args.kwargs.get("extra_filter")
+        assert extra_filter is not None, "extra_filter was not passed to read_all"
+        q_dict = extra_filter.to_dict()
+        assert "term" in q_dict, f"Expected term query, got: {q_dict}"
+        term_body = q_dict["term"]
+        assert "id.keyword" in term_body, (
+            f"Term query targets {list(term_body.keys())!r} instead of 'id.keyword'."
+            " Uppercase/hyphenated vocabulary IDs (e.g. EHVM-H119) will fail."
+        )
+        assert "id" not in term_body, (
+            "Term query must NOT target the text-analyzed 'id' field"
+        )
+
+    def test_returns_props_on_hit(self):
+        hit = _make_hit(props={"datacite": "Dataset"})
+        results = _make_results(hit)
+        mock_svc = _make_mock_svc(results)
+
+        with patch(
+            "invenio_rdm_records.resources.serializers.utils.vocabulary_service",
+            new=mock_svc,
+        ):
+            props = get_vocabulary_props("resourcetypes", ["datacite"], "dataset")
+
+        assert props == {"datacite": "Dataset"}
+
+    def test_raises_when_not_found(self):
+        results = _make_results()
+        mock_svc = _make_mock_svc(results)
+
+        with patch(
+            "invenio_rdm_records.resources.serializers.utils.vocabulary_service",
+            new=mock_svc,
+        ):
+            with pytest.raises(VocabularyItemNotFoundError):
+                get_vocabulary_props("resourcetypes", ["datacite"], "EHVM-H119")
+
+    def test_returns_empty_props_when_props_key_missing(self):
+        hit = _make_hit()
+        results = _make_results(hit)
+        mock_svc = _make_mock_svc(results)
+
+        with patch(
+            "invenio_rdm_records.resources.serializers.utils.vocabulary_service",
+            new=mock_svc,
+        ):
+            props = get_vocabulary_props("resourcetypes", ["datacite"], "dataset")
+
+        assert props == {}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The OpenSearch mapping for the vocabulary index maps the `id` field as `type: text` (with a `keyword` sub-field). The `get_vocabulary_props` function in `invenio-rdm-records` searches for vocabulary terms using `dsl.Q("term", id=id_)` — a term query on the text field. For IDs that contain uppercase letters or are split by the text analyzer (e.g., `EHVM-H119`), the term query returns zero hits and raises `VocabularyItemNotFoundError`, even though the record exists in both the database and the OpenSearch index.

### Resolution implemented

Fix the query** (`invenio-rdm-records`): Change `dsl.Q("term", id=id_)` to `dsl.Q("term", **{"id.keyword": id_})` in `get_vocabulary_props`.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
