### PR TITLE
feat(notifications): add NOTIFICATIONS_SHOW_EMOJIS config option

### DIFF
--- a/invenio_rdm_records/config.py
+++ b/invenio_rdm_records/config.py
@@ -958,3 +958,6 @@ RDM_RECORDS_CONTAINER_EXTENSIONS = [".zip"]
 Experimental, this config can later be removed."""
 
 RDM_RECORD_FILE_EXTRACTORS = [ZipExtractor()]
+
+NOTIFICATIONS_SHOW_EMOJIS = True
+"""Whether to show emojis in notification email subject lines."""

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.accept.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.accept.jinja
@@ -21,10 +21,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
-
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-       {{ _("✅ Community inclusion accepted for '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "✅ " if show_emojis else "" -%}
+       {{ emoji }}{{ _("Community inclusion accepted for '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.cancel.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.cancel.jinja
@@ -21,9 +21,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-       {{ _("❌ Community inclusion cancelled for '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "❌ " if show_emojis else "" -%}
+       {{ emoji }}{{ _("Community inclusion cancelled for '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.decline.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.decline.jinja
@@ -21,9 +21,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-       {{ _("⛔️ Community inclusion declined for '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "⛔️ " if show_emojis else "" -%}
+       {{ emoji }}{{ _("Community inclusion declined for '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.expire.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.expire.jinja
@@ -19,9 +19,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-       {{ _("⌛️ Community inclusion expired for '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "⌛️ " if show_emojis else "" -%}
+       {{ emoji }}{{ _("Community inclusion expired for '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.submit.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/community-submission.submit.jinja
@@ -20,9 +20,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-       {{ _("📥 New record submission to your community '{community_title}'").format(community_title=community_title) }}
+{%- set emoji = "📥 " if show_emojis else "" -%}
+       {{ emoji }}{{ _("New record submission to your community '{community_title}'").format(community_title=community_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/grant-user-access.create.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/grant-user-access.create.jinja
@@ -17,15 +17,17 @@
     {% set shared_link = record.links.self_html %}
 {%- endif -%}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
+{%- set emoji = "👤✔️ " if show_emojis else "" -%}
     {%- if record.is_published -%}
-        {{ _("👤✔️ You were granted {permission} access to all versions of the record '{record_title}'").format(permission=permission, record_title=record_title) }}
+        {{ emoji }}{{ _("You were granted {permission} access to all versions of the record '{record_title}'").format(permission=permission, record_title=record_title) }}
     {%- else -%}
         {%- if record_title -%}
-            {{ _("👤✔️ You were granted {permission} access to draft '{record_title}'").format(permission=permission, record_title=record_title) }}
+            {{ emoji }}{{ _("You were granted {permission} access to draft '{record_title}'").format(permission=permission, record_title=record_title) }}
         {%- else -%}
-            {{ _("👤✔️ You were granted {permission} access to a draft").format(permission=permission) }}
+            {{ emoji }}{{ _("You were granted {permission} access to a draft").format(permission=permission) }}
         {%- endif -%}
     {%- endif -%}
 {%- endblock subject -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request-token.create.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request-token.create.jinja
@@ -10,9 +10,11 @@
 
 {% set record_title = record.metadata.title %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("❗️ Access request for '{record_title}' requires action").format(record_title=record_title) }}
+{%- set emoji = "❗️ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request for '{record_title}' requires action").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.accept.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.accept.jinja
@@ -10,9 +10,11 @@
 
 {% set record_title = record.metadata.title %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("✅ Access request for '{record_title}' was accepted.").format(record_title=record_title) }}
+{%- set emoji = "✅ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request for '{record_title}' was accepted.").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.cancel.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.cancel.jinja
@@ -12,9 +12,11 @@
 
 {% set request_link = submission_request.links.self_html %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("❌ Access request canceled") }}
+{%- set emoji = "❌ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request canceled") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.decline.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.decline.jinja
@@ -13,9 +13,11 @@
 
 {% set request_link = submission_request.links.self_html %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("⛔️ Access request declined") }}
+{%- set emoji = "⛔️ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request declined") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submit.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submit.jinja
@@ -12,9 +12,11 @@
 {% set request_id = access_request.id %}
 {% set request_link = access_request.links.self_html %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("📥 New access request for your record '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "📥 " if show_emojis else "" -%}
+    {{ emoji }}{{ _("New access request for your record '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submitted.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/guest-access-request.submitted.jinja
@@ -8,9 +8,11 @@
 {% set request_id = access_request.id %}
 {% set request_link = access_request.links.self_html %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("📥 Your access request was submitted successfully") }}
+{%- set emoji = "📥 " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Your access request was submitted successfully") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/record-deletion.accept.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/record-deletion.accept.jinja
@@ -9,9 +9,11 @@
 {% set request_links = notification.context.request.links %}
 
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("✅ Your record has been deleted") }}
+{%- set emoji = "✅ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Your record has been deleted") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.accept.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.accept.jinja
@@ -11,9 +11,11 @@
 {% set record_title = record.metadata.title %}
 {% set record_link = record.links.self_html %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("✅ Access request accepted") }}
+{%- set emoji = "✅ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request accepted") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.cancel.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.cancel.jinja
@@ -21,9 +21,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("❌ Access request canceled") }}
+{%- set emoji = "❌ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request canceled") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.decline.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.decline.jinja
@@ -16,9 +16,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("⛔️ Access request declined") }}
+{%- set emoji = "⛔️ " if show_emojis else "" -%}
+    {{ emoji }}{{ _("Access request declined") }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.submit.jinja
+++ b/invenio_rdm_records/templates/semantic-ui/invenio_notifications/user-access-request.submit.jinja
@@ -16,9 +16,11 @@
     )
 %}
 {% set account_settings_link = invenio_url_for("invenio_notifications_settings.index") %}
+{% set show_emojis = config.get('NOTIFICATIONS_SHOW_EMOJIS', True) %}
 
 {%- block subject -%}
-    {{ _("📥 New access request for your record '{record_title}'").format(record_title=record_title) }}
+{%- set emoji = "📥 " if show_emojis else "" -%}
+    {{ emoji }}{{ _("New access request for your record '{record_title}'").format(record_title=record_title) }}
 {%- endblock subject -%}
 
 {%- block html_body -%}

--- a/tests/resources/test_access_requests.py
+++ b/tests/resources/test_access_requests.py
@@ -8,6 +8,7 @@ import io
 import re
 import urllib
 
+import pytest
 from flask_principal import UserNeed
 from flask_security import login_user
 from invenio_access.permissions import (
@@ -25,8 +26,34 @@ from invenio_rdm_records.proxies import current_rdm_records_service as service
 from invenio_rdm_records.requests.access import AccessRequestTokenNeed
 
 
-def test_simple_guest_access_request_flow(running_app, client, users, minimal_record):
+@pytest.mark.parametrize(
+    ("show_emojis", "owner_subject", "guest_subject"),
+    [
+        (
+            None,
+            "📥 New access request for your record 'A Romans story'",
+            "📥 Your access request was submitted successfully",
+        ),
+        (
+            False,
+            "New access request for your record 'A Romans story'",
+            "Your access request was submitted successfully",
+        ),
+    ],
+)
+def test_simple_guest_access_request_flow(
+    running_app,
+    client,
+    users,
+    minimal_record,
+    show_emojis,
+    owner_subject,
+    guest_subject,
+):
     """Test a the simple guest-based access request flow."""
+    if show_emojis is not None:
+        running_app.app.config["NOTIFICATIONS_SHOW_EMOJIS"] = show_emojis
+
     with running_app.app.extensions["mail"].record_messages() as outbox:
         # Log in a user (whose ID we need later)
         record_owner, _ = users
@@ -97,16 +124,10 @@ def test_simple_guest_access_request_flow(running_app, client, users, minimal_re
         assert f"/access/requests/{request.id}" in request.links["self_html"]
         assert len(outbox) == 3
         owner_submit_message = outbox[1]
-        assert (
-            "New access request for your record 'A Romans story'"
-            in owner_submit_message.subject
-        )
+        assert owner_submit_message.subject == owner_subject
 
         guest_submit_message = outbox[2]
-        assert (
-            "Your access request was submitted successfully"
-            in guest_submit_message.subject
-        )
+        assert guest_submit_message.subject == guest_subject
         assert request["links"]["self_html"] in guest_submit_message.html
         # Following is a 1-off test of invenio_url_for in Jinja settings + dynamic
         # blueprint route registration (decorator style within a function). Good to keep


### PR DESCRIPTION
## Summary

Closes #2240.

Introduces `NOTIFICATIONS_SHOW_EMOJIS` (default: `True`) so operators can disable emoji prefixes in notification email subject lines by setting `NOTIFICATIONS_SHOW_EMOJIS = False` in `invenio.cfg`.

- New config variable in `config.py` (default `True`, fully backwards-compatible)
- All 17 notification templates updated: emoji extracted from `_()` translation string and rendered conditionally via `{%- set emoji = "…" if show_emojis else "" -%}`
- Emojis removed from translatable strings as a side effect (i18n improvement)

Templates without emojis in their subjects (`record-deletion.decline`, all `repository-release.*`) are untouched.

## Test plan

- [ ] Send a notification with default config → subject still contains emoji
- [ ] Set `NOTIFICATIONS_SHOW_EMOJIS = False` → all notification subjects are emoji-free
- [ ] Existing notification tests still pass