### PR TITLE
fix: restoring schema field in RDMdraft

### DIFF
--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2024 CERN.
 # Copyright (C) 2021-2023 TU Wien.
+# Copyright (C) 2026 CESNET i.a.l.e.
 #
 # Invenio-RDM-Records is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.

--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -422,6 +422,17 @@ class RDMDraft(CommonFieldsMixin, Draft):
 
     status = DraftStatus()
 
+    @classmethod
+    def edit(cls, record):
+        """Restore $schema for soft-deleted records when editing a record."""
+        # ConstantField.pre_init skips data=None (soft-deleted) records, so
+        # $schema is missing after undelete — restore it from the field. $schema
+        # field is RDM related and therefore it is not handled in edit method of
+        # the base Draft class https://github.com/inveniosoftware/invenio-drafts-resources/blob/0bd2cc6dd2a333c8a2db39eb6c3e17128ebeeefc/invenio_drafts_resources/records/api.py#L231
+        draft = super().edit(record)
+        draft.setdefault("$schema", cls.schema.value)
+        return draft
+
 
 RDMFileDraft.record_cls = RDMDraft
 

--- a/tests/services/test_rdm_service.py
+++ b/tests/services/test_rdm_service.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2021 Graz University of Technology.
 # Copyright (C) 2021 TU Wien.
 # Copyright (C) 2024 California Institute of Technology.
+# Copyright (C) 2026 CESNET i.a.l.e.
 #
 # Invenio-RDM-Records is free software; you can redistribute it
 # and/or modify it under the terms of the MIT License; see LICENSE file for
@@ -18,6 +19,7 @@ from invenio_pidstore.errors import PIDDoesNotExistError
 from invenio_pidstore.models import PIDStatus
 
 from invenio_rdm_records.proxies import current_rdm_records
+from invenio_rdm_records.records.api import RDMDraft, RDMRecord
 from invenio_rdm_records.services.errors import (
     EmbargoNotLiftedError,
     ValidationErrorWithMessageAsList,
@@ -467,3 +469,25 @@ def test_search_sort_verified_enabled(
 
     expected_order = [v_record.id, nv_record.id]
     assert expected_order == [h["id"] for h in hits]
+
+
+def test_edit_restores_schema_on_undeleted_draft(
+    running_app, search_clear, minimal_record
+):
+    """$schema must be restored when editing a published record.
+
+    Publishing soft-deletes the draft; editing the record undeletes it via
+    ``RDMDraft.edit(record)``. ``ConstantField.pre_init`` skips data=None
+    (soft-deleted) records, so ``$schema`` would otherwise be missing on the
+    undeleted draft.
+    """
+    superuser_identity = running_app.superuser_identity
+    service = current_rdm_records.records_service
+
+    draft = service.create(superuser_identity, minimal_record)
+    record = service.publish(superuser_identity, draft.id)
+
+    record_obj = RDMRecord.pid.resolve(record.id)
+    undeleted_draft = RDMDraft.edit(record_obj)
+
+    assert undeleted_draft["$schema"] == RDMDraft.schema.value


### PR DESCRIPTION
* after undeleting draft (when clicking on edit of published record)
* schema field is missing in the draft

:heart: Thank you for your contribution!

### Description

When you have a published record and then you want to edit it. The restored draft (undeleted), does not contain $schema field at this stage. In current RDM this is not visible, but only by chance. For us, we use this field to determine the type of record (metadata) it is and then apply appropriate serialization to the record based on this and it crashes at this point. 

As $schema is RDM related thing, my logic was to put this inside of RDMdraft. Alternative approach would be to use a service component with edit method that would inject this into the draft, similarly how it is done for access field, though I felt like this was more in line with https://github.com/inveniosoftware/invenio-drafts-resources/blob/0bd2cc6dd2a333c8a2db39eb6c3e17128ebeeefc/invenio_drafts_resources/records/api.py#L231-L240 what is already done at Draft level here. 

Please let us know if we can merge this. Thanks a lot.

Dusan S

CESNET


