### PR TITLE
fix: enable community owner to remove it from record

### DIFF
--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -254,8 +254,8 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     can_remove_community_from_record_ = [
         IfConfig(
             "RDM_ALLOW_OWNERS_REMOVE_COMMUNITY_FROM_RECORD",
-            then_=[RecordOwners(), CommunityCurators(), SystemProcess()],
-            else_=[CommunityCurators(), SystemProcess()],
+            then_=[RecordOwners(), RecordCommunitiesAction("curate"), SystemProcess()],
+            else_=[RecordCommunitiesAction("curate"), SystemProcess()],
         ),
     ]
     can_remove_community_from_record = [


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Via the UI, the button to remove a community from a record is disabled to community owners, with a message of "you don't have permission".

<img width="834" height="554" alt="image" src="https://github.com/user-attachments/assets/e54c200e-dd20-4930-a405-4c841b0d034a" />


CommunityCurators should be able to remove it, but community_id is missing from the call has_permissions_to makes to `check_permission`, and the check returns False. Instead, we use
RecordCommunitiesAction("curate"), as it's done for `can_manage`.

Closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3452



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
