### PR TITLE
results: use records index for drafts of published records

### DIFF
--- a/invenio_rdm_records/services/results.py
+++ b/invenio_rdm_records/services/results.py
@@ -90,7 +90,7 @@ class RDMRecordList(RecordList):
             record_dict = hit.to_dict()
 
             index_name = self._service.record_cls.index._name
-            if index_name in hit.meta["index"]:
+            if (index_name in hit.meta["index"]) or record_dict["is_published"]:
                 record = self._service.record_cls.loads(record_dict)
             else:
                 record = self._service.draft_cls.loads(record_dict)


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes Issue: https://github.com/zenodo/ops/issues/489

The active draft of a published record, uses the stats of the record instead of the draft

- **Published Record** in search results:
<img width="1194" height="296" alt="Screenshot 2026-05-19 at 15 20 44" src="https://github.com/user-attachments/assets/fc54e2df-bd8e-4b22-8823-31d2062a16c5" />



- **Record with an active draft in user dashboard**

_Created a draft of the record (with updated description, title and file access)_
<img width="1108" height="258" alt="Screenshot 2026-05-19 at 15 21 00" src="https://github.com/user-attachments/assets/35d59422-5d3f-4658-bc2a-d612eb4bce3d" />



**Before the change**
<img width="1110" height="249" alt="Screenshot 2026-05-19 at 15 21 12" src="https://github.com/user-attachments/assets/cd6ec469-2136-46d0-a07b-aa0e473d8464" />



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
