### PR TITLE
fix(communities): return 400 on malformed community id

### DIFF
--- a/invenio_rdm_records/services/schemas/record_communities.py
+++ b/invenio_rdm_records/services/schemas/record_communities.py
@@ -10,8 +10,43 @@
 
 from invenio_i18n import lazy_gettext as _
 from invenio_requests.customizations import CommentEventType
-from marshmallow import Schema, ValidationError, fields, validate, validates
+from marshmallow import Schema, ValidationError, fields, validate
 from marshmallow_utils.context import context_schema
+
+
+def validate_communities(value):
+    """Validate community count and uniqueness.
+
+    A field ``validate`` callable, not ``@validates``: it runs only after every
+    item deserialized, so a malformed entry fails first and ``community["id"]``
+    is always present here. Messages are wrapped in a list because the field's
+    ``validate`` list combines them through marshmallow's ``And``, which would
+    otherwise split a lazy_gettext string character by character.
+    """
+    max_number = context_schema.get()["max_number"]
+    if max_number < len(value):
+        raise ValidationError(
+            [
+                _(
+                    "Too many communities passed, {max_number} max allowed.".format(
+                        max_number=max_number
+                    )
+                )
+            ]
+        )
+
+    uniques = set()
+    duplicated = set()
+    for community in value:
+        com_id = community["id"]
+        if com_id in uniques:
+            duplicated.add(com_id)
+        uniques.add(com_id)
+
+    if duplicated:
+        raise ValidationError(
+            [_("Duplicated communities {com_ids}.".format(com_ids=duplicated))]
+        )
 
 
 class CommunitySchema(Schema):
@@ -26,32 +61,7 @@ class RecordCommunitiesSchema(Schema):
     """Record communities schema."""
 
     communities = fields.List(
-        fields.Nested(CommunitySchema), validate=validate.Length(min=1), required=True
+        fields.Nested(CommunitySchema),
+        validate=[validate.Length(min=1), validate_communities],
+        required=True,
     )
-
-    @validates("communities")
-    def validate_communities(self, value):
-        """Validate communities."""
-        max_number = context_schema.get()["max_number"]
-        if max_number < len(value):
-            raise ValidationError(
-                _(
-                    "Too many communities passed, {max_number} max allowed.".format(
-                        max_number=max_number
-                    )
-                )
-            )
-
-        # check unique ids
-        uniques = set()
-        duplicated = set()
-        for community in value:
-            com_id = community["id"]
-            if com_id in uniques:
-                duplicated.add(com_id)
-            uniques.add(com_id)
-
-        if duplicated:
-            raise ValidationError(
-                _("Duplicated communities {com_ids}.".format(com_ids=duplicated))
-            )

--- a/tests/resources/test_resources_record_communities.py
+++ b/tests/resources/test_resources_record_communities.py
@@ -80,6 +80,49 @@ def test_search_record_suggested_communities(
     assert hits["hits"][0]["id"] != open_review_community.id
 
 
+def test_add_communities_malformed_id(
+    client,
+    community,
+    open_review_community,
+    uploader,
+    record_community,
+    headers,
+):
+    """A malformed community id returns 400, not a 500."""
+    record = record_community.create_record()
+    client = uploader.login(client)
+
+    # A non-string id fails nested validation; it should surface as a 400, not
+    # crash the uniqueness check with a KeyError.
+    for bad_id in ({}, 42):
+        response = client.post(
+            f"/records/{record.pid.pid_value}/communities",
+            headers=headers,
+            json={
+                "communities": [
+                    {
+                        "id": bad_id,
+                        "comment": {"payload": {"content": "spam", "format": "html"}},
+                    }
+                ]
+            },
+        )
+        assert response.status_code == 400
+
+    # Duplicate valid ids are still rejected with 400.
+    response = client.post(
+        f"/records/{record.pid.pid_value}/communities",
+        headers=headers,
+        json={
+            "communities": [
+                {"id": open_review_community.id},
+                {"id": open_review_community.id},
+            ]
+        },
+    )
+    assert response.status_code == 400
+
+
 def test_set_default_community(
     client,
     headers,


### PR DESCRIPTION
* A non-string `id` (e.g. `{}`) failed nested field validation, but the
  uniqueness check ran via `@validates("communities")` on the partially
  loaded list and crashed with `KeyError: 'id'`, returning a 500.
  marshmallow runs `@validates` field validators unconditionally, even on
  items that failed deserialization. Moved the count and uniqueness checks
  to a field `validate=[...]` callable, which runs only after every item
  deserialized, so a malformed entry surfaces as the nested 400 instead.
