### PR TITLE
refactor(schema): Optimize RDM record schemas for reusability

### DIFF
--- a/invenio_rdm_records/contrib/meeting/custom_fields.py
+++ b/invenio_rdm_records/contrib/meeting/custom_fields.py
@@ -15,8 +15,6 @@ Implements the following fields:
 - meeting.url
 """
 
-from functools import partial
-
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.custom_fields import BaseCF
 from marshmallow import fields
@@ -45,9 +43,8 @@ class MeetingCF(BaseCF):
                 ),
                 "identifiers": IdentifierValueSet(
                     fields.Nested(
-                        partial(
-                            IdentifierSchema,
-                            allowed_schemes=record_related_identifiers_schemes,
+                        IdentifierSchema(
+                            allowed_schemes=record_related_identifiers_schemes
                         )
                     )
                 ),

--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -20,6 +20,10 @@ from invenio_collections.services.config import CollectionServiceConfig
 from invenio_collections.services.service import CollectionsService
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.resources.files import FileResource
+from invenio_records_resources.services.custom_fields.schema import (
+    CustomFieldsSchema,
+    CustomFieldsSchemaUI,
+)
 
 from . import config
 from .oaiserver.resources.config import OAIPMHServerResourceConfig
@@ -366,3 +370,10 @@ def init(app):
     iregistry = app.extensions["invenio-indexer"].registry
     iregistry.register(ext.records_service.indexer, indexer_id="records")
     iregistry.register(ext.records_service.draft_indexer, indexer_id="records-drafts")
+
+    # Register custom fields schemas
+    cfs_registry = app.extensions[
+        "invenio-records-resources"
+    ].custom_fields_schema_registry
+    cfs_registry.register(app, "RDM_CUSTOM_FIELDS", CustomFieldsSchema)
+    cfs_registry.register(app, "RDM_CUSTOM_FIELDS", CustomFieldsSchemaUI)

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -18,14 +18,19 @@ from invenio_communities.communities.resources.ui_schema import (
 )
 from invenio_i18n import get_locale
 from invenio_i18n import lazy_gettext as _
+from invenio_records_resources.proxies import current_custom_fields_schema_registry
 from invenio_records_resources.services.custom_fields import CustomFieldsSchemaUI
 from invenio_vocabularies.contrib.awards.serializer import AwardL10NItemSchema
 from invenio_vocabularies.contrib.funders.serializer import FunderL10NItemSchema
 from invenio_vocabularies.resources import L10NString, VocabularyL10Schema
 from marshmallow import Schema, fields, missing, post_dump, pre_dump
-from marshmallow_utils.fields import FormatDate as FormatDate_
-from marshmallow_utils.fields import FormatEDTF as FormatEDTF_
-from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode, StrippedHTML
+from marshmallow_utils.fields import (
+    FormatDate,
+    FormatEDTF,
+    SanitizedHTML,
+    SanitizedUnicode,
+    StrippedHTML,
+)
 from marshmallow_utils.fields.babel import gettext_from_dict
 from pyparsing import ParseException
 
@@ -40,11 +45,6 @@ def current_default_locale():
         return current_app.config.get("BABEL_DEFAULT_LOCALE", "en")
     # Use english by default if not specified
     return "en"
-
-
-# Partial to make short definitions in below schema.
-FormatEDTF = partial(FormatEDTF_, locale=get_locale)
-FormatDate = partial(FormatDate_, locale=get_locale)
 
 
 def make_affiliation_index(attr, obj, *args):
@@ -333,9 +333,13 @@ class TombstoneSchema(Schema):
     # This information is masked into a string in UIRecordSchema
     removed_by = fields.Raw(attribute="removed_by")
 
-    removal_date_l10n_medium = FormatEDTF(attribute="removal_date", format="medium")
+    removal_date_l10n_medium = FormatEDTF(
+        attribute="removal_date", format="medium", locale=get_locale
+    )
 
-    removal_date_l10n_long = FormatEDTF(attribute="removal_date", format="long")
+    removal_date_l10n_long = FormatEDTF(
+        attribute="removal_date", format="long", locale=get_locale
+    )
 
     citation_text = fields.String(attribute="citation_text")
 
@@ -369,16 +373,20 @@ class UIRecordSchema(BaseObjectSchema):
     object_key = "ui"
 
     publication_date_l10n_medium = FormatEDTF(
-        attribute="metadata.publication_date", format="medium"
+        attribute="metadata.publication_date", format="medium", locale=get_locale
     )
 
     publication_date_l10n_long = FormatEDTF(
-        attribute="metadata.publication_date", format="long"
+        attribute="metadata.publication_date", format="long", locale=get_locale
     )
 
-    created_date_l10n_long = FormatDate(attribute="created", format="long")
+    created_date_l10n_long = FormatDate(
+        attribute="created", format="long", locale=get_locale
+    )
 
-    updated_date_l10n_long = FormatDate(attribute="updated", format="long")
+    updated_date_l10n_long = FormatDate(
+        attribute="updated", format="long", locale=get_locale
+    )
 
     resource_type = fields.Nested(
         VocabularyL10Schema, attribute="metadata.resource_type"
@@ -390,7 +398,9 @@ class UIRecordSchema(BaseObjectSchema):
 
     # Custom fields
     custom_fields = fields.Nested(
-        partial(CustomFieldsSchemaUI, fields_var="RDM_CUSTOM_FIELDS")
+        lambda: current_custom_fields_schema_registry.get(
+            "RDM_CUSTOM_FIELDS", CustomFieldsSchemaUI.field_property_name
+        )
     )
 
     publishing_information = fields.Function(compute_publishing_information)
@@ -399,9 +409,13 @@ class UIRecordSchema(BaseObjectSchema):
 
     access_status = AccessStatusField(attribute="access")
 
-    creators = fields.Function(partial(make_affiliation_index, "creators"))
+    creators = fields.Function(
+        lambda obj: make_affiliation_index(attr="creators", obj=obj)
+    )
 
-    contributors = fields.Function(partial(make_affiliation_index, "contributors"))
+    contributors = fields.Function(
+        lambda obj: make_affiliation_index(attr="contributors", obj=obj)
+    )
 
     languages = fields.List(
         fields.Nested(VocabularyL10Schema),

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -6,7 +6,6 @@
 
 """RDM record schemas."""
 
-from functools import partial
 from urllib import parse
 
 from flask import current_app
@@ -99,13 +98,10 @@ class PersonOrOrganizationSchema(Schema):
     family_name = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                # It is intended to allow org schemes to be sent as personal
-                # and viceversa. This is a trade off learnt from running
-                # Zenodo in production.
-                allowed_schemes=record_personorg_schemes,
-            )
+            # It is intended to allow org schemes to be sent as personal
+            # and viceversa. This is a trade off learnt from running
+            # Zenodo in production.
+            IdentifierSchema(allowed_schemes=record_personorg_schemes),
         )
     )
 
@@ -323,9 +319,7 @@ class LocationSchema(Schema):
     geometry = fields.Nested(GeometryObjectSchema)
     place = SanitizedUnicode()
     identifiers = fields.List(
-        fields.Nested(
-            partial(IdentifierSchema, allowed_schemes=record_location_schemes)
-        )
+        fields.Nested(IdentifierSchema(allowed_schemes=record_location_schemes))
     )
     description = SanitizedUnicode()
 
@@ -374,9 +368,7 @@ class MetadataSchema(Schema):
     languages = fields.List(fields.Nested(VocabularySchema))
     # alternate identifiers
     identifiers = IdentifierValueSet(
-        fields.Nested(
-            partial(IdentifierSchema, allowed_schemes=record_identifiers_schemes)
-        )
+        fields.Nested(IdentifierSchema(allowed_schemes=record_identifiers_schemes))
     )
     related_identifiers = fields.List(fields.Nested(RelatedIdentifierSchema))
     sizes = fields.List(

--- a/invenio_rdm_records/services/schemas/record.py
+++ b/invenio_rdm_records/services/schemas/record.py
@@ -11,6 +11,7 @@ from functools import partial
 from flask import current_app
 from invenio_drafts_resources.services.records.schema import RecordSchema
 from invenio_i18n import lazy_gettext as _
+from invenio_records_resources.proxies import current_custom_fields_schema_registry
 from invenio_records_resources.services.custom_fields import CustomFieldsSchema
 from invenio_requests.services.schemas import GenericRequestSchema
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_dump
@@ -73,7 +74,9 @@ class RDMRecordSchema(RecordSchema, FieldPermissionsMixin, CleanReviewMixin):
     )
     metadata = NestedAttribute(MetadataSchema)
     custom_fields = NestedAttribute(
-        partial(CustomFieldsSchema, fields_var="RDM_CUSTOM_FIELDS")
+        lambda: current_custom_fields_schema_registry.get(
+            "RDM_CUSTOM_FIELDS", CustomFieldsSchema.field_property_name
+        )
     )
     # provenance
     access = NestedAttribute(AccessSchema)


### PR DESCRIPTION
closes: https://github.com/inveniosoftware/invenio-app-rdm/issues/3480
requires: https://github.com/inveniosoftware/invenio-records-resources/pull/687

- Removed `functools.partial` nested schema patterns
- Record and UI schemas now consume the shared custom-fields registry instead of constructing schemas per request.
  - CustomFieldsSchema / CustomFieldsSchemaUI are registered at app startup and resolved through current_custom_fields_schema_registry.