### PR TITLE
fix(ui): use SECURITY_LOGIN_URL in restricted files login link

### DIFF
--- a/invenio_rdm_records/resources/serializers/ui/fields.py
+++ b/invenio_rdm_records/resources/serializers/ui/fields.py
@@ -5,10 +5,11 @@
 
 """Record response serializers."""
 
+from urllib.parse import quote
+
 from babel_edtf import format_edtf
-from flask import request
+from flask import current_app, request
 from flask_login import current_user
-from invenio_base import invenio_url_for
 from invenio_i18n import get_locale
 from invenio_i18n import gettext as _
 from marshmallow import fields
@@ -97,7 +98,11 @@ class UIObjectAccessStatus(UIAccessStatus):
                 )
         else:
             if request and current_user.is_anonymous:
-                login_url = invenio_url_for("invenio_accounts.login", next=request.url)
+                login_page = (
+                    current_app.config.get("SECURITY_LOGIN_URL")
+                    or current_app.extensions["security"].login_url
+                )
+                login_url = f"{login_page}?next={quote(request.path)}"
                 restricted_message = _(
                     "The record is publicly accessible, but files are restricted. "
                     '<a href="%(login_url)s">Log in</a> to check if you have access.'


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes https://github.com/CERNDocumentServer/cds-rdm/issues/798
When someone is logged out and views a public CDS record whose files are restricted, the red Files box invites them to “Log in” to check if they can access the files. That link was sending people to the account settings page instead of the normal login page, while the Log in button in the site header worked correctly. This change fixes the Files box link so it goes to the same login page as the header, and brings users back to the record they were viewing after they sign in.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
