### PR TITLE
fix(requests): expose record version in expanded topic

### DIFF
--- a/invenio_rdm_records/requests/entity_resolvers.py
+++ b/invenio_rdm_records/requests/entity_resolvers.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from ..proxies import current_rdm_records_service
 from ..records.api import RDMDraft, RDMRecord
+from ..resources.serializers.ui.schema import record_version
 from ..services.config import RDMRecordServiceConfig
 from ..services.dummy import DummyExpandingService
 
@@ -59,6 +60,14 @@ class RDMRecordProxy(RecordProxy):
         public records, thus the `ghost_record` method will always kick in!
         """
         return {"id": record}
+
+    def pick_resolved_fields(self, identity, resolved_dict):
+        """Select which fields to return when resolving the reference."""
+        out = {"id": resolved_dict["id"]}
+        version = record_version(resolved_dict)
+        if version:
+            out["version"] = version
+        return out
 
     def get_needs(self, ctx=None):
         """Enrich request with record needs.


### PR DESCRIPTION
Fixes inveniosoftware/invenio-rdm-records#2358
Related: https://github.com/inveniosoftware/invenio-requests/pull/613

:heart: Thank you for your contribution!

### Description


Expose version on expanded.topic when request topics are resolved, so the UI can display which record version a community submission refers to.


<img width="298" height="451" alt="image" src="https://github.com/user-attachments/assets/847b1787-0221-459c-ac73-83c75e7c0505" />

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
