### PR TITLE
fix(performance): replace expensive `deepcopy()` calls with lighter alternatives

### DIFF
--- a/invenio_rdm_records/records/api.py
+++ b/invenio_rdm_records/records/api.py
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2020-2024 CERN.
-# SPDX-FileCopyrightText: 2021-2023 TU Wien.
+# SPDX-FileCopyrightText: 2021-2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """RDM Record and Draft API."""
@@ -14,7 +14,6 @@ from invenio_drafts_resources.services.records.components.media_files import (
     MediaFilesAttrConfig,
 )
 from invenio_pidstore.models import PIDStatus
-from invenio_records.dumpers import SearchDumper
 from invenio_records.dumpers.relations import RelationDumperExt
 from invenio_records.systemfields import ConstantField, DictField, ModelField
 from invenio_records.systemfields.relations import MultiRelationsField
@@ -49,6 +48,7 @@ from .dumpers import (
     EDTFDumperExt,
     EDTFListDumperExt,
     GrantTokensDumperExt,
+    SearchDumper,
     StatisticsDumperExt,
     SubjectHierarchyDumperExt,
 )

--- a/invenio_rdm_records/records/dumpers/__init__.py
+++ b/invenio_rdm_records/records/dumpers/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020-2024 CERN.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Search dumpers, for transforming to and from versions to index."""
@@ -8,6 +9,7 @@ from .combined_subjects import CombinedSubjectsDumperExt
 from .edtf import EDTFDumperExt, EDTFListDumperExt
 from .locations import LocationsDumper
 from .pids import PIDsDumperExt
+from .search import SearchDumper
 from .statistics import StatisticsDumperExt
 from .subject_hierarchy import SubjectHierarchyDumperExt
 
@@ -15,6 +17,7 @@ __all__ = (
     "CombinedSubjectsDumperExt",
     "EDTFDumperExt",
     "EDTFListDumperExt",
+    "SearchDumper",
     "PIDsDumperExt",
     "GrantTokensDumperExt",
     "LocationsDumper",

--- a/invenio_rdm_records/records/dumpers/search.py
+++ b/invenio_rdm_records/records/dumpers/search.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 TU Wien.
+# SPDX-License-Identifier: MIT
+
+"""Faster search dumper that runs a faster deep-ish copy of the data before dumping."""
+
+from invenio_records.dumpers import SearchDumper as BaseSearchDumper
+
+from ...utils import very_simple_deepcopy
+
+
+class SearchDumper(BaseSearchDumper):
+    """Search dumper that creates a faster deep-ish copy of the data before dumping.
+
+    In this version of the search dumper, we replace ``copy.deepcopy()`` with a simpler
+    copy deep-ish copy mechanism that still satisfies our expectations, for performance
+    gains.
+    """
+
+    def _copy_record(self, record):
+        """Create a simpler version of a deepcopy for the record."""
+        return very_simple_deepcopy(dict(record))
+
+    def _copy_data(self, data):
+        """Create a simpler version of a deepcopy for the record."""
+        return very_simple_deepcopy(data)

--- a/invenio_rdm_records/records/models.py
+++ b/invenio_rdm_records/records/models.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2026 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Record and draft database models."""
@@ -15,13 +16,39 @@ from invenio_drafts_resources.records import (
     ParentRecordStateMixin,
 )
 from invenio_files_rest.models import Bucket
-from invenio_records.models import RecordMetadataBase
+from invenio_records.models import RecordMetadataBase as OriginalRecordMetadataBase
 from invenio_records_resources.records import FileRecordModelMixin
 from invenio_requests.records.models import RequestMetadata
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy_utils.types import ChoiceType, UUIDType
 
+from ..utils import very_simple_deepcopy
 from .systemfields.deletion_status import RecordDeletionStatusEnum
+
+
+class RecordMetadataBase(OriginalRecordMetadataBase):
+    """Record metadata class with a lighter decode mechanism.
+
+    This class replaces the ``copy.deepcopy()`` call that's being done by the parent
+    classes with a simple shallow copy for performance gains on read operations on
+    record data.
+
+    This less defensive approach may require some extra precautions when manipulating
+    data dictionaries from records than are necessary with ``copy.deepcopy()``.
+    In InvenioRDM, such use cases are few and far between however.
+    """
+
+    @classmethod
+    def decode(cls, json):
+        """Decode a JSON document, doing only a very simple deepcopy."""
+        data = very_simple_deepcopy(json) if json else json
+        return cls.encoder.decode(data) if cls.encoder else data
+
+    @classmethod
+    def encode(cls, value):
+        """Encode a JSON document, doing only a very simple deepcopy."""
+        data = very_simple_deepcopy(value)
+        return cls.encoder.encode(data) if cls.encoder else data
 
 
 # Moved from invenio-communities/invenio_communities/records/records/models.py

--- a/invenio_rdm_records/records/systemfields/tombstone.py
+++ b/invenio_rdm_records/records/systemfields/tombstone.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 TU Wien.
+# SPDX-FileCopyrightText: 2023-2026 TU Wien.
 # SPDX-FileCopyrightText: 2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
@@ -39,6 +39,10 @@ class Tombstone:
         #       in the record's relations systemfield
         if isinstance(value, str):
             value = {"id": value}
+        elif isinstance(value, dict):
+            # in case we run into a dictionary, we want to avoid shallow copies
+            # that are subject to side effects -> we take only what we're interested in
+            value = {"id": value["id"]}
 
         self._removal_reason = value
 

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2020-2025 CERN.
 # SPDX-FileCopyrightText: 2020 Northwestern University.
 # SPDX-FileCopyrightText: 2021-2025 Graz University of Technology.
-# SPDX-FileCopyrightText: 2022-2023 TU Wien.
+# SPDX-FileCopyrightText: 2022-2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Record response serializers."""
 
-from copy import deepcopy
 from functools import partial
 
 from babel_edtf import parse_edtf
@@ -31,6 +30,7 @@ from pyparsing import ParseException
 
 from ....services.request_policies import RDMRecordDeletionPolicy
 from ....services.schemas.fields import SanitizedHTML
+from ....utils import simple_deepcopy
 from .fields import AccessStatusField
 
 
@@ -55,7 +55,7 @@ def make_affiliation_index(attr, obj, *args):
     changes to fix RemovedInMarshmallow4Warning
     """
     # Copy so we don't modify in place the existing dict.
-    creators = deepcopy(obj.get("metadata", {}).get(attr))
+    creators = simple_deepcopy(obj.get("metadata", {}).get(attr))
     if not creators:
         return missing
 

--- a/invenio_rdm_records/utils.py
+++ b/invenio_rdm_records/utils.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2022-2024 CERN.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Utility functions."""
@@ -147,3 +148,36 @@ def verify_token(identity):
     if access_request_token:
         session["access_request_token"] = access_request_token
         identity.provides.add(AccessRequestTokenNeed(access_request_token))
+
+
+def simple_deepcopy(data):
+    """A simpler variant of ``deepcopy()`` that's sufficient for our use cases.
+
+    This function only creates deep copies of some specific data structures; basically
+    the ones that are representable in JSON.
+    This makes it faster than ``deepcopy()``.
+
+    This is sufficient in many cases in InvenioRDM since we don't generally manipulate
+    data from sources where we care about manipulations via side effects.
+    """
+    if isinstance(data, dict):
+        return {k: simple_deepcopy(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [simple_deepcopy(v) for v in data]
+    return data
+
+
+def very_simple_deepcopy(data):
+    """An even simpler variant of ``deepcopy()`` that does the job sometimes.
+
+    This function only creates deep copies of dictionaries, and creates new references
+    for lists (but does not touch the items within them).
+    This makes it much faster than ``deepcopy()``.
+
+    Like ``simple_deepcopy()``, this is sufficient for some use cases in InvenioRDM.
+    """
+    if isinstance(data, dict):
+        return {k: very_simple_deepcopy(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [*data]
+    return data


### PR DESCRIPTION
Experiments with the profiler have shown that deep copying of data on read operations can have a significant impact on performance in some cases.
Since we don't generally fetch data from records and immediately manipulate it without further consideration, we can be a bit more aggressive here.

Edit: Some comparison between the different functions for a record's data of 5k creators and some other fields:
```
In [4]: %timeit -r 20 -n 10 deepcopy(dict(rec))
11.3 ms ± 2.47 ms per loop (mean ± std. dev. of 20 runs, 10 loops each)

In [5]: %timeit -r 20 -n 10 simple_deepcopy(dict(rec))
4.13 ms ± 1.1 ms per loop (mean ± std. dev. of 20 runs, 10 loops each)

In [6]: %timeit -r 20 -n 10 very_simple_deepcopy(dict(rec))
18.8 μs ± 3.41 μs per loop (mean ± std. dev. of 20 runs, 10 loops each)
```