### PR TITLE
iiif: fix: logging without reserved filename key

### DIFF
--- a/invenio_rdm_records/services/iiif/storage.py
+++ b/invenio_rdm_records/services/iiif/storage.py
@@ -141,7 +141,9 @@ class LocalTilesStorage(TilesStorage):
                 "Failed to delete tiles for record.",
                 extra={
                     "record_id": record["id"],
-                    "filename": filename,
+                    # Not using the key `filename` as it is a field of `LogRecord`
+                    # and using it would raise a KeyError exception.
+                    "filename_": filename,
                 },
             )
             return False


### PR DESCRIPTION
The following code:

```python
from flask import current_app
current_app.logger.exception("This is message", extra={"filename": "test.txt"})
```

Fails with:

```
KeyError: "Attempt to overwrite 'filename' in LogRecord"
```

This is due to the fact that `filename` is a field of `LogRecord`, so it cannot be passed as an `extra`.

This pull request fixes this logging statement by using a another key.