### PR TITLE
fix: fixed isParentAlreadyPublished not working on /new

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/reducers/deposit.js
@@ -69,7 +69,7 @@ function hasStatus(record, statuses = []) {
 // within its parent.
 // This essentially corresponds to whether the parent record has been published.
 function isParentAlreadyPublished(record) {
-  return hasStatus(record, [DepositStatus.PUBLISHED]) || record.versions?.index !== 1;
+  return hasStatus(record, [DepositStatus.PUBLISHED]) || record.versions?.index > 1;
 }
 
 function getSelectedCommunityMetadata(record, selectedCommunity) {


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

When you go to create a new record, you select a community, and press save, review is not called. It is because in the "empty" record in the beginning the check in current code is incorrect and so you just save draft. Only after you save for the second time is review called. 

So you think you selected community, if you refresh the page, right after the first save, the community is gone. 

