### PR TITLE
Reusable marshmallow schema instances in services

### DIFF
--- a/invenio_rdm_records/contrib/meeting/custom_fields.py
+++ b/invenio_rdm_records/contrib/meeting/custom_fields.py
@@ -1,5 +1,6 @@
-# SPDX-FileCopyrightText: 2023-2025 CERN.
+# SPDX-FileCopyrightText: 2023-2026 CERN.
 # SPDX-FileCopyrightText: 2024 KTH Royal Institute of Technology.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """Meeting custom fields.
@@ -14,8 +15,6 @@ Implements the following fields:
 - meeting.title
 - meeting.url
 """
-
-from functools import partial
 
 from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.custom_fields import BaseCF
@@ -45,9 +44,8 @@ class MeetingCF(BaseCF):
                 ),
                 "identifiers": IdentifierValueSet(
                     fields.Nested(
-                        partial(
-                            IdentifierSchema,
-                            allowed_schemes=record_related_identifiers_schemes,
+                        IdentifierSchema(
+                            allowed_schemes=record_related_identifiers_schemes
                         )
                     )
                 ),

--- a/invenio_rdm_records/oaiserver/services/services.py
+++ b/invenio_rdm_records/oaiserver/services/services.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2022-2025 Graz University of Technology.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """OAI-PMH service."""
@@ -56,11 +57,15 @@ class OAIPMHServerService(Service):
         """Init service with config."""
         super().__init__(config)
         self.extra_reserved_prefixes = extra_reserved_prefixes or {}
+        self._schema = ServiceSchemaWrapper(self, schema=self.config.schema)
+        self._metadata_format_schema = ServiceSchemaWrapper(
+            self, schema=self.config.metadata_format_schema
+        )
 
     @property
     def schema(self):
         """Returns the data schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema)
+        return self._schema
 
     @property
     def links_item_tpl(self):
@@ -247,9 +252,7 @@ class OAIPMHServerService(Service):
             self,
             identity,
             results,
-            schema=ServiceSchemaWrapper(
-                self, schema=self.config.metadata_format_schema
-            ),
+            schema=self._metadata_format_schema,
         )
 
     def rebuild_index(self, identity):

--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -23,9 +23,13 @@ from invenio_vocabularies.contrib.awards.serializer import AwardL10NItemSchema
 from invenio_vocabularies.contrib.funders.serializer import FunderL10NItemSchema
 from invenio_vocabularies.resources import L10NString, VocabularyL10Schema
 from marshmallow import Schema, fields, missing, post_dump, pre_dump
-from marshmallow_utils.fields import FormatDate as FormatDate_
-from marshmallow_utils.fields import FormatEDTF as FormatEDTF_
-from marshmallow_utils.fields import SanitizedHTML, SanitizedUnicode, StrippedHTML
+from marshmallow_utils.fields import (
+    FormatDate,
+    FormatEDTF,
+    SanitizedHTML,
+    SanitizedUnicode,
+    StrippedHTML,
+)
 from marshmallow_utils.fields.babel import gettext_from_dict
 from pyparsing import ParseException
 
@@ -40,11 +44,6 @@ def current_default_locale():
         return current_app.config.get("BABEL_DEFAULT_LOCALE", "en")
     # Use english by default if not specified
     return "en"
-
-
-# Partial to make short definitions in below schema.
-FormatEDTF = partial(FormatEDTF_, locale=get_locale)
-FormatDate = partial(FormatDate_, locale=get_locale)
 
 
 def make_affiliation_index(attr, obj, *args):
@@ -333,9 +332,13 @@ class TombstoneSchema(Schema):
     # This information is masked into a string in UIRecordSchema
     removed_by = fields.Raw(attribute="removed_by")
 
-    removal_date_l10n_medium = FormatEDTF(attribute="removal_date", format="medium")
+    removal_date_l10n_medium = FormatEDTF(
+        attribute="removal_date", format="medium", locale=get_locale
+    )
 
-    removal_date_l10n_long = FormatEDTF(attribute="removal_date", format="long")
+    removal_date_l10n_long = FormatEDTF(
+        attribute="removal_date", format="long", locale=get_locale
+    )
 
     citation_text = fields.String(attribute="citation_text")
 
@@ -369,16 +372,20 @@ class UIRecordSchema(BaseObjectSchema):
     object_key = "ui"
 
     publication_date_l10n_medium = FormatEDTF(
-        attribute="metadata.publication_date", format="medium"
+        attribute="metadata.publication_date", format="medium", locale=get_locale
     )
 
     publication_date_l10n_long = FormatEDTF(
-        attribute="metadata.publication_date", format="long"
+        attribute="metadata.publication_date", format="long", locale=get_locale
     )
 
-    created_date_l10n_long = FormatDate(attribute="created", format="long")
+    created_date_l10n_long = FormatDate(
+        attribute="created", format="long", locale=get_locale
+    )
 
-    updated_date_l10n_long = FormatDate(attribute="updated", format="long")
+    updated_date_l10n_long = FormatDate(
+        attribute="updated", format="long", locale=get_locale
+    )
 
     resource_type = fields.Nested(
         VocabularyL10Schema, attribute="metadata.resource_type"
@@ -389,9 +396,7 @@ class UIRecordSchema(BaseObjectSchema):
     )
 
     # Custom fields
-    custom_fields = fields.Nested(
-        partial(CustomFieldsSchemaUI, fields_var="RDM_CUSTOM_FIELDS")
-    )
+    custom_fields = fields.Nested(lambda: CustomFieldsSchemaUI("RDM_CUSTOM_FIELDS"))
 
     publishing_information = fields.Function(compute_publishing_information)
 
@@ -399,9 +404,13 @@ class UIRecordSchema(BaseObjectSchema):
 
     access_status = AccessStatusField(attribute="access")
 
-    creators = fields.Function(partial(make_affiliation_index, "creators"))
+    creators = fields.Function(
+        lambda obj: make_affiliation_index(attr="creators", obj=obj)
+    )
 
-    contributors = fields.Function(partial(make_affiliation_index, "contributors"))
+    contributors = fields.Function(
+        lambda obj: make_affiliation_index(attr="contributors", obj=obj)
+    )
 
     languages = fields.List(
         fields.Nested(VocabularyL10Schema),

--- a/invenio_rdm_records/services/access/service.py
+++ b/invenio_rdm_records/services/access/service.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2020-2021 Northwestern University.
-# SPDX-FileCopyrightText: 2021 TU Wien.
+# SPDX-FileCopyrightText: 2021-2026 TU Wien.
 # SPDX-FileCopyrightText: 2023-2025 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
@@ -52,6 +52,23 @@ class RecordAccessService(RecordService):
 
     group_subject_type = "role"
 
+    def __init__(self, config):
+        """Constructor."""
+        super().__init__(config)
+        self._schema_secret_link = ServiceSchemaWrapper(
+            self, schema=self.config.schema_secret_link
+        )
+        self._schema_grant = ServiceSchemaWrapper(self, schema=self.config.schema_grant)
+        self._schema_grants = ServiceSchemaWrapper(
+            self, schema=self.config.schema_grants
+        )
+        self._schema_request_access = ServiceSchemaWrapper(
+            self, schema=self.config.schema_request_access
+        )
+        self._schema_access_settings = ServiceSchemaWrapper(
+            self, schema=self.config.schema_access_settings
+        )
+
     def link_result_item(self, *args, **kwargs):
         """Create a new instance of the resource unit."""
         return self.config.link_result_item_cls(*args, **kwargs)
@@ -81,27 +98,27 @@ class RecordAccessService(RecordService):
     @property
     def schema_secret_link(self):
         """Schema for secret links."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_secret_link)
+        return self._schema_secret_link
 
     @property
     def schema_grant(self):
         """Schema for secret links."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_grant)
+        return self._schema_grant
 
     @property
     def schema_grants(self):
         """Schema for grants."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_grants)
+        return self._schema_grants
 
     @property
     def schema_request_access(self):
         """Schema for secret links."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_request_access)
+        return self._schema_request_access
 
     @property
     def schema_access_settings(self):
         """Schema for record parent."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_access_settings)
+        return self._schema_access_settings
 
     @property
     def expandable_fields(self):

--- a/invenio_rdm_records/services/communities/service.py
+++ b/invenio_rdm_records/services/communities/service.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023-2026 CERN.
 # SPDX-FileCopyrightText: 2024 Graz University of Technology.
 # SPDX-FileCopyrightText: 2024 KTH Royal Institute of Technology.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """RDM Record Communities Service."""
@@ -48,15 +49,23 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
     The communities service is in charge of managing communities of a given record.
     """
 
+    def __init__(self, config):
+        """Constructor."""
+        super().__init__(config)
+        self._schema = ServiceSchemaWrapper(self, schema=self.config.schema)
+        self._communities_schema = ServiceSchemaWrapper(
+            self, schema=self.config.communities_schema
+        )
+
     @property
     def schema(self):
         """Returns the data schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema)
+        return self._schema
 
     @property
     def communities_schema(self):
         """Returns the communities schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.communities_schema)
+        return self._communities_schema
 
     @property
     def record_cls(self):

--- a/invenio_rdm_records/services/communities/service.py
+++ b/invenio_rdm_records/services/communities/service.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023-2024 CERN.
+# SPDX-FileCopyrightText: 2023-2026 CERN.
 # SPDX-FileCopyrightText: 2024 Graz University of Technology.
 # SPDX-FileCopyrightText: 2024 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT

--- a/invenio_rdm_records/services/community_records/service.py
+++ b/invenio_rdm_records/services/community_records/service.py
@@ -25,10 +25,17 @@ class CommunityRecordsService(RecordService):
     The record communities service is in charge of managing the records of a given community.
     """
 
+    def __init__(self, config):
+        """Constructor."""
+        super().__init__(config)
+        self._community_record_schema = ServiceSchemaWrapper(
+            self, schema=self.config.community_record_schema
+        )
+
     @property
     def community_record_schema(self):
         """Returns the community schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.community_record_schema)
+        return self._community_record_schema
 
     @property
     def community_cls(self):

--- a/invenio_rdm_records/services/community_records/service.py
+++ b/invenio_rdm_records/services/community_records/service.py
@@ -1,4 +1,5 @@
-# SPDX-FileCopyrightText: 2023-2024 CERN.
+# SPDX-FileCopyrightText: 2023-2026 CERN.
+# SPDX-FileCopyrightText: 2026 TU Wien.
 # SPDX-License-Identifier: MIT
 
 """RDM Community Records Service."""

--- a/invenio_rdm_records/services/schemas/metadata.py
+++ b/invenio_rdm_records/services/schemas/metadata.py
@@ -6,7 +6,6 @@
 
 """RDM record schemas."""
 
-from functools import partial
 from urllib import parse
 
 from flask import current_app
@@ -99,13 +98,10 @@ class PersonOrOrganizationSchema(Schema):
     family_name = SanitizedUnicode()
     identifiers = IdentifierSet(
         fields.Nested(
-            partial(
-                IdentifierSchema,
-                # It is intended to allow org schemes to be sent as personal
-                # and viceversa. This is a trade off learnt from running
-                # Zenodo in production.
-                allowed_schemes=record_personorg_schemes,
-            )
+            # It is intended to allow org schemes to be sent as personal
+            # and viceversa. This is a trade off learnt from running
+            # Zenodo in production.
+            IdentifierSchema(allowed_schemes=record_personorg_schemes),
         )
     )
 
@@ -323,9 +319,7 @@ class LocationSchema(Schema):
     geometry = fields.Nested(GeometryObjectSchema)
     place = SanitizedUnicode()
     identifiers = fields.List(
-        fields.Nested(
-            partial(IdentifierSchema, allowed_schemes=record_location_schemes)
-        )
+        fields.Nested(IdentifierSchema(allowed_schemes=record_location_schemes))
     )
     description = SanitizedUnicode()
 
@@ -374,9 +368,7 @@ class MetadataSchema(Schema):
     languages = fields.List(fields.Nested(VocabularySchema))
     # alternate identifiers
     identifiers = IdentifierValueSet(
-        fields.Nested(
-            partial(IdentifierSchema, allowed_schemes=record_identifiers_schemes)
-        )
+        fields.Nested(IdentifierSchema(allowed_schemes=record_identifiers_schemes))
     )
     related_identifiers = fields.List(fields.Nested(RelatedIdentifierSchema))
     sizes = fields.List(

--- a/invenio_rdm_records/services/schemas/record.py
+++ b/invenio_rdm_records/services/schemas/record.py
@@ -72,9 +72,8 @@ class RDMRecordSchema(RecordSchema, FieldPermissionsMixin, CleanReviewMixin):
         values=fields.Nested(PIDSchema),
     )
     metadata = NestedAttribute(MetadataSchema)
-    custom_fields = NestedAttribute(
-        partial(CustomFieldsSchema, fields_var="RDM_CUSTOM_FIELDS")
-    )
+    custom_fields = NestedAttribute(lambda: CustomFieldsSchema("RDM_CUSTOM_FIELDS"))
+
     # provenance
     access = NestedAttribute(AccessSchema)
     files = NestedAttribute(FilesSchema)

--- a/invenio_rdm_records/services/services.py
+++ b/invenio_rdm_records/services/services.py
@@ -65,6 +65,10 @@ class RDMRecordService(RecordService):
         self._access = access_service
         self._pids = pids_service
         self._review = review_service
+        self._schema_tombstone = ServiceSchemaWrapper(
+            self, schema=self.config.schema_tombstone
+        )
+        self._schema_quota = ServiceSchemaWrapper(self, schema=self.config.schema_quota)
 
     #
     # Subservices
@@ -103,12 +107,12 @@ class RDMRecordService(RecordService):
     @property
     def schema_tombstone(self):
         """Schema for tombstone information."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_tombstone)
+        return self._schema_tombstone
 
     @property
     def schema_quota(self):
         """Returns the featured data schema instance."""
-        return ServiceSchemaWrapper(self, schema=self.config.schema_quota)
+        return self._schema_quota
 
     #
     # Service methods


### PR DESCRIPTION
PR based on @sakshamarora1 's PR https://github.com/inveniosoftware/invenio-rdm-records/pull/2355 but without the schema registry (pulled the schema initialization into the service constructors instead).

~~This PR also contains the changes from https://github.com/inveniosoftware/invenio-rdm-records/pull/2367 for my own convenience.~~