### PR TITLE
fix(entity_resolvers): Fix ghost_record for drafts on submission

### DIFF
--- a/invenio_rdm_records/resources/serializers/ui/schema.py
+++ b/invenio_rdm_records/resources/serializers/ui/schema.py
@@ -97,7 +97,11 @@ def record_version(obj):
     field_data = obj.get("metadata", {}).get("version")
 
     if not field_data:
-        return f"v{obj['versions']['index']}"
+        field_data = obj.get("versions", {}).get("index")
+        if field_data:
+            return f"v{field_data}"
+        # If both metadata.version and versions.index are not available, return None as it is not published yet
+        return None
 
     return field_data
 


### PR DESCRIPTION
For new draft requests, the UI was failing with a bug because for drafts, it returns the ghost record with "id" only, so a check was required to confirm if the version is needed for the ui serielizer or not

fixes: https://github.com/inveniosoftware/invenio-rdm-records/issues/2358
related: https://github.com/inveniosoftware/invenio-rdm-records/pull/2365