### PR TITLE
feat(ui): make NewVersionButton overridable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,15 @@
 Changes
 =======
 
+Version v33.2.0 (released 2026-07-09)
+
+- feat(ui): make NewVersionButton overridable
+- fix(checks): Removed redundant check
+- fix(checks): resolve section labels
+- fix(entity_resolvers): Fix ghost_record for drafts on submission
+- tests: update citation string for csl 1.0.2
+- fix(citation): use harvard-cite-them-right and setup _extras in tests
+
 Version v33.1.0 (released 2026-07-01)
 
 - chore(setup): migrate build backend from setuptools to hatchling

--- a/invenio_rdm_records/__init__.py
+++ b/invenio_rdm_records/__init__.py
@@ -8,6 +8,6 @@
 
 from .ext import InvenioRDMRecords
 
-__version__ = "33.1.0"
+__version__ = "33.2.0"
 
 __all__ = ("__version__", "InvenioRDMRecords")

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/controls/NewVersionButton/NewVersionButton.js
@@ -5,12 +5,13 @@
  */
 
 import React, { useState } from "react";
-import { http } from "react-invenio-forms";
+import { http, showHideOverridable } from "react-invenio-forms";
 import { Icon, Button, Popup } from "semantic-ui-react";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import PropTypes from "prop-types";
+import Overridable from "react-overridable";
 
-export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
+const NewVersionButtonComponent = ({ onError, record, disabled, ...uiProps }) => {
   const [loading, setLoading] = useState(false);
 
   const handleClick = async () => {
@@ -27,39 +28,51 @@ export const NewVersionButton = ({ onError, record, disabled, ...uiProps }) => {
   };
 
   return (
-    <Popup
-      content={i18next.t("You don't have permissions to create a new version.")}
-      position="top center"
-      disabled={!disabled}
-      trigger={
-        // Extra span needed since disabled buttons do not trigger hover events
-        <span>
-          <Button
-            type="button"
-            positive
-            size="mini"
-            onClick={handleClick}
-            loading={loading}
-            icon
-            labelPosition="left"
-            disabled={disabled}
-            {...uiProps}
-          >
-            <Icon name="tag" />
-            {i18next.t("New version")}
-          </Button>
-        </span>
-      }
-    />
+    <Overridable
+      id="InvenioRdmRecords.RecordLandingPage.RecordManagement.NewVersionButton.container"
+      onError={onError}
+      record={record}
+      disabled={disabled}
+    >
+      <Popup
+        content={i18next.t("You don't have permissions to create a new version.")}
+        position="top center"
+        disabled={!disabled}
+        trigger={
+          // Extra span needed since disabled buttons do not trigger hover events
+          <span>
+            <Button
+              type="button"
+              positive
+              size="mini"
+              onClick={handleClick}
+              loading={loading}
+              icon
+              labelPosition="left"
+              disabled={disabled}
+              {...uiProps}
+            >
+              <Icon name="tag" />
+              {i18next.t("New version")}
+            </Button>
+          </span>
+        }
+      />
+    </Overridable>
   );
 };
 
-NewVersionButton.propTypes = {
+NewVersionButtonComponent.propTypes = {
   onError: PropTypes.func.isRequired,
   record: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
 };
 
-NewVersionButton.defaultProps = {
+NewVersionButtonComponent.defaultProps = {
   disabled: false,
 };
+
+export const NewVersionButton = showHideOverridable(
+  "InvenioRdmRecords.RecordLandingPage.RecordManagement.NewVersionButton",
+  NewVersionButtonComponent
+);


### PR DESCRIPTION
Closes https://github.com/CERNDocumentServer/cds-rdm/issues/842

---

* Added a React Overridable wrapper to the new version button, along with show/hide support (as already applies to many fields on the deposit form)

* The exported name of the component is unchanged and the props remain the same, so this change is fully backward-compatible.