### PR TITLE
fix(iiif): add handlers for more possible IIIF errors

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -15,7 +15,11 @@ import marshmallow as ma
 import requests
 from flask import Response, current_app, g, request, send_file
 from flask_cors import cross_origin
-from flask_iiif.errors import MultimediaImageNotFound
+from flask_iiif.errors import (
+    MultimediaError,
+    MultimediaImageFormatError,
+    MultimediaImageNotFound,
+)
 from flask_resources import (
     HTTPJSONException,
     JSONSerializer,
@@ -112,6 +116,20 @@ class IIIFResourceConfig(ResourceConfig, ConfiguratorMixin):
         ),
         IdentifierShapeException: create_error_handler(
             lambda e: HTTPJSONException(code=400, description=e.description)
+        ),
+        MultimediaImageFormatError: create_error_handler(
+            lambda e: HTTPJSONException(
+                code=400,
+                description=_(
+                    # Once Flask-IIIF has translations, we can simply use `e.message` here
+                    "%(requested_format)s is not supported, please select one of the valid formats: %(supported_formats)s",
+                    requested_format=e.requested_format,
+                    supported_formats=e.supported_formats,
+                ),
+            )
+        ),
+        MultimediaError: create_error_handler(
+            lambda e: HTTPJSONException(code=400, message=e.message)
         ),
     }
 


### PR DESCRIPTION
We get a good number of requests that result in HTTP 500 responses even though they really don't need to.
`Flask-IIIF` is already doing a decent job at raising semantically meaningful errors (including messages [1]), we're just not handling them here.
This PR adds error handlers to basically forward the error messages that `Flask-IIIF` gives us, to the user.

Requires https://github.com/inveniosoftware/flask-iiif/pull/110 for accessing `e.requested_format` and `e.supported_formats` for translations.

[1] `Flask-IIIF` doesn't have translations yet though.