### PR TITLE
fix(iiif): handle DelegateError for unsupported file types

### DIFF
--- a/invenio_rdm_records/resources/iiif.py
+++ b/invenio_rdm_records/resources/iiif.py
@@ -129,7 +129,7 @@ class IIIFResourceConfig(ResourceConfig, ConfiguratorMixin):
             )
         ),
         MultimediaError: create_error_handler(
-            lambda e: HTTPJSONException(code=400, message=e.message)
+            lambda e: HTTPJSONException(code=400, description=e.message)
         ),
     }
 

--- a/invenio_rdm_records/services/iiif/service.py
+++ b/invenio_rdm_records/services/iiif/service.py
@@ -9,12 +9,15 @@ import importlib.metadata as metadata
 import io
 
 from flask_iiif.api import IIIFImageAPIWrapper
+from flask_iiif.errors import MultimediaError
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import Service
 
 from ..errors import IdentifierShapeException
 
 try:
     metadata.distribution("wand")
+    from wand.exceptions import DelegateError
     from wand.image import Image
 
     HAS_IMAGEMAGICK = True
@@ -113,13 +116,24 @@ class IIIFService(Service):
             fp.close()
             return first_page_buf
         elif HAS_IMAGEMAGICK:
-            first_page = Image(blob=fp)
-            first_page_buf = io.BytesIO()
-            with first_page.convert(format="png") as converted:
-                converted.save(file=first_page_buf)
-            first_page_buf.seek(0)
-            fp.close()
-            return first_page_buf
+            try:
+                first_page = Image(blob=fp)
+                first_page_buf = io.BytesIO()
+                with first_page.convert(format="png") as converted:
+                    converted.save(file=first_page_buf)
+                first_page_buf.seek(0)
+                fp.close()
+                return first_page_buf
+
+            except DelegateError as e:
+                # This can happen with unsupported file types; e.g. it has been observed
+                # with PDF files
+                raise MultimediaError(
+                    _(
+                        "The requested file cannot be transformed into PNG: %(filename)s",
+                        filename=file_["key"],
+                    )
+                )
 
         return fp
 


### PR DESCRIPTION
It has been observed that PDF files cause this code path to be executed, only to fail with a `wand.exceptions.DelegateError` because the file type conversion fails.
This PR catches that exception and gives a better response than HTTP 500.

For instance, calling `https://researchdata.tuwien.at/api/iiif/record:3z16r-zh592:File%20codes%20for%20compounds.pdf/full/full/0/default.png` (note the requested file being PDF) results in:
```
Exception on /iiif/record:5g22b-qje58:OR2026_ TU Wien's InvenioRDM.pdf/full/!800,800/0/default.png [GET]
Traceback (most recent call last):
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_debugtoolbar/__init__.py", line 222, in dispatch_request
    return view_func(**view_args)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/resources.py", line 61, in view
    return view_meth()
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/content_negotiation.py", line 112, in inner_content_negotiation
    return f(*args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_cors/decorator.py", line 135, in wrapped_function
    resp = make_response(f(*args, **kwargs))
                         ~^^^^^^^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/parsers/decorators.py", line 47, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/parsers/decorators.py", line 47, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/flask_resources/parsers/decorators.py", line 47, in inner
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_rdm_records/resources/iiif.py", line 179, in _wrapper
    return f(self, *args, **kwargs)
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_rdm_records/resources/iiif.py", line 289, in image_api
    to_serve = self.service.image_api(
        identity=g.identity,
    ...<5 lines>...
        image_format=image_format,
    )
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_rdm_records/services/iiif/service.py", line 176, in image_api
    data = self._open_image(file_)
  File "/var/instance/.venv/lib/python3.14/site-packages/invenio_rdm_records/services/iiif/service.py", line 120, in _open_image
    first_page = Image(blob=fp)
  File "/var/instance/.venv/lib/python3.14/site-packages/wand/image.py", line 9380, in __init__
    self.read(blob=blob)
    ~~~~~~~~~^^^^^^^^^^^
  File "/var/instance/.venv/lib/python3.14/site-packages/wand/image.py", line 10137, in read
    self.raise_exception()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/var/instance/.venv/lib/python3.14/site-packages/wand/resource.py", line 225, in raise_exception
    raise e
wand.exceptions.DelegateError: FailedToExecuteCommand `'gs' -sstdout=%stderr -dQUIET -dSAFER -dBATCH -dNOPAUSE -dNOPROMPT -dMaxBitmap=500000000 -dAlignToPixels=0 -dGridFitTT=2 '-sDEVICE=png16malpha' -dTextAlphaBits=4 -dGraphicsAlphaBits=4 '-r72x72' -dPrinted=false  '-sOutputFile=/tmp/magick-NEroiG6CnCskCk74cLx64ZCG2xas8dfJ%d' '-f/tmp/magick-XV526GPZDCYFuVnc23k3GUXVWg8X2Sdh' '-f/tmp/magick-y4XRWUVs5x0Fly6U7DXPirCgw6Qw6Ubs'' (32512) @ error/ghostscript-private.h/ExecuteGhostscriptCommand/75
```

---

## Testing various files for IIIF

The following record has 4 files:
* `download.csv`
* `OR2026_ TU Wien's InvenioRDM.pdf`
* `Screen Shot 2026-06-03 at 01.38.37.png`
* `TU_Signet_CMYK.ai`

<img width="1920" height="1055" alt="image" src="https://github.com/user-attachments/assets/9a2eaaf4-095b-4845-81e6-e6dbe6bf2822" />

### Various IIIF endpoint responses

Calling IIIF endpoints for each of those files results in different responses:

https://localhost/api/iiif/record:5g22b-qje58:download.csv/full/!800,800/0/default.png

> `{"status": 404, "message": "The requested image cannot be found."}`

https://localhost/api/iiif/record:5g22b-qje58:OR2026_%20TU%20Wien's%20InvenioRDM.pdf/full/!800,800/0/default.png

> `{"message":"The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.","status":500}`
(with the `DelegateError` in the logs, as above)

https://localhost/api/iiif/record:5g22b-qje58:Screen%20Shot%202026-06-03%20at%2001.38.37.png/full/!800,800/0/default.png

> IIIF preview, as expected

https://localhost/api/iiif/record:5g22b-qje58:TU_Signet_CMYK.ai/full/!800,800/0/default.png

> `{"status": 404, "message": "The requested image cannot be found."}`

It seems like for some reason, other file formats get filtered out beforehand, but at least PDF files somehow take the code path into file format conversion to PNG, and then fail with a `DelegateError`.