### PR TITLE
fix(deposit-ui): enforce file count and storage quotas in Uppy uploader

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/UppyUploader.js
@@ -12,7 +12,7 @@ import ImageEditor from "@uppy/image-editor";
 import { useFormikContext } from "formik";
 import _get from "lodash/get";
 import PropTypes from "prop-types";
-import { Grid, Message, Icon, Button } from "semantic-ui-react";
+import { Button, Dimmer, Grid, Icon, Message } from "semantic-ui-react";
 import Overridable from "react-overridable";
 import RDMUppyUploaderPlugin from "./RDMUppyUploaderPlugin";
 import { NewVersionButton } from "../../controls/NewVersionButton";
@@ -20,6 +20,7 @@ import { UploadState } from "../../state/reducers/files";
 import { i18next } from "@translations/invenio_rdm_records/i18next";
 import { getFilesList, FilesListTable, FileUploaderToolbar } from "../FileUploader";
 import { useUppyLocale } from "./locale";
+import { humanReadableBytes } from "react-invenio-forms";
 
 const defaultDashboardProps = {
   showRemoveButtonAfterComplete: false,
@@ -69,6 +70,68 @@ const createDuplicateFileChecker = (uppy, filesList) => {
   };
 };
 
+export const createFileValidator = (
+  uppy,
+  filesList,
+  filesSize,
+  quota,
+  decimalSizeDisplay
+) => {
+  const duplicateFileChecker = createDuplicateFileChecker(uppy, filesList);
+
+  return (file, files) => {
+    const uppyFilesSize = Object.values(files).reduce(
+      (totalSize, uppyFile) => (totalSize += uppyFile.size),
+      0
+    );
+    const wouldBeTotalFiles = filesList.length + Object.keys(files).length + 1;
+    const wouldBeTotalSize = filesSize + uppyFilesSize + file.size;
+
+    if (wouldBeTotalFiles > quota.maxFiles) {
+      uppy.info(
+        i18next.t(
+          "Uploading this file would result in {{total}} files (max. {{maxFiles}}).",
+          {
+            total: wouldBeTotalFiles,
+            maxFiles: quota.maxFiles,
+          }
+        ),
+        "warning"
+      );
+      return false;
+    }
+
+    if (wouldBeTotalSize > quota.maxStorage) {
+      uppy.info(
+        i18next.t(
+          "Uploading this file would result in {{total}} of used storage (max. {{limit}}).",
+          {
+            total: humanReadableBytes(wouldBeTotalSize, decimalSizeDisplay),
+            limit: humanReadableBytes(quota.maxStorage, decimalSizeDisplay),
+          }
+        ),
+        "warning"
+      );
+      return false;
+    }
+
+    if (quota.maxFileSize && file.size > quota.maxFileSize) {
+      uppy.info(
+        i18next.t(
+          "Uploading this file would exceed the maximum file size of {{limit}}.",
+          {
+            limit: humanReadableBytes(quota.maxFileSize, decimalSizeDisplay),
+          }
+        ),
+        "warning"
+      );
+      return false;
+    }
+
+    return duplicateFileChecker(file, files);
+  };
+};
+
 export const UppyUploaderComponent = ({
   config,
   files,
@@ -102,6 +165,7 @@ export const UppyUploaderComponent = ({
   const filesSize = filesList.reduce((totalSize, file) => (totalSize += file.size), 0);
   const lockFileUploader = !isDraftRecord && filesLocked;
   const filesLeft = filesList.length < quota.maxFiles;
+  const storageLeft = filesSize < quota.maxStorage;
   const displayImportBtn =
     filesEnabled && isDraftRecord && hasParentRecord && !filesList.length;
 
@@ -121,8 +185,9 @@ export const UppyUploaderComponent = ({
   const restrictions = React.useMemo(
     () => ({
       minFileSize: allowEmptyFiles ? 0 : 1,
-      maxNumberOfFiles: quota.maxFiles - filesList.length,
-      maxTotalFileSize: quota.maxStorage - filesSize,
+      maxNumberOfFiles: Math.max(0, quota.maxFiles - filesList.length),
+      maxTotalFileSize: Math.max(0, quota.maxStorage - filesSize),
+      maxFileSize: quota.maxFileSize,
     }),
     [allowEmptyFiles, quota, filesList, filesSize]
   );
@@ -164,9 +229,8 @@ export const UppyUploaderComponent = ({
   }, [uppy]);
 
   React.useEffect(() => {
-    const onBeforeFileAdded = createDuplicateFileChecker(uppy, filesList);
-    uppy.setOptions({ onBeforeFileAdded });
-  }, [uppy, filesList]);
+    uppy.setOptions({ restrictions });
+  }, [uppy, restrictions]);
 
   React.useEffect(() => {
     const uploaderPlugin = uppy.getPlugin("RDMUppyUploaderPlugin");
@@ -182,16 +246,32 @@ export const UppyUploaderComponent = ({
   }, [uppy, locale]);
 
   React.useEffect(() => {
-    uppy.setOptions({ restrictions });
-  }, [uppy, restrictions]);
+    uppy.setOptions({
+      onBeforeFileAdded: createFileValidator(
+        uppy,
+        filesList,
+        filesSize,
+        quota,
+        decimalSizeDisplay
+      ),
+    });
+  }, [uppy, filesList, filesSize, quota, decimalSizeDisplay]);
 
+  const [uppyHasFiles, setUppyHasFiles] = useState(false);
   React.useEffect(() => {
-    const dashboardPlugin = uppy.getPlugin("uppy-uploader-dashboard");
-    if (!dashboardPlugin) {
-      return;
-    }
-    dashboardPlugin.setOptions({ disabled: !filesLeft });
-  }, [uppy, filesLeft]);
+    const update = () =>
+      setUppyHasFiles(Object.keys(uppy.getState().files || {}).length > 0);
+    uppy.on("file-added", update);
+    uppy.on("file-removed", update);
+    update();
+    return () => {
+      uppy.off("file-added", update);
+      uppy.off("file-removed", update);
+    };
+  }, [uppy]);
+
+  const showQuotaOverlay =
+    (!filesLeft || !storageLeft) && !lockFileUploader && !uppyHasFiles;
 
   return (
     <Overridable
@@ -296,19 +376,36 @@ export const UppyUploaderComponent = ({
                   </Grid.Column>
                 )}
                 {!(!isDraftRecord && filesLocked) && (
-                  <Dashboard
-                    style={{ width: "100%" }}
-                    uppy={uppy}
-                    id="uppy-uploader-dashboard"
-                    disabled={!filesLeft || lockFileUploader}
-                    // `null` means "do not display a Done button in a status bar"
-                    doneButtonHandler={null}
-                    note={i18next.t(
-                      "File addition, removal or modification are not allowed after you have published your upload."
+                  <div
+                    inert={showQuotaOverlay ? "" : undefined}
+                    style={{ position: "relative", width: "100%", zIndex: 0 }}
+                  >
+                    <Dashboard
+                      style={{ width: "100%" }}
+                      uppy={uppy}
+                      id="uppy-uploader-dashboard"
+                      disabled={lockFileUploader}
+                      // `null` means "do not display a Done button in a status bar"
+                      doneButtonHandler={null}
+                      note={i18next.t(
+                        "File addition, removal or modification are not allowed after you have published your upload."
+                      )}
+                      {...defaultDashboardProps}
+                      {...uiProps}
+                    />
+                    {showQuotaOverlay && (
+                      <Dimmer active style={{ cursor: "not-allowed" }}>
+                        <Message compact icon inverted>
+                          <Icon name="ban" />
+                          <Message.Content>
+                            {i18next.t(
+                              "The file quota has been reached. No more files can be uploaded."
+                            )}
+                          </Message.Content>
+                        </Message>
+                      </Dimmer>
                     )}
-                    {...defaultDashboardProps}
-                    {...uiProps}
-                  />
+                  </div>
                 )}
               </Grid.Column>
             </Grid.Row>
@@ -371,6 +468,7 @@ UppyUploaderComponent.propTypes = {
   quota: PropTypes.shape({
     maxStorage: PropTypes.number,
     maxFiles: PropTypes.number,
+    maxFileSize: PropTypes.number,
   }),
   record: PropTypes.object,
   importButtonIcon: PropTypes.string,
@@ -401,6 +499,7 @@ UppyUploaderComponent.defaultProps = {
   quota: {
     maxFiles: 5,
     maxStorage: 10 ** 10,
+    maxFileSize: undefined,
   },
   importButtonIcon: "sync",
   importButtonText: i18next.t("Import files"),


### PR DESCRIPTION
Uppy's `onBeforeFileAdded` callback was only performing duplicate-file checks — it had no quota validation. Additionally, relying on Uppy's `disabled` Dashboard prop triggers  race condition in upstream code: https://github.com/transloadit/uppy/pull/4292

This  PR tries to fix the issue by:
* Adding createFileValidator to reject files exceeding maxFiles/maxStorage
* Enforcing maxFileSize quota in validator and Uppy restrictions
* Showing SUI Dimmer overlay when file count or storage quota is reached (blocking any interactions with Uppy Dashboard)

Fixes https://github.com/inveniosoftware/invenio-app-rdm/issues/3101


<img width="902" height="654" alt="Screenshot 2026-07-10 at 15 27 35" src="https://github.com/user-attachments/assets/5cb5bca4-66e3-4384-aa23-df28178f5bf3" />


### Description

> Please describe briefly your pull request.



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
