### PR TITLE
fix: handle empty CROSSREF_PREFIX and/or DATACITE_PREFIX addresses #2386

### DIFF
--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -23,7 +23,9 @@ class BlockedPrefixes:
 
     @property
     def prefixes(self):
-        """Get list of blocked prefixes. Can be string, list or dict in config."""
+        """Get list of blocked prefixes. Can be string, list or dict in config.
+
+        Do not include empty strings."""
         _prefixes = []
         for name in self._config_names:
             val = current_app.config[name]
@@ -36,7 +38,7 @@ class BlockedPrefixes:
         return [prefix for prefix in _prefixes + self._prefixes if prefix]
 
     def __call__(self, record, identifier, provider, errors):
-        """Validator call."""
+        """Validator call. Validate the identifier as non-empty and against the blocked prefixes."""
         for p in self.prefixes:
             if p and identifier.startswith(p):
                 errors.append(

--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -33,12 +33,12 @@ class BlockedPrefixes:
                 _prefixes += list(val.values())
             else:
                 _prefixes += val
-        return _prefixes + self._prefixes
+        return [prefix for prefix in _prefixes + self._prefixes if prefix]
 
     def __call__(self, record, identifier, provider, errors):
         """Validator call."""
         for p in self.prefixes:
-            if identifier.startswith(p):
+            if p and identifier.startswith(p):
                 errors.append(
                     _(
                         "The prefix '%(prefix)s' is managed by %(sitename)s. Please supply an external DOI or select 'No' to have a DOI generated for you.",

--- a/invenio_rdm_records/services/pids/providers/external.py
+++ b/invenio_rdm_records/services/pids/providers/external.py
@@ -25,7 +25,8 @@ class BlockedPrefixes:
     def prefixes(self):
         """Get list of blocked prefixes. Can be string, list or dict in config.
 
-        Do not include empty strings."""
+        Do not include empty strings.
+        """
         _prefixes = []
         for name in self._config_names:
             val = current_app.config[name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,24 +11,15 @@ description = "InvenioRDM module for the communities feature."
 readme = "README.rst"
 requires-python = ">=3.9"
 license = "MIT"
-authors = [
-  { name = "CERN", email = "info@inveniosoftware.org" },
-]
-keywords = [
-  "data",
-  "invenio",
-  "model",
-  "rdm",
-]
-classifiers = [
-  "Development Status :: 5 - Production/Stable",
-]
+authors = [{ name = "CERN", email = "info@inveniosoftware.org" }]
+keywords = ["data", "invenio", "model", "rdm"]
+classifiers = ["Development Status :: 5 - Production/Stable"]
 dependencies = [
   "arrow>=0.17.0",
   "babel-edtf>=1.2.0",
   "citeproc-py>=0.6.0",
   "citeproc-py-styles>=0.1.2,<1.0.0",
-  "commonmeta-py>=0.215,<1.0.0",
+  "commonmeta-py>=0.256,<1.0.0",
   "datacite>=1.1.1,<2.0.0",
   "dcxml>=0.1.2,<1.0.0",
   "faker>=2.0.3",
@@ -162,15 +153,9 @@ block = "invenio_rdm_records.requests.user_moderation.actions:on_block"
 restore = "invenio_rdm_records.requests.user_moderation.actions:on_restore"
 
 [project.optional-dependencies]
-elasticsearch7 = [
-  "invenio-search[elasticsearch7]>=3.0.0,<4.0.0",
-]
-opensearch1 = [
-  "invenio-search[opensearch1]>=3.0.0,<4.0.0",
-]
-opensearch2 = [
-  "invenio-search[opensearch2]>=3.0.0,<4.0.0",
-]
+elasticsearch7 = ["invenio-search[elasticsearch7]>=3.0.0,<4.0.0"]
+opensearch1 = ["invenio-search[opensearch1]>=3.0.0,<4.0.0"]
+opensearch2 = ["invenio-search[opensearch2]>=3.0.0,<4.0.0"]
 tests = [
   "invenio-app>=3.0.0,<4.0.0",
   "invenio-db[postgresql,mysql]>=2.2.0,<3.0.0",
@@ -225,9 +210,7 @@ encoding = "utf-8"
 path = "invenio_rdm_records/__init__.py"
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "/invenio_rdm_records",
-]
+include = ["/invenio_rdm_records"]
 
 [tool.isort]
 profile = "black"
@@ -249,5 +232,5 @@ conflicts = [
     { extra = "opensearch1" },
     { extra = "opensearch2" },
     { extra = "elasticsearch7" },
-  ]
+  ],
 ]

--- a/tests/resources/serializers/test_crossref_serializer.py
+++ b/tests/resources/serializers/test_crossref_serializer.py
@@ -15,11 +15,11 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         "provider": "crossref",
         "client": "crossref",
     }
-    full_record_to_dict["metadata"]["resource_type"]["id"] = "publication-preprint"
+    full_record_to_dict["metadata"]["resource_type"]["id"] = "poster"
     full_record_to_dict["metadata"]["publication_date"] = "2018-01-01"
     expected_data = """
 <?xml version="1.0" encoding="utf-8"?>
-<doi_batch xmlns="http://www.crossref.org/schema/5.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" version="5.4.0">
+<doi_batch xmlns="http://www.crossref.org/schema/5.5.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" version="5.5.0">
   <head>
     <doi_batch_id>352789d5-4785-4ab6-8426-cc34773d3acd</doi_batch_id>
     <timestamp>20251101134647</timestamp>
@@ -30,7 +30,7 @@ def test_crossref_serializer(running_app, full_record_to_dict):
     <registrant>test</registrant>
   </head>
   <body>
-    <posted_content type="other" language="da">
+    <posted_content type="poster" language="da">
       <contributors>
         <person_name contributor_role="author" sequence="first">
           <given_name>Lars Holm</given_name>
@@ -40,6 +40,15 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         <person_name contributor_role="author" sequence="additional">
           <given_name>Blabin</given_name>
           <surname>Tom</surname>
+        </person_name>
+        <person_name contributor_role="other" sequence="additional">
+          <given_name>Lars Holm</given_name>
+          <surname>Nielsen</surname>
+          <ORCID>https://orcid.org/0000-0001-8135-3489</ORCID>
+        </person_name>
+        <person_name contributor_role="other" sequence="additional">
+          <given_name>Dirkin</given_name>
+          <surname>Dirk</surname>
         </person_name>
       </contributors>
       <titles>
@@ -65,6 +74,11 @@ def test_crossref_serializer(running_app, full_record_to_dict):
           <fr:assertion name="funder_name">Caltech Library</fr:assertion>
         </fr:assertion>
       </fr:program>
+      <rel:program xmlns:rel="http://www.crossref.org/relations.xsd" name="relations">
+        <rel:related_item>
+          <rel:intra_work_relation relationship-type="isVersionOf" identifier-type="doi">10.1234/pgfpj-at058</rel:intra_work_relation>
+        </rel:related_item>
+      </rel:program>
       <version_info>
         <version>v1.0</version>
       </version_info>

--- a/tests/services/pids/providers/test_external_pid_provider.py
+++ b/tests/services/pids/providers/test_external_pid_provider.py
@@ -7,9 +7,13 @@
 
 import pytest
 from invenio_pidstore.models import PersistentIdentifier, PIDStatus
+from flask import current_app
 
 from invenio_rdm_records.records import RDMDraft, RDMRecord
-from invenio_rdm_records.services.pids.providers import ExternalPIDProvider
+from invenio_rdm_records.services.pids.providers import (
+    BlockedPrefixes,
+    ExternalPIDProvider,
+)
 
 
 @pytest.fixture(scope="function")
@@ -85,3 +89,31 @@ def test_external_provider_validate_failure(running_app, db, external_provider, 
     success, errors = external_provider.validate(record=record, provider="external")
     assert not success
     assert "Missing DOI for required field." in errors[0]["messages"]
+
+
+def test_blocked_prefixes_ignores_empty_prefix(running_app):
+    """Ensure empty configured prefixes do not block all external DOIs."""
+    old_config = dict(current_app.config)
+    current_app.config.update(
+        {
+            "THEME_SITENAME": "TestSite",
+            "DATACITE_PREFIX": "",
+            "CROSSREF_PREFIX": "",
+        }
+    )
+
+    try:
+        validator = BlockedPrefixes(config_names=["DATACITE_PREFIX", "CROSSREF_PREFIX"])
+        errors = []
+
+        validator(
+            record=None,
+            identifier="10.1234/external",
+            provider="external",
+            errors=errors,
+        )
+
+        assert errors == []
+    finally:
+        current_app.config.clear()
+        current_app.config.update(old_config)

--- a/tests/services/pids/providers/test_external_pid_provider.py
+++ b/tests/services/pids/providers/test_external_pid_provider.py
@@ -6,8 +6,8 @@
 """External provider tests."""
 
 import pytest
-from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 from flask import current_app
+from invenio_pidstore.models import PersistentIdentifier, PIDStatus
 
 from invenio_rdm_records.records import RDMDraft, RDMRecord
 from invenio_rdm_records.services.pids.providers import (


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Fixes issue #2386 where an empty CROSSREF_PREFIX or DATACITE_PREFIX disables external DOIs.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
