### PR TITLE
fix: commonmeta changed crossref schema to 5.5.0

### DIFF
--- a/tests/resources/serializers/test_crossref_serializer.py
+++ b/tests/resources/serializers/test_crossref_serializer.py
@@ -19,7 +19,7 @@ def test_crossref_serializer(running_app, full_record_to_dict):
     full_record_to_dict["metadata"]["publication_date"] = "2018-01-01"
     expected_data = """
 <?xml version="1.0" encoding="utf-8"?>
-<doi_batch xmlns="http://www.crossref.org/schema/5.4.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" version="5.4.0">
+<doi_batch xmlns="http://www.crossref.org/schema/5.5.0" xmlns:ai="http://www.crossref.org/AccessIndicators.xsd" xmlns:rel="http://www.crossref.org/relations.xsd" xmlns:fr="http://www.crossref.org/fundref.xsd" version="5.5.0">
   <head>
     <doi_batch_id>352789d5-4785-4ab6-8426-cc34773d3acd</doi_batch_id>
     <timestamp>20251101134647</timestamp>
@@ -30,7 +30,7 @@ def test_crossref_serializer(running_app, full_record_to_dict):
     <registrant>test</registrant>
   </head>
   <body>
-    <posted_content type="other" language="da">
+    <posted_content type="preprint" language="da">
       <contributors>
         <person_name contributor_role="author" sequence="first">
           <given_name>Lars Holm</given_name>
@@ -40,6 +40,15 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         <person_name contributor_role="author" sequence="additional">
           <given_name>Blabin</given_name>
           <surname>Tom</surname>
+        </person_name>
+        <person_name contributor_role="other" sequence="additional">
+          <given_name>Lars Holm</given_name>
+          <surname>Nielsen</surname>
+          <ORCID>https://orcid.org/0000-0001-8135-3489</ORCID>
+        </person_name>
+        <person_name contributor_role="other" sequence="additional">
+          <given_name>Dirkin</given_name>
+          <surname>Dirk</surname>
         </person_name>
       </contributors>
       <titles>
@@ -65,6 +74,11 @@ def test_crossref_serializer(running_app, full_record_to_dict):
           <fr:assertion name="funder_name">Caltech Library</fr:assertion>
         </fr:assertion>
       </fr:program>
+      <rel:program xmlns:rel="http://www.crossref.org/relations.xsd" name="relations">
+        <rel:related_item>
+          <rel:intra_work_relation relationship-type="isVersionOf" identifier-type="doi">10.1234/pgfpj-at058</rel:intra_work_relation>
+        </rel:related_item>
+      </rel:program>
       <version_info>
         <version>v1.0</version>
       </version_info>


### PR DESCRIPTION
### Description

Recent commonmeta changes caused test in rdm-records not working.

Note: needs to be backported to RDM14


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
