### PR TITLE
fix(uppy): keep failed uploads in dashboard on complete

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/UppyUploader/RDMUppyUploaderPlugin.js
@@ -55,9 +55,9 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
   install() {
     AwsS3Multipart.prototype.install.apply(this);
     this.uppy.on("upload-success", this.#completeSinglePartUpload);
+    this.uppy.on("upload-success", this.#removeFileOnSuccess);
     this.uppy.on("upload-progress", this.#onUploadProgress);
     this.uppy.on("file-removed", this.#onFileRemoved);
-    this.uppy.on("complete", this.#resetOnComplete);
     this.uppy.addPreProcessor(this.#saveDraftBeforeUpload);
     // Disable resumable uploads Uppy capability.
     // Currently unsupported, as it requires missing API
@@ -68,9 +68,9 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
   uninstall() {
     AwsS3Multipart.prototype.uninstall.apply(this);
     this.uppy.off("upload-success", this.#completeSinglePartUpload);
+    this.uppy.off("upload-success", this.#removeFileOnSuccess);
     this.uppy.off("upload-progress", this.#onUploadProgress);
     this.uppy.off("file-removed", this.#onFileRemoved);
-    this.uppy.off("complete", this.#resetOnComplete);
     this.uppy.removePreProcessor(this.#saveDraftBeforeUpload);
     this.uppy.removePreProcessor(this.#disableResumableUploadsCapability);
   }
@@ -115,8 +115,10 @@ export class RDMUppyUploaderPlugin extends AwsS3Multipart {
     }
   };
 
-  #resetOnComplete = (result) => {
-    this.uppy.cancelAll();
+  #removeFileOnSuccess = (file) => {
+    // Remove successful uploads from Uppy state so they disappear from the Dashboard.
+    // Failed uploads remain available for retry/removal.
+    this.uppy.removeFile(file.id);
   };
 
   #saveDraftBeforeUpload = async (fileIDs) => {


### PR DESCRIPTION

:heart: Thank you for your contribution!

### Description

Fixes the dashboard reset behavior so that successful uploads are removed from the Uppy Dashboard immediately, while failed uploads remain available for retry/removal.

The previous implementation relied on complete event to remove all completed files (success + fail) from the Dashboard so users could upload more. Meaning that failed files could not be cleanly retried.

#### Solution

Remove successful files on the upload-success event instead of complete. Failed files stay in the Dashboard because upload-success is not emitted for them.

Related: https://github.com/inveniosoftware/invenio-app-rdm/issues/3101

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
