### PR TITLE
fix(files): extract metadata after draft publication

### DIFF
--- a/invenio_rdm_records/services/permissions.py
+++ b/invenio_rdm_records/services/permissions.py
@@ -130,6 +130,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
         IfRestricted("files", then_=SameAs("can_view"), else_=SameAs("can_all")),
         ResourceAccessToken("read"),
     ]
+    can_extract_file_metadata = [SystemProcess()]
     can_get_content_files = [
         # note: even though this is closer to business logic than permissions,
         # it was simpler and less coupling to implement this as permission check
@@ -178,6 +179,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     ]
     can_draft_update_files = SameAs("can_review")
     can_draft_delete_files = SameAs("can_review")
+    can_draft_extract_file_metadata = [SystemProcess()]
 
     can_draft_get_file_transfer_metadata = [SystemProcess()]
     can_draft_update_file_transfer_metadata = [SystemProcess()]
@@ -293,6 +295,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
     ]
     can_draft_media_update_files = SameAs("can_review")
     can_draft_media_delete_files = SameAs("can_review")
+    can_draft_media_extract_file_metadata = [SystemProcess()]
 
     #
     # Media files - record
@@ -301,6 +304,7 @@ class RDMRecordPermissionPolicy(RecordPermissionPolicy):
         IfRestricted("record", then_=SameAs("can_view"), else_=SameAs("can_all")),
         ResourceAccessToken("read"),
     ]
+    can_media_extract_file_metadata = [SystemProcess()]
     can_media_get_content_files = [
         # note: even though this is closer to business logic than permissions,
         # it was simpler and less coupling to implement this as permission check


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

Closes https://github.com/CERNDocumentServer/cds-rdm/issues/861
Related pr: https://github.com/inveniosoftware/invenio-records-resources/pull/702
Solves point 8 of https://codimd.web.cern.ch/s/DBWeY3d5y


This is the RDM Records configuration for the fallback added in the related invenio-records-resources PR. It fixes the Failed to extract file metadata errors seen in the INSPIRE harvester when a draft is published before the queued extraction task starts.
For normal record files, the task first uses draft-files. If the draft has already been published and no longer exists, it continues through the published files service. The same setup is added for media files, using draft-media-files first and media-files as the fallback.
The published services need permission to run this specific operation, but the existing create_files permission is disabled for published records because published files should not be uploaded or replaced directly. To avoid weakening that restriction, this PR adds a separate extract_file_metadata action that is only allowed for SystemProcess(), which is the internal identity used by the background task.
This permission only lets the internal task read an existing file and save technical information extracted from it, such as image width and height or ZIP archive information. It does not allow users to change published record metadata, upload or replace files, modify file content, or change the file list.
The integration test reproduces the original order of events: it uploads and commits a ZIP file, publishes the draft before running the queued task, then runs the task and checks the published file. The test confirms that the task falls back to the published service and that zip_toc_position is saved successfully instead of producing the harvester error.

<img width="1421" height="594" alt="image" src="https://github.com/user-attachments/assets/a1ed99b7-2b3c-431f-b0c4-52a5b129b170" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
