### PR TITLE
fix(checks): explicitly add target_type

### DIFF
--- a/invenio_rdm_records/checks/base.py
+++ b/invenio_rdm_records/checks/base.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Checks integration with record check target."""
+
+from invenio_checks.base import CheckTarget
+
+from invenio_rdm_records.proxies import current_rdm_records_service as service
+
+
+class RecordCheckTarget(CheckTarget):
+    """CheckTarget class for records."""
+
+    id = "record"
+
+    def resolve(self, check_run):
+        """Get the target object for a record check target."""
+        if check_run.is_draft:
+            return service.draft_cls.get_record(check_run.record_id)
+
+        return service.record_cls.get_record(check_run.record_id)

--- a/invenio_rdm_records/checks/requests.py
+++ b/invenio_rdm_records/checks/requests.py
@@ -37,7 +37,7 @@ class SubmissionCreateAction(BaseCommunitySubmissionCreateAction):
             if community.parent:
                 community_ids.add(str(community.parent.id))
 
-            configs = ChecksAPI.get_configs(community_ids)
+            configs = ChecksAPI.get_configs(community_ids, target_type="record")
             for config in configs:
                 ChecksAPI.run_check(config, draft, uow)
 
@@ -115,7 +115,7 @@ class InclusionSubmitAction(community_inclusion.SubmitAction):
                 if community_parent_id:
                     community_ids.add(community_parent_id)
 
-            configs = ChecksAPI.get_configs(community_ids)
+            configs = ChecksAPI.get_configs(community_ids, target_type="record")
             for config in configs:
                 ChecksAPI.run_check(config, record, uow, is_draft=record.has_draft)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,9 @@ approve = "invenio_rdm_records.requests.user_moderation.actions:on_approve"
 block = "invenio_rdm_records.requests.user_moderation.actions:on_block"
 restore = "invenio_rdm_records.requests.user_moderation.actions:on_restore"
 
+[project.entry-points."invenio_checks.check_targets"]
+record = "invenio_rdm_records.checks.base:RecordCheckTarget"
+
 [project.optional-dependencies]
 elasticsearch7 = ["invenio-search[elasticsearch7]>=3.0.0,<4.0.0"]
 opensearch1 = ["invenio-search[opensearch1]>=3.0.0,<4.0.0"]


### PR DESCRIPTION
:heart: Thank you for your review!

### Description

Explicitly add target_type to ChecksAPI.get_configs to ensure that only matching check_runs are queried, i.e. check_runs with target type "record" are queried for records, and  check_runs with target type "community" are queried for subcommunities.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
