### PR TITLE
chore: add dev dependency group for simple local setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,11 @@ tests = [
   "tripoli>=2.0.0",
 ]
 
+[dependency-groups]
+dev = [
+  "invenio-rdm-records[tests,opensearch2]",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
If we introduce appropriate `dev` dependency groups (which are like extras but just for local setups, not included in distribution wheels for users), we get to use one single command for any of our packages to install the dependencies required to locally develop and run tests: `uv sync` (the `dev` group is included by default), or `pip install --group dev .` if you prefer `pip`
Other package managers likely have support too since dependency groups are a PEP (see below), but I haven't checked.

Having just a single command to install a local dev setup also enables us to simplify the GitHub action workflows by removing the necessity to explicitly list the dependencies, e.g. here: https://github.com/inveniosoftware/invenio-oauthclient/blob/v9.1.1/.github/workflows/tests.yml#L37

---

From the commit message:
* can be used via `uv sync` or `pip install --group dev .`
* this replaces `uv sync --extras=tests,opensearch2` and `pip install -e '.[tests,opensearch2]'`, respectively
* it offers a unified command interface for getting the necessary dependencies for local development and testing installed
* cf. https://packaging.python.org/en/latest/specifications/dependency-groups/

---

`uv` recently had a bug that prevented dependency groups from working in many of our setups, but that just got fixed (and released as part of `uv` 0.12.0 yesterday): https://github.com/astral-sh/uv/issues/19106#event-28602192132