### PR TITLE
fix(quota-increase): resolve draft by string recid, not int

### DIFF
--- a/invenio_rdm_records/requests/quota_increase.py
+++ b/invenio_rdm_records/requests/quota_increase.py
@@ -38,7 +38,11 @@ class AcceptAction(actions.AcceptAction):
 
     def execute(self, identity, uow, **kwargs):
         """Apply the quota increase."""
-        DRAFT = int(self.request.get("topic", {}).get("record"))
+        # ``topic.record`` is the record's PID value, and ``pid_value`` is a
+        # ``String`` column, so ``set_quota`` must receive it as-is. Casting it to
+        # ``int`` assumes numeric-only recids and raises ``ValueError`` for the
+        # alphanumeric recids InvenioRDM mints by default (e.g. "07cy4-9tg98").
+        DRAFT = self.request.get("topic", {}).get("record")
         QUOTA_SIZE = int(self.request.get("payload", {}).get("quota_size"))
         data = {
             "notes": f"request_id:{str(self.request.id)}",


### PR DESCRIPTION
## Summary

`QuotaIncrease`'s `AcceptAction` casts the topic record reference to `int` before passing it to `set_quota`:

```python
DRAFT = int(self.request.get("topic", {}).get("record"))
...
records_service.set_quota(system_identity, DRAFT, data)
```

This raises `ValueError` for any record whose recid is not purely numeric — i.e. the **default alphanumeric recids InvenioRDM mints** (e.g. `07cy4-9tg98`):

```
ValueError: invalid literal for int() with base 10: '07cy4-9tg98'
```

## Why the cast is wrong (and unnecessary)

`topic.record` is a record's PID **`pid_value`**, and `pid_value` is a `String(255)` column:

```python
# invenio_pidstore/models.py
pid_value = db.Column(db.String(255), nullable=False)
```

`set_quota` resolves the draft via `self.draft_cls.pid.resolve(id_)`, and resolution stringifies its input before querying:

```python
# invenio_pidstore/models.py — PersistentIdentifier.get
args = dict(pid_type=pid_type, pid_value=six.text_type(pid_value))
```

So the resolver already accepts either a string or an int and coerces to string. The `int()` cast is therefore:

- **redundant** for numeric recids (`"123456"` → `123456` → `"123456"` — a lossless round-trip the resolver would have done anyway), and
- **fatal** for alphanumeric recids, because it fails at the cast before the resolver's `str()` coercion is ever reached.

The cast only ever "worked" because it was historically exercised with numeric (Zenodo-style) recids.

## Fix

Pass the recid through unchanged:

```python
DRAFT = self.request.get("topic", {}).get("record")
```

Behaviour is unchanged for numeric recids (still resolved, as strings) and fixed for alphanumeric recids. `QUOTA_SIZE` is left as `int(...)` since that value is genuinely numeric.

## Test plan

- Submit a quota-increase request against a record with a default alphanumeric recid → accept action now applies the quota instead of raising `ValueError`.
- Numeric recids continue to resolve as before.