### PR TITLE
fix(quota): don't cast record id to int

### DIFF
--- a/invenio_rdm_records/requests/quota_increase.py
+++ b/invenio_rdm_records/requests/quota_increase.py
@@ -38,8 +38,8 @@ class AcceptAction(actions.AcceptAction):
 
     def execute(self, identity, uow, **kwargs):
         """Apply the quota increase."""
-        DRAFT = int(self.request.get("topic", {}).get("record"))
-        QUOTA_SIZE = int(self.request.get("payload", {}).get("quota_size"))
+        DRAFT = self.request["topic"]["record"]
+        QUOTA_SIZE = int(self.request["payload"]["quota_size"])
         data = {
             "notes": f"request_id:{str(self.request.id)}",
             "quota_size": QUOTA_SIZE * 1000000000,

--- a/tests/requests/test_quota_increase.py
+++ b/tests/requests/test_quota_increase.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Test quota increase requests."""
+
+import pytest
+
+from invenio_rdm_records.proxies import current_rdm_records_service as records_service
+from invenio_rdm_records.services.request_policies import QuotaIncreasePolicy
+
+
+@pytest.fixture(scope="module")
+def app_config(app_config):
+    """Enable self-service quota increases."""
+    app_config["RDM_IMMEDIATE_QUOTA_INCREASE_ENABLED"] = True
+    app_config["RDM_IMMEDIATE_QUOTA_INCREASE_POLICIES"] = [QuotaIncreasePolicy()]
+    app_config["RDM_FILES_DEFAULT_MAX_ADDITIONAL_QUOTA_SIZE"] = 50 * 10**9
+    return app_config
+
+
+def test_quota_increase_with_non_integer_pid(
+    running_app, minimal_record, uploader, location
+):
+    """Quota increase works with the default (non-integer) record identifiers."""
+    draft = records_service.create(uploader.identity, minimal_record)
+    assert not draft.id.isdigit()  # the default provider mints alphanumeric ids
+
+    records_service.quota_increase(uploader.identity, draft.id, {"quota_size": "10"})
+
+    draft = records_service.read_draft(uploader.identity, draft.id)
+    assert draft._record.files.bucket.quota_size == 10 * 10**9


### PR DESCRIPTION
* The topic record id is a PID value, which is a string for any instance
  using the default alphanumeric provider. Only repositories that mint
  numeric recids (e.g. Zenodo) could accept a quota increase request.
