### PR TITLE
fix(file-modification): handle validation errors

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileModification/ModificationModal.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/FileModification/ModificationModal.js
@@ -8,7 +8,7 @@ import { Formik } from "formik";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
 import Overridable from "react-overridable";
-import { save } from "../../../state/actions";
+import { save, hasValidationErrorsWithSeverityError } from "../../../state/actions";
 import { connect } from "react-redux";
 
 import { ErrorMessage, http, withCancel } from "react-invenio-forms";
@@ -100,12 +100,25 @@ class ModificationModalComponent extends Component {
     }
 
     // save draft before reloading the page
-    await saveAction(draft, {});
-
-    this.cancellableAction = withCancel(
-      http.post(record.links.file_modification, payload)
-    );
     try {
+      await saveAction(draft, {});
+    } catch (saveError) {
+      // warnings don't block reload, but errors do
+      if (hasValidationErrorsWithSeverityError(saveError?.errors)) {
+        this.setState({
+          loading: false,
+          error: i18next.t(
+            "Your record has validation errors that must be fixed before enabling file editing."
+          ),
+        });
+        return;
+      }
+    }
+
+    try {
+      this.cancellableAction = withCancel(
+        http.post(record.links.file_modification, payload)
+      );
       const response = await this.cancellableAction.promise;
       const data = response.data;
 

--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/state/actions/deposit.js
@@ -63,7 +63,7 @@ export const saveDraftWithUrlUpdate = async (draft, draftsService) => {
   return response;
 };
 
-function _hasValidationErrorsWithSeverityError(errors) {
+export function hasValidationErrorsWithSeverityError(errors) {
   if (typeof errors === "object") {
     if (
       Object.hasOwn(errors, "message") &&
@@ -76,7 +76,7 @@ function _hasValidationErrorsWithSeverityError(errors) {
     }
     for (const key of Object.keys(errors)) {
       if (key !== "message" && key !== "severity" && key !== "description") {
-        return _hasValidationErrorsWithSeverityError(errors[key]);
+        return hasValidationErrorsWithSeverityError(errors[key]);
       }
     }
   } else {
@@ -110,7 +110,7 @@ async function _saveDraft(
   }
 
   const draftHasValidationErrors = showOnlyValidationErrorsWithSeverityError
-    ? _hasValidationErrorsWithSeverityError(response.errors)
+    ? hasValidationErrorsWithSeverityError(response.errors)
     : !_isEmpty(response.errors);
   const draftValidationErrorResponse = draftHasValidationErrors ? response : {};
 


### PR DESCRIPTION
:heart: Thank you for your review!

When clicking "Enable file editing", the modal would freeze in a loading state if the draft had any validation errors or warnings. `saveAction` threw on validation issues but the call was outside the try/catch/finally, so loading was never reset.

Now, saveAction is covered by try/catch, with blocking errors surfacing an error message in the modal, while warning errors are non-blocking and the file modification request proceeds. This behavior is consistent with the publish and preview flows.

**Before** - stayed loading indefinitely 
<img width="1306" height="607" alt="image" src="https://github.com/user-attachments/assets/63bd607f-1dc7-4d34-8d68-057c6f33104b" />


**After**
<img width="1286" height="602" alt="image" src="https://github.com/user-attachments/assets/e7c412f3-356f-4daa-b2f9-4f828a3be4da" />



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
