### PR TITLE
fix(alembic): pin alembic due to test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [{ name = "CERN", email = "info@inveniosoftware.org" }]
 keywords = ["data", "invenio", "model", "rdm"]
 classifiers = ["Development Status :: 5 - Production/Stable"]
 dependencies = [
+  "alembic<1.19",  # v1.19 causes test failures
   "arrow>=0.17.0",
   "babel-edtf>=1.2.0",
   "citeproc-py>=0.6.0",


### PR DESCRIPTION
Alembic 1.19.0 has been released yesterday (2026-08-04), and causes test failures.

It seems like we're getting a reality `CHECK` ( :sunglasses: ): https://alembic.sqlalchemy.org/en/latest/changelog.html#change-fef61c6df0e43e54e99b62afd912db40

>  FAILED tests/test_alembic.py::test_alembic - RuntimeError: Unexpected migration: ('add_constraint', CheckConstraint(<sqlalchemy.sql.elements.TextClause object at 0x7f03941d5ed0>, name='ck_communities_members_user_or_group', table=Table('communities_members', MetaData(), Column('x', Integer(), table=<communities_members>), schema=None)))

---

The [`alembic` docs](https://alembic.sqlalchemy.org/en/latest/autogenerate.html#detecting-check-constraints) mention this being implemented via a plugin that can be disabled:
> This detection is implemented as a built-in [plugin](https://alembic.sqlalchemy.org/en/latest/api/plugins.html#alembic-plugins-toplevel) named alembic.autogenerate.checkconstraint_byname, which is part of the alembic.autogenerate.* wildcard and therefore active by default. If this behavior is not desired, for example if the name-only comparison is producing unwanted false negatives on constraint changes, it can be turned off by excluding it from the [EnvironmentContext.configure.autogenerate_plugins](https://alembic.sqlalchemy.org/en/latest/api/runtime.html#alembic.runtime.environment.EnvironmentContext.configure.params.autogenerate_plugins) list:

Perhaps that would be a better way forward than pinning `alembic` as a quick fix (though I don't know from the top of my head where we configure this in Invenio).

In the long run, a more proper fix would be the most desirable; that might include a revision though (and thus not make it into v14)?