### PR TITLE
feat: new ChecksRun API for RDMRecords

### DIFF
--- a/invenio_rdm_records/ext.py
+++ b/invenio_rdm_records/ext.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2019-2026 CERN.
 # SPDX-FileCopyrightText: 2019-2021 Northwestern University.
 # SPDX-FileCopyrightText: 2022 Universität Hamburg.
-# SPDX-FileCopyrightText: 2023-2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2023-2026 Graz University of Technology.
 # SPDX-FileCopyrightText: 2023 TU Wien.
 # SPDX-FileCopyrightText: 2025 KTH Royal Institute of Technology.
 # SPDX-License-Identifier: MIT
@@ -39,6 +39,7 @@ from .resources import (
     RDMParentGrantsResourceConfig,
     RDMParentRecordLinksResource,
     RDMParentRecordLinksResourceConfig,
+    RDMRecordChecksResource,
     RDMRecordCommunitiesResourceConfig,
     RDMRecordFilesResourceConfig,
     RDMRecordRequestsResourceConfig,
@@ -47,6 +48,7 @@ from .resources import (
 )
 from .resources.config import (
     RDMDraftMediaFilesResourceConfig,
+    RDMRecordChecksResourceConfig,
     RDMRecordMediaFilesResourceConfig,
 )
 from .resources.resources import RDMRecordCommunitiesResource, RDMRecordRequestsResource
@@ -63,11 +65,13 @@ from .services import (
     RecordAccessService,
     RecordRequestsService,
 )
+from .services.checks import RDMRecordChecksService
 from .services.communities.service import RecordCommunitiesService
 from .services.community_inclusion.service import CommunityInclusionService
 from .services.config import (
     RDMMediaFileDraftServiceConfig,
     RDMMediaFileRecordServiceConfig,
+    RDMRecordChecksServiceConfig,
     RDMRecordMediaFilesServiceConfig,
 )
 from .services.files import RDMFileService
@@ -157,6 +161,7 @@ class InvenioRDMRecords(object):
             record_communities = RDMRecordCommunitiesConfig.build(app)
             community_records = RDMCommunityRecordsConfig.build(app)
             record_requests = RDMRecordRequestsConfig.build(app)
+            record_checks = RDMRecordChecksServiceConfig.build(app)
 
         return ServiceConfigs
 
@@ -207,6 +212,11 @@ class InvenioRDMRecords(object):
         self.community_collections_service = CollectionsService(
             config=CollectionServiceConfig.build(app),
             records_service=self.community_records_service,
+        )
+
+        # Checks
+        self.checks_service = RDMRecordChecksService(
+            config=RDMRecordChecksServiceConfig.build(app),
         )
 
     def init_resource(self, app):
@@ -293,6 +303,12 @@ class InvenioRDMRecords(object):
         self.community_collections_resource = CollectionsResource(
             service=self.community_collections_service,
             config=RDMCollectionsResourceConfig.build(app),
+        )
+
+        # Checks
+        self.checks_resource = RDMRecordChecksResource(
+            service=self.checks_service,
+            config=RDMRecordChecksResourceConfig.build(app),
         )
 
     def fix_datacite_configs(self, app):

--- a/invenio_rdm_records/resources/__init__.py
+++ b/invenio_rdm_records/resources/__init__.py
@@ -12,6 +12,7 @@ from .config import (
     RDMGrantUserAccessResourceConfig,
     RDMParentGrantsResourceConfig,
     RDMParentRecordLinksResourceConfig,
+    RDMRecordChecksResourceConfig,
     RDMRecordCommunitiesResourceConfig,
     RDMRecordFilesResourceConfig,
     RDMRecordRequestsResourceConfig,
@@ -23,6 +24,7 @@ from .resources import (
     RDMGrantsAccessResource,
     RDMParentGrantsResource,
     RDMParentRecordLinksResource,
+    RDMRecordChecksResource,
     RDMRecordRequestsResource,
     RDMRecordResource,
 )
@@ -47,4 +49,6 @@ __all__ = (
     "RDMRecordRequestsResourceConfig",
     "RDMRecordResource",
     "RDMRecordResourceConfig",
+    "RDMRecordChecksResource",
+    "RDMRecordChecksResourceConfig",
 )

--- a/invenio_rdm_records/resources/config.py
+++ b/invenio_rdm_records/resources/config.py
@@ -13,12 +13,14 @@ from citeproc_styles import StyleNotFoundError
 from flask_resources import (
     JSONDeserializer,
     JSONSerializer,
+    MultiDictSchema,
     RequestBodyParser,
     ResourceConfig,
     ResponseHandler,
     create_error_handler,
     resource_requestctx,
 )
+from invenio_checks.resources.args import ChecksSearchRequestArgsSchema
 from invenio_collections.resources.config import CollectionsResourceConfig
 from invenio_communities.communities.resources import CommunityResourceConfig
 from invenio_communities.communities.resources.config import community_error_handlers
@@ -30,6 +32,7 @@ from invenio_records_resources.resources.files import FileResourceConfig
 from invenio_records_resources.resources.records.headers import etag_headers
 from invenio_records_resources.services.base.config import ConfiguratorMixin, FromConfig
 from invenio_requests.resources.requests.config import RequestSearchRequestArgsSchema
+from marshmallow import Schema, fields
 
 from ..services.errors import (
     AccessRequestExistsError,
@@ -641,4 +644,27 @@ class RDMCollectionsResourceConfig(CollectionsResourceConfig):
         "application/vnd.inveniordm.v1+json": ResponseHandler(
             UIJSONSerializer(), headers=etag_headers
         ),
+    }
+
+
+class RDMRecordChecksResourceConfig(ResourceConfig, ConfiguratorMixin):
+    """Record checks resource config."""
+
+    blueprint_name = "record_checks"
+    url_prefix = "/records"
+    routes = {
+        "list": "/<pid_value>/checks",
+    }
+
+    request_search_args = ChecksSearchRequestArgsSchema
+
+    request_view_args = {
+        "pid_value": ma.fields.Str(),
+    }
+
+    response_handlers = {
+        "application/vnd.inveniordm.v1+json": ResourceConfig.response_handlers[
+            "application/json"
+        ],
+        **ResourceConfig.response_handlers,
     }

--- a/invenio_rdm_records/resources/resources.py
+++ b/invenio_rdm_records/resources/resources.py
@@ -847,3 +847,32 @@ class RDMCommunityRecordsResource(RecordResource):
         if errors:
             response["errors"] = errors
         return response, 200
+
+
+class RDMRecordChecksResource(ErrorHandlersMixin, Resource):
+    """Record checks resource."""
+
+    def __init__(self, config, service):
+        """Constructor."""
+        super().__init__(config)
+        self.service = service
+
+    def create_url_rules(self):
+        """Create the URL rules for the record resource."""
+        routes = self.config.routes
+        url_rules = [
+            route("GET", routes["list"], self.search),
+        ]
+        return url_rules
+
+    @request_search_args
+    @request_view_args
+    @response_handler(many=True)
+    def search(self):
+        """Search for record's check runs."""
+        items = self.service.search(
+            identity=g.identity,
+            id_=resource_requestctx.view_args["pid_value"],
+            params=resource_requestctx.args,
+        )
+        return items.to_dict(), 200

--- a/invenio_rdm_records/services/__init__.py
+++ b/invenio_rdm_records/services/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2023-2024 CERN.
 # SPDX-FileCopyrightText: 2022 Universität Hamburg.
+# SPDX-FileCopyrightText: 2026 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """High-level API for wokring with RDM records, files, pids and search."""
@@ -10,6 +11,7 @@ from .config import (
     RDMCommunityRecordsConfig,
     RDMFileDraftServiceConfig,
     RDMFileRecordServiceConfig,
+    RDMRecordChecksServiceConfig,
     RDMRecordCommunitiesConfig,
     RDMRecordMediaFilesServiceConfig,
     RDMRecordRequestsConfig,
@@ -34,4 +36,5 @@ __all__ = (
     "RDMRecordRequestsConfig",
     "RecordRequestsService",
     "RDMRecordMediaFilesServiceConfig",
+    "RDMRecordChecksServiceConfig",
 )

--- a/invenio_rdm_records/services/checks/__init__.py
+++ b/invenio_rdm_records/services/checks/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Graz University of Technology.
+# SPDX-License-Identifier: MIT
+
+"""Record checks service."""
+
+from .service import RDMRecordChecksService
+
+__all__ = ("RDMRecordChecksService",)

--- a/invenio_rdm_records/services/checks/service.py
+++ b/invenio_rdm_records/services/checks/service.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Graz University of Technology.
+# SPDX-License-Identifier: MIT
+
+"""RDM Record Checks Service."""
+
+import sqlalchemy as sa
+from invenio_checks.models import CheckRun
+from invenio_pidstore.errors import PIDUnregistered
+from invenio_records_resources.services import LinksTemplate, RecordService
+from invenio_records_resources.services.base.utils import map_search_params
+
+
+class RDMRecordChecksService(RecordService):
+    """Record checks service.
+
+    The checks service is in charge of managing the checks of a given record.
+    """
+
+    @property
+    def record_cls(self):
+        """Factory for creating a record class."""
+        return self.config.record_cls
+
+    @property
+    def draft_cls(self):
+        """Factory for creating a draft class."""
+        return self.config.draft_cls
+
+    def search(self, id_, identity, params):
+        """Search for record's checks runs."""
+        try:
+            record = self.record_cls.pid.resolve(id_)
+        except PIDUnregistered:
+            record = self.draft_cls.pid.resolve(id_, registered_only=False)
+        self.require_permission(identity, "read", record=record)
+
+        check_runs = CheckRun.query.filter(CheckRun.record_id == record.pid.object_uuid)
+
+        return self.result_list(
+            self,
+            identity,
+            check_runs,
+        )

--- a/invenio_rdm_records/services/config.py
+++ b/invenio_rdm_records/services/config.py
@@ -15,6 +15,8 @@ from os.path import splitext
 from pathlib import Path
 
 from flask import current_app
+from invenio_checks.services.results import ChecksRunList, Item
+from invenio_checks.services.schema import CheckRunSchema
 from invenio_communities.communities.records.api import Community
 from invenio_drafts_resources.services.records.components import (
     DraftMediaFilesComponent,
@@ -28,6 +30,7 @@ from invenio_drafts_resources.services.records.config import (
     is_record,
 )
 from invenio_drafts_resources.services.records.search_params import AllVersionsParam
+from invenio_i18n import gettext as _
 from invenio_indexer.api import RecordIndexer
 from invenio_records_resources.services import (
     ConditionalLink,
@@ -62,6 +65,7 @@ from invenio_records_resources.services.records.params import (
 from invenio_requests.services.requests import RequestItem, RequestList
 from invenio_requests.services.requests.config import RequestSearchOptions
 from requests import Request
+from sqlalchemy import asc, desc
 from werkzeug.local import LocalProxy
 
 from invenio_rdm_records.records.processors.tiles import TilesProcessor
@@ -247,6 +251,18 @@ class RDMSearchVersionsOptions(SearchVersionsOptions, SearchOptionsMixin):
     params_interpreters_cls = [
         PublishedRecordsParam
     ] + SearchVersionsOptions.params_interpreters_cls
+
+
+class RDMChecksSearchOptions(SearchOptions):
+    """Checks search options."""
+
+    sort_default = "created"
+    sort_direction_default = "asc"
+    sort_direction_options = {
+        "asc": dict(title=_("Ascending"), fn=asc),
+        "desc": dict(title=_("Descending"), fn=desc),
+    }
+    sort_options = {"created": dict(title=_("Created"), fields=["created"])}
 
 
 #
@@ -852,6 +868,7 @@ class RDMRecordServiceConfig(RecordServiceConfig, ConfiguratorMixin):
                 else None
             ),
         ),
+        "checks": RecordEndpointLink("record_checks.search"),
     }
 
     nested_links_item = [
@@ -988,3 +1005,21 @@ class RDMMediaFileDraftServiceConfig(FileServiceConfig, ConfiguratorMixin):
     name_of_file_blueprint = "draft_media_files"
 
     file_schema = FileSchema
+
+
+class RDMRecordChecksServiceConfig(ServiceConfig, ConfiguratorMixin):
+    """Record communities service config."""
+
+    service_id = "record-checks"
+
+    record_cls = FromConfig("RDM_RECORD_CLS", default=RDMRecord)
+    draft_cls = FromConfig("RDM_DRAFT_CLS", default=RDMDraft)
+    permission_policy_cls = FromConfig(
+        "RDM_PERMISSION_POLICY", default=RDMRecordPermissionPolicy, import_string=True
+    )
+
+    search = RDMChecksSearchOptions
+
+    schema = CheckRunSchema
+    result_list_cls = ChecksRunList
+    result_item_cls = Item

--- a/invenio_rdm_records/views.py
+++ b/invenio_rdm_records/views.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2020-2026 CERN.
 # SPDX-FileCopyrightText: 2021 TU Wien.
 # SPDX-FileCopyrightText: 2022 Universität Hamburg.
-# SPDX-FileCopyrightText: 2024 Graz University of Technology.
+# SPDX-FileCopyrightText: 2024-2026 Graz University of Technology.
 # SPDX-License-Identifier: MIT
 
 """Views."""
@@ -108,6 +108,12 @@ def create_community_collections_bp(app):
     """Create community collections blueprint."""
     ext = app.extensions["invenio-rdm-records"]
     return ext.community_collections_resource.as_blueprint()
+
+
+def create_checks_bp(app):
+    """Create community collections blueprint."""
+    ext = app.extensions["invenio-rdm-records"]
+    return ext.checks_resource.as_blueprint()
 
 
 @blueprint.app_context_processor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ invenio_rdm_records_parent_links = "invenio_rdm_records.views:create_parent_reco
 invenio_rdm_records_record_files = "invenio_rdm_records.views:create_record_files_bp"
 invenio_rdm_records_record_media_files = "invenio_rdm_records.views:create_record_media_files_bp"
 invenio_rdm_records_user_access = "invenio_rdm_records.views:create_grant_user_access_bp"
+invenio_rdm_records_checks = "invenio_rdm_records.views:create_checks_bp"
 
 [project.entry-points."invenio_base.api_finalize_app"]
 invenio_rdm_records = "invenio_rdm_records.ext:api_finalize_app"


### PR DESCRIPTION
  * implement an API to search for all CheckRuns for a particular RDMRecord - at /api/<pid_value>/checks
  * this API is (for now) meant to be used only by other service
    calls, not by the UI

needs https://github.com/inveniosoftware/invenio-checks/pull/85
