### PR TITLE
fix(quota): exclude deleted records from remaining_storage

### DIFF
--- a/invenio_rdm_records/alembic/c2d3e4f5a6b7_add_parent_id_index.py
+++ b/invenio_rdm_records/alembic/c2d3e4f5a6b7_add_parent_id_index.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Add parent_id index."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c2d3e4f5a6b7"
+down_revision = "1780576627"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_index(
+        op.f("ix_rdm_records_metadata_parent_id"),
+        "rdm_records_metadata",
+        ["parent_id"],
+        unique=False,
+    )
+
+    op.create_index(
+        op.f("ix_rdm_drafts_metadata_parent_id"),
+        "rdm_drafts_metadata",
+        ["parent_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_index(
+        op.f("ix_rdm_records_metadata_parent_id"),
+        table_name="rdm_records_metadata",
+    )
+
+    op.drop_index(
+        op.f("ix_rdm_drafts_metadata_parent_id"),
+        table_name="rdm_drafts_metadata",
+    )

--- a/invenio_rdm_records/records/models.py
+++ b/invenio_rdm_records/records/models.py
@@ -93,6 +93,8 @@ class RDMRecordMetadata(db.Model, RecordMetadataBase, ParentRecordMixin):
     __tablename__ = "rdm_records_metadata"
     __parent_record_model__ = RDMParentMetadata
 
+    __table_args__ = (db.Index("ix_rdm_records_metadata_parent_id", "parent_id"),)
+
     # Enable versioning
     __versioned__ = {}
 
@@ -140,6 +142,8 @@ class RDMDraftMetadata(db.Model, DraftMetadataBase, ParentRecordMixin):
 
     __tablename__ = "rdm_drafts_metadata"
     __parent_record_model__ = RDMParentMetadata
+
+    __table_args__ = (db.Index("ix_rdm_drafts_metadata_parent_id", "parent_id"),)
 
     bucket_id = db.Column(UUIDType, db.ForeignKey(Bucket.id), index=True)
     bucket = db.relationship(Bucket, foreign_keys=[bucket_id])

--- a/invenio_rdm_records/services/storage/service.py
+++ b/invenio_rdm_records/services/storage/service.py
@@ -12,13 +12,16 @@ from invenio_accounts.models import User
 from invenio_db import db
 from invenio_files_rest.models import Bucket
 from invenio_search.engine import dsl
-from sqlalchemy import func
+from sqlalchemy import func, or_
 
 from invenio_rdm_records.records.models import (
     RDMDraftMetadata,
     RDMRecordMetadata,
     RDMRecordQuota,
     RDMUserQuota,
+)
+from invenio_rdm_records.records.systemfields.deletion_status import (
+    RecordDeletionStatusEnum,
 )
 
 logger = logging.getLogger(__name__)
@@ -107,13 +110,30 @@ class StorageService:
 
     def remaining_storage(self, user_id, record):
         """Remaining storage for this draft and user."""
+        has_published_records = db.session.query(RDMRecordMetadata.parent_id).filter(
+            RDMRecordMetadata.parent_id == RDMRecordQuota.parent_id,
+            RDMRecordMetadata.deletion_status
+            == RecordDeletionStatusEnum.PUBLISHED.value,
+        )
+
+        has_draft = db.session.query(RDMDraftMetadata.parent_id).filter(
+            RDMDraftMetadata.parent_id == RDMRecordQuota.parent_id,
+            RDMDraftMetadata.json.isnot(None),  # filter-out soft-deleted drafts
+        )
+
         additional_storage_user = (
             RDMRecordQuota.query.with_entities(
                 func.coalesce(
                     func.sum(RDMRecordQuota.quota_size - self.default_quota(user_id)), 0
                 )
             )
-            .filter(RDMRecordQuota.user_id == user_id)
+            .filter(
+                RDMRecordQuota.user_id == user_id,
+                or_(
+                    has_published_records.exists(),
+                    has_draft.exists(),
+                ),
+            )
             .scalar()
         )
 

--- a/tests/services/storage/__init__.py
+++ b/tests/services/storage/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for storage services."""

--- a/tests/services/storage/conftest.py
+++ b/tests/services/storage/conftest.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: TU Wien.
+# SPDX-License-Identifier: MIT
+
+"""Configuration for storage service tests."""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def app_config(app_config):
+    """Set quota size for storage service."""
+    app_config["RDM_FILES_DEFAULT_MAX_ADDITIONAL_QUOTA_SIZE"] = 20 * 10**9
+    app_config["RDM_FILES_DEFAULT_QUOTA_SIZE"] = 10 * 10**9
+    return app_config

--- a/tests/services/storage/test_remaining_storage.py
+++ b/tests/services/storage/test_remaining_storage.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+"""Tests for StorageService.remaining_storage."""
+
+from invenio_access.permissions import system_identity
+
+from invenio_rdm_records.proxies import current_rdm_records_service as records_service
+from invenio_rdm_records.proxies import (
+    current_rdm_records_storage_service as storage_service,
+)
+
+# 5 GB of extra quota per record
+EXTRA_QUOTA = 5 * 10**9
+
+
+def _max_additional_quota(app):
+    return app.config["RDM_FILES_DEFAULT_MAX_ADDITIONAL_QUOTA_SIZE"]
+
+
+def _create_draft_with_extra_quota(
+    app, identity, minimal_record, extra_quota=EXTRA_QUOTA
+):
+    """Create a draft and grant it extra_quota above the default."""
+    draft = records_service.create(identity, minimal_record)
+    size = app.config["RDM_FILES_DEFAULT_QUOTA_SIZE"] + extra_quota
+    records_service.set_quota(
+        system_identity,
+        draft.id,
+        {
+            "quota_size": size,
+            "max_file_size": size,
+        },
+    )
+    return draft
+
+
+def _create_published_record_with_extra_quota(
+    app, identity, minimal_record, extra_quota=EXTRA_QUOTA
+):
+    """Create a published record with extra_quota above the default."""
+    draft = _create_draft_with_extra_quota(app, identity, minimal_record, extra_quota)
+    record = records_service.publish(identity, draft.id)
+    return record
+
+
+def test_remaining_storage_no_records(app, users, location, resource_type_v):
+    """With no records, the full additional quota is available."""
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app)
+
+
+def test_remaining_storage_published_record(
+    app, identity_simple, users, minimal_record, location, resource_type_v
+):
+    """A published record with allocated quota reduces the remaining storage."""
+    _create_published_record_with_extra_quota(app, identity_simple, minimal_record)
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app) - EXTRA_QUOTA
+
+
+def test_remaining_storage_draft(
+    app, identity_simple, users, minimal_record, location, resource_type_v
+):
+    """A draft with allocated quota reduces the remaining storage."""
+    _create_draft_with_extra_quota(app, identity_simple, minimal_record)
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app) - EXTRA_QUOTA
+
+
+def test_remaining_storage_record_deleted(
+    app, identity_simple, users, minimal_record, location, resource_type_v
+):
+    """A parent without published versions should not reduce the remaining storage.
+
+    A parent with allocated quota initially reduces the remaining storage. If its records
+    are deleted, and no drafts exist for it, the allocated storage is no longer taken into
+    consideration when calculating the remaining storage.
+    """
+    record = _create_published_record_with_extra_quota(
+        app, identity_simple, minimal_record
+    )
+    draft_v2 = records_service.new_version(identity_simple, record.id)
+    record_v2 = records_service.publish(identity_simple, draft_v2.id)
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app) - EXTRA_QUOTA
+
+    # delete v2
+    records_service.delete_record(system_identity, record_v2.id, {})
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app) - EXTRA_QUOTA
+
+    # delete v1
+    records_service.delete_record(system_identity, record.id, {})
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app)
+
+
+def test_remaining_storage_record_deleted_active_draft(
+    app, identity_simple, users, minimal_record, location, resource_type_v
+):
+    """A parent with allocated quota, no published records and a draft reduces the remaining storage."""
+    record = _create_published_record_with_extra_quota(
+        app, identity_simple, minimal_record
+    )
+    records_service.new_version(identity_simple, record.id)
+    remaining = storage_service.remaining_storage(users[0].id, record=None)
+    assert remaining == _max_additional_quota(app) - EXTRA_QUOTA
+
+
+def test_remaining_storage_current_draft(
+    app, identity_simple, users, minimal_record, location, resource_type_v
+):
+    """Correctly calculates a draft's remaining storage.
+
+    A currently-edited draft's extra quota is added back to remaining storage,
+    but other drafts' and records' allocated storage reduced the remaining storage.
+    """
+    draft_1 = _create_draft_with_extra_quota(app, identity_simple, minimal_record)
+
+    # Additional draft and record with allocated storage
+    _draft_2 = _create_draft_with_extra_quota(app, identity_simple, minimal_record)
+    draft_3 = _create_draft_with_extra_quota(app, identity_simple, minimal_record)
+    _record_3 = records_service.publish(identity_simple, draft_3.id)
+
+    draft_obj = records_service.read_draft(identity_simple, draft_1.id)._record
+    additional_storage_draft_1 = storage_service.additional_storage(
+        users[0].id, record=draft_obj
+    )
+    assert additional_storage_draft_1 == EXTRA_QUOTA
+
+    remaining_draft_1 = storage_service.remaining_storage(users[0].id, record=draft_obj)
+    assert remaining_draft_1 == _max_additional_quota(app) - 2 * EXTRA_QUOTA


### PR DESCRIPTION
:heart: Thank you for your review!

### Description

`remaining_storage()` queries RDMRecordQuota to calculate the available remaining storage for a draft and user. The query includes quota for records even if they have no published versions (only deleted).

This commit filters out the cases where a record has no published versions, so the remaining storage reflects only active records.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
