### PR TITLE
fix(mappings): add files.order to record and draft mappings

### DIFF
--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/drafts/draft-v6.0.0.json
@@ -1394,6 +1394,9 @@
           "default_preview": {
             "type": "keyword"
           },
+          "order": {
+            "type": "keyword"
+          },
           "count": {
             "type": "integer"
           },
@@ -1459,6 +1462,9 @@
             "type": "boolean"
           },
           "default_preview": {
+            "type": "keyword"
+          },
+          "order": {
             "type": "keyword"
           },
           "count": {

--- a/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v1/rdmrecords/records/record-v7.0.0.json
@@ -1420,6 +1420,9 @@
           "default_preview": {
             "type": "keyword"
           },
+          "order": {
+            "type": "keyword"
+          },
           "count": {
             "type": "integer"
           },
@@ -1485,6 +1488,9 @@
             "type": "boolean"
           },
           "default_preview": {
+            "type": "keyword"
+          },
+          "order": {
             "type": "keyword"
           },
           "count": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/drafts/draft-v6.0.0.json
@@ -1394,6 +1394,9 @@
           "default_preview": {
             "type": "keyword"
           },
+          "order": {
+            "type": "keyword"
+          },
           "count": {
             "type": "integer"
           },
@@ -1459,6 +1462,9 @@
             "type": "boolean"
           },
           "default_preview": {
+            "type": "keyword"
+          },
+          "order": {
             "type": "keyword"
           },
           "count": {

--- a/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
+++ b/invenio_rdm_records/records/mappings/os-v2/rdmrecords/records/record-v7.0.0.json
@@ -1402,6 +1402,9 @@
           "default_preview": {
             "type": "keyword"
           },
+          "order": {
+            "type": "keyword"
+          },
           "count": {
             "type": "integer"
           },
@@ -1467,6 +1470,9 @@
             "type": "boolean"
           },
           "default_preview": {
+            "type": "keyword"
+          },
+          "order": {
             "type": "keyword"
           },
           "count": {

--- a/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
+++ b/invenio_rdm_records/records/mappings/v7/rdmrecords/drafts/draft-v6.0.0.json
@@ -1360,6 +1360,9 @@
           "default_preview": {
             "type": "keyword"
           },
+          "order": {
+            "type": "keyword"
+          },
           "count": {
             "type": "integer"
           },
@@ -1425,6 +1428,9 @@
             "type": "boolean"
           },
           "default_preview": {
+            "type": "keyword"
+          },
+          "order": {
             "type": "keyword"
           },
           "count": {


### PR DESCRIPTION
:heart: 

### Description

Adds `files.order` (and `media_files.order`) to the current record and draft
search mappings so a record with `order` set can be reindexed under
`dynamic: strict`.
This is the first step toward inveniosoftware/invenio-app-rdm#2573 /
inveniosoftware/invenio-app-rdm#3549. It does not change the deposit UI.
Verified locally on a v14 OpenSearch 2 instance: reindex failed with
`strict_dynamic_mapping_exception` before the field existed, and succeeded
after adding `"order": { "type": "keyword" }`.
Existing instances need a search index update/recreate to pick this up
(expected for mapping changes; targets InvenioRDM v15).

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

Frontend: not applicable (mapping JSON only).

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.

