### PR TITLE
fix(quota): hide labels in narrow bars

### DIFF
--- a/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/QuotaManager/QuotaDisplay.js
+++ b/invenio_rdm_records/assets/semantic-ui/js/invenio_rdm_records/src/deposit/fields/FileUploader/QuotaManager/QuotaDisplay.js
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2025 CERN.
+ * SPDX-FileCopyrightText: 2026 KTH Royal Institute of Technology.
  * SPDX-License-Identifier: MIT
  */
 
@@ -100,11 +101,11 @@ export const QuotaDisplay = (props) => {
                   xOffset += bar[keys[i]];
                 }
                 const barWidth = bar[key];
-                const xPos =
-                  valueScale(xOffset) +
-                  (barWidth > 15 ? valueScale(barWidth) / 2 : valueScale(barWidth) + 5);
+                const pixelWidth = valueScale(barWidth);
+                const xPos = valueScale(xOffset) + pixelWidth / 2;
 
-                if (barWidth <= 0) return null;
+                // 20px seems to be the minimum width for the text to be readable
+                if (barWidth <= 0 || pixelWidth < 20) return null;
 
                 return (
                   <Text
@@ -112,7 +113,7 @@ export const QuotaDisplay = (props) => {
                     x={xPos}
                     y={categoryScale("Storage") + categoryScale.bandwidth() / 2}
                     verticalAnchor="middle"
-                    textAnchor={barWidth > 15 ? "middle" : "start"}
+                    textAnchor="middle"
                     fontSize={11}
                     fill="white"
                     fontWeight={500}


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Hide quota bar labels that cannot fit inside their segment to prevent overlapping values.
* Keep all quota values available in the legend.
* Remove confusing double values from the start.

Needs backport to v14


## After:
<img width="856" height="762" alt="Screen Recording 2026-08-20 at 09 32 49" src="https://github.com/user-attachments/assets/4491a45f-84e3-480f-a8b4-2afa80cb8fc0" />

## Before:
<img width="1108" height="718" alt="Screen Recording 2026-08-20 at 10 10 39" src="https://github.com/user-attachments/assets/665f64d0-e90a-4e02-943b-6902d49148a9" />


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
