### PR TITLE
fix(signposting): fix custom licenses links percent-encoding

### DIFF
--- a/invenio_rdm_records/resources/serializers/signposting/schema.py
+++ b/invenio_rdm_records/resources/serializers/signposting/schema.py
@@ -6,6 +6,7 @@
 """Signposting schemas."""
 
 import re
+import urllib
 
 import idutils
 from invenio_base import invenio_url_for
@@ -139,8 +140,16 @@ class LandingPageSchema(Schema):
             elif right.get("props"):
                 return right["props"].get("url")
 
+        def percent_encode(url):
+            url_parts = urllib.parse.urlsplit(url)
+            url_parts = url_parts._replace(path=urllib.parse.quote(url_parts.path))
+            url_parts = url_parts._replace(
+                query=urllib.parse.urlencode(urllib.parse.parse_qsl(url_parts.query))
+            )
+            return url_parts.geturl()
+
         result = [extract_link(right) for right in rights]
-        result = [{"href": link} for link in result if link]
+        result = [{"href": percent_encode(link)} for link in result if link]
         return result or missing
 
     def serialize_type(self, obj, **kwargs):

--- a/invenio_rdm_records/resources/serializers/signposting/schema.py
+++ b/invenio_rdm_records/resources/serializers/signposting/schema.py
@@ -6,7 +6,7 @@
 """Signposting schemas."""
 
 import re
-import urllib
+from urllib.parse import SplitResult, parse_qsl, quote, urlencode, urlsplit
 
 import idutils
 from invenio_base import invenio_url_for
@@ -122,7 +122,6 @@ class LandingPageSchema(Schema):
 
         Note that we provide an entry for each license (rather than just 1).
         """
-        rights = obj["metadata"].get("rights", [])
 
         def extract_link(right):
             """Return link associated with right.
@@ -141,13 +140,18 @@ class LandingPageSchema(Schema):
                 return right["props"].get("url")
 
         def percent_encode(url):
-            url_parts = urllib.parse.urlsplit(url)
-            url_parts = url_parts._replace(path=urllib.parse.quote(url_parts.path))
-            url_parts = url_parts._replace(
-                query=urllib.parse.urlencode(urllib.parse.parse_qsl(url_parts.query))
+            """Return the percent-encoded, Link-header-compatible URL."""
+            url_parts = urlsplit(url)
+            result = SplitResult(
+                scheme=url_parts.scheme,
+                netloc=url_parts.netloc,
+                path=quote(url_parts.path),
+                query=urlencode(parse_qsl(url_parts.query)),
+                fragment=url_parts.fragment,
             )
-            return url_parts.geturl()
+            return result.geturl()
 
+        rights = obj["metadata"].get("rights", [])
         result = [extract_link(right) for right in rights]
         result = [{"href": percent_encode(link)} for link in result if link]
         return result or missing

--- a/tests/resources/serializers/test_signposting_serializer.py
+++ b/tests/resources/serializers/test_signposting_serializer.py
@@ -57,7 +57,7 @@ def full_record_to_dict_signposting(full_record_to_dict, collections_size):
             "description": {
                 "en": "A description",
             },
-            "link": f"https://customlicense.org/licenses/by/{n + 1}.0/",
+            "link": f"https://customlicense.org/licenses/testé/{n + 1}.0/?testé=testé",
             "title": {
                 "en": "A custom license",
             },
@@ -202,9 +202,15 @@ def test_signposting_lvl2_serializer_full(
                     },
                 ],
                 "license": [
-                    {"href": "https://customlicense.org/licenses/by/1.0/"},
-                    {"href": "https://customlicense.org/licenses/by/2.0/"},
-                    {"href": "https://customlicense.org/licenses/by/3.0/"},
+                    {
+                        "href": "https://customlicense.org/licenses/test%C3%A9/1.0/?test%C3%A9=test%C3%A9"
+                    },
+                    {
+                        "href": "https://customlicense.org/licenses/test%C3%A9/2.0/?test%C3%A9=test%C3%A9"
+                    },
+                    {
+                        "href": "https://customlicense.org/licenses/test%C3%A9/3.0/?test%C3%A9=test%C3%A9"
+                    },
                     {"href": "https://creativecommons.org/licenses/by/4.0/legalcode"},
                     {"href": "https://creativecommons.org/licenses/by/5.0/legalcode"},
                     {"href": "https://creativecommons.org/licenses/by/6.0/legalcode"},
@@ -340,8 +346,8 @@ def test_signposting_lvl1_serializer_full_collections_size_ok(
         f'<{ui_url}/files/test%C3%A9_3.txt> ; rel="item" ; type="text/plain"',
         f'<{ui_url}/files/test%C3%A9_4.txt> ; rel="item" ; type="text/plain"',
         f'<{ui_url}/files/test%C3%A9_5.txt> ; rel="item" ; type="text/plain"',
-        '<https://customlicense.org/licenses/by/1.0/> ; rel="license"',
-        '<https://customlicense.org/licenses/by/2.0/> ; rel="license"',
+        '<https://customlicense.org/licenses/test%C3%A9/1.0/?test%C3%A9=test%C3%A9> ; rel="license"',
+        '<https://customlicense.org/licenses/test%C3%A9/2.0/?test%C3%A9=test%C3%A9> ; rel="license"',
         '<https://creativecommons.org/licenses/by/3.0/legalcode> ; rel="license"',
         '<https://creativecommons.org/licenses/by/4.0/legalcode> ; rel="license"',
         '<https://creativecommons.org/licenses/by/5.0/legalcode> ; rel="license"',


### PR DESCRIPTION
How to reproduce the problem:
* Add a custom license to a record with the link `https://customlicense.org/licenses/testé/1.0/?testé=testé` 
* Save the record
* The rendering of the landing page will fail with `TypeError: http header must be encodable in latin1` in `invenio_app_rdm_records.record_detail`
