### PR TITLE
fix: update crossref serializer fixture

### DIFF
--- a/tests/resources/serializers/conftest.py
+++ b/tests/resources/serializers/conftest.py
@@ -74,6 +74,9 @@ def full_record_to_dict():
                     "ext": "txt",
                     "id": "d22bde05-5a36-48a3-86a7-acf2c4bb6f64",
                     "key": "test.txt",
+                    "links": {
+                        "content": "https://127.0.0.1:5000/api/records/12345-abcde/files/test.txt/content",
+                    },
                     "metadata": None,
                     "mimetype": "text/plain",
                     "size": 9,

--- a/tests/resources/serializers/test_crossref_serializer.py
+++ b/tests/resources/serializers/test_crossref_serializer.py
@@ -58,6 +58,14 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         <person_name contributor_role="author" sequence="first">
           <given_name>Lars Holm</given_name>
           <surname>Nielsen</surname>
+          <affiliations>
+            <institution>
+              <institution_name>CERN</institution_name>
+            </institution>
+            <institution>
+              <institution_name>free-text</institution_name>
+            </institution>
+          </affiliations>
           <ORCID>https://orcid.org/0000-0001-8135-3489</ORCID>
         </person_name>
         <person_name contributor_role="author" sequence="additional">
@@ -67,6 +75,14 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         <person_name contributor_role="other" sequence="additional">
           <given_name>Lars Holm</given_name>
           <surname>Nielsen</surname>
+          <affiliations>
+            <institution>
+              <institution_name>CERN</institution_name>
+            </institution>
+            <institution>
+              <institution_name>TU Wien</institution_name>
+            </institution>
+          </affiliations>
           <ORCID>https://orcid.org/0000-0001-8135-3489</ORCID>
         </person_name>
         <person_name contributor_role="other" sequence="additional">
@@ -111,6 +127,9 @@ def test_crossref_serializer(running_app, full_record_to_dict):
         <collection property="text-mining">
           <item>
             <resource mime_type="text/html">https://127.0.0.1:5000/records/12345-abcde</resource>
+          </item>
+          <item>
+            <resource mime_type="text/plain">https://127.0.0.1:5000/api/records/12345-abcde/files/test.txt/content</resource>
           </item>
         </collection>
       </doi_data>


### PR DESCRIPTION
### Description

This fixes a failing Crossref serializer test, caused by the Crossref serializer including more affiliations for the test.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
