### PR TITLE
feat(record_community_service): rely on request permission to return …

### DIFF
--- a/invenio_rdm_records/services/communities/service.py
+++ b/invenio_rdm_records/services/communities/service.py
@@ -492,32 +492,43 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
         return errors
 
     def get_record_requests(self, identity, record):
-        """
-        Get all accepted community requests of the given record.
+        """Get community requests of the given record readable by the identity.
+
+        Returns only requests the identity has permission to read, so that
+        request reviewers (who have can_read but not can_review on the record)
+        also see the relevant requests.
 
         :param identity: The identity performing the action.
         :param record: The record (RecordItem) to get the community requests for.
 
         Output: {<Community-UUID>: <Request-UUID>}
         """
-        can_review = self.check_permission(identity, "review", record=record._record)
-        if not can_review:
-            # Instead of raising PermissionDeniedError, return an empty dictionary because anonymous users do not have permissions to search requests
-            return {}
         if type(identity) is AnonymousIdentity:
-            return {}  # secret link users do not have permissions to search requests
+            return {}
 
-        # Get all accepted requests that led to the record being added to the community
+        # Accepted requests are read from the parent record directly — reliable
+        # and not subject to search pagination limits. A secondary search filters
+        # them down to only those the identity can read.
         parent = record._record.parent
-        community_requests = parent.communities.get_requests()
         community_requests = {
-            str(request.community_id): str(request.request_id)
-            for request in community_requests
+            str(req.community_id): str(req.request_id)
+            for req in parent.communities.get_requests()
         }
+        if community_requests:
+            readable_requests = current_requests_service.search(
+                identity,
+                extra_filter=dsl.Q("ids", values=list(community_requests.values())),
+            )
+            readable_requests_ids = {r["id"] for r in readable_requests}
+            community_requests = {
+                c_id: r_id
+                for c_id, r_id in community_requests.items()
+                if r_id in readable_requests_ids
+            }
 
-        # Get the requests that concern only the current record, i.e. submission or inclusion regardless of their status
-        # This takes precedence over only considering accepted requests because there may be an unaccepted request in this
-        # version of the record that should be shown instead of the accepted request.
+        # Active inclusion/submission requests override accepted ones for the
+        # same community. search() applies can_read query filters, so reviewers
+        # are included automatically when REQUESTS_REVIEWERS_ENABLED=True.
         record_requests = current_requests_service.search(
             identity,
             extra_filter=dsl.Q(
@@ -537,11 +548,7 @@ class RecordCommunitiesService(Service, RecordIndexerMixin):
             ),
             params={"sort": "oldest"},
         )
-        record_requests = {
-            request["receiver"]["community"]: request["id"]
-            for request in record_requests
-        }
-
-        community_requests.update(record_requests)
-        # Return a dictionary with the community id mapped to the request id
+        community_requests.update(
+            {r["receiver"]["community"]: r["id"] for r in record_requests}
+        )
         return community_requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2158,6 +2158,34 @@ def curator(UserFixture, community, inviter, app, db):
 
 
 @pytest.fixture()
+def reviewer_user(UserFixture, app, db, index_users):
+    """An authenticated user with no community membership, usable as a request reviewer."""
+    u = UserFixture(
+        email="reviewer@inveniosoftware.org",
+        password="reviewer",
+        active=True,
+        confirmed=True,
+    )
+    u.create(app, db)
+    index_users()
+    return u
+
+
+@pytest.fixture()
+def non_community_user(UserFixture, app, db, index_users):
+    """An authenticated user with no community membership and no relation to any request."""
+    u = UserFixture(
+        email="non_community@inveniosoftware.org",
+        password="non_community",
+        active=True,
+        confirmed=True,
+    )
+    u.create(app, db)
+    index_users()
+    return u
+
+
+@pytest.fixture()
 def community_type_type(superuser_identity):
     """Creates and retrieves a language vocabulary type."""
     v = vocabulary_service.create_type(superuser_identity, "communitytypes", "comtyp")

--- a/tests/services/test_service_record_communities.py
+++ b/tests/services/test_service_record_communities.py
@@ -5,14 +5,33 @@
 
 import pytest
 from flask import current_app
+from flask_principal import AnonymousIdentity
 from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
 from invenio_records_resources.services.records.components import ServiceComponent
+from invenio_requests import current_requests_service
+from invenio_requests.records.api import Request
 
 from invenio_rdm_records.proxies import (
     current_rdm_records_service,
     current_record_communities_service,
 )
+from invenio_rdm_records.requests.community_submission import CommunitySubmission
+
+
+@pytest.fixture()
+def submitted_draft(running_app, uploader, community, minimal_record):
+    """A draft submitted for community review (request in 'submitted' state)."""
+    minimal_record["parent"] = {
+        "review": {
+            "type": CommunitySubmission.type_id,
+            "receiver": {"community": community.data["id"]},
+        }
+    }
+    draft = current_rdm_records_service.create(uploader.identity, minimal_record)
+    req = current_rdm_records_service.review.submit(uploader.identity, draft.id)
+    Request.index.refresh()
+    return draft, req.to_dict()
 
 
 def test_bulk_add_non_authorized_permission(community, uploader, record_factory):
@@ -204,3 +223,34 @@ def test_bulk_add_component_called(
     result3 = current_rdm_records_service.record_cls.pid.resolve(record3.pid.pid_value)
     assert community.id not in result3.parent.communities.ids
     assert result3.parent.communities.default is None
+
+
+def test_get_record_requests_visibility(
+    submitted_draft, uploader, curator, reviewer_user, non_community_user
+):
+    """Users with read access to the request can see it; others cannot."""
+    draft, req = submitted_draft
+    request_id = req["id"]
+
+    current_requests_service.update(
+        system_identity,
+        request_id,
+        {"reviewers": [{"user": str(reviewer_user.id)}]},
+    )
+    Request.index.refresh()
+
+    draft_item = current_rdm_records_service.read_draft(uploader.identity, draft.id)
+
+    # Users who can read the request see it.
+    for identity in [uploader.identity, curator.identity, reviewer_user.identity]:
+        result = current_record_communities_service.get_record_requests(
+            identity, draft_item
+        )
+        assert request_id in result.values(), f"Expected {identity} to see the request"
+
+    # Users with no relation to the request do not see it.
+    for identity in [AnonymousIdentity(), non_community_user.identity]:
+        result = current_record_communities_service.get_record_requests(
+            identity, draft_item
+        )
+        assert result == {}, f"Expected {identity} to get empty result"


### PR DESCRIPTION
Before the "View comments" button was available only to who could review a record, thus reviewers of a request could not access the button from the record's landing page.

This PR changes the logic to always rely to "if the given user can read the associated request" to return the list of record communities with their associated requests and subsequently see the "View comments" button.

closes https://github.com/inveniosoftware/invenio-app-rdm/issues/3561


## Performance check on production cluster

- Claude code used below

```python
import time
from invenio_access.permissions import system_identity
from invenio_rdm_records.proxies import current_rdm_records_service
from invenio_requests import current_requests_service
from invenio_search.engine import dsl

RECORD_PID = "<pid>"
RUNS = 20

record = current_rdm_records_service.read(system_identity, RECORD_PID)

real_reqs = list(record._record.parent.communities.get_requests())
print(f"Real requests: {len(real_reqs)}")

def get_record_requests_opensearch(identity, reqs):
    community_requests = {str(r.community_id): str(r.request_id) for r in reqs}
    if community_requests:
        readable = current_requests_service.search(
            identity,
            extra_filter=dsl.Q("ids", values=list(community_requests.values())),
        )
        readable_ids = {r["id"] for r in readable}
        community_requests = {c: r for c, r in community_requests.items() if r in readable_ids}
    return community_requests

def get_record_requests_db(identity, reqs):
    ids = [req.request_id for req in reqs]
    request_objs = {
        str(obj.id): obj
        for obj in current_requests_service.record_cls.get_records(ids)
    }
    community_requests = {}
    for req in reqs:
        request_obj = request_objs.get(str(req.request_id))
        if request_obj and current_requests_service.check_permission(
            identity, "read", request=request_obj
        ):
            community_requests[str(req.community_id)] = str(req.request_id)
    return community_requests

def bench(fn, label, reqs, runs):
    fn(system_identity, reqs)  # warm-up
    times = []
    for _ in range(runs):
        t0 = time.perf_counter()
        fn(system_identity, reqs)
        times.append(time.perf_counter() - t0)
    avg = sum(times) / len(times)
    print(f"  {label}: avg={avg*1000:.1f}ms  min={min(times)*1000:.1f}ms  max={max(times)*1000:.1f}ms")

for n, reqs in [("3 (real)", real_reqs), ("30 (replicated)", real_reqs * 10)]:
    print(f"\n--- N={n} ---")
    bench(get_record_requests_opensearch, "OpenSearch    ", reqs, RUNS)
    bench(get_record_requests_db,         "DB+in-process ", reqs, RUNS)


```

- Production Zenodo cluster results

```
----- Run 1 -------

--- N=3 (real) ---
  OpenSearch    : avg=19.3ms  min=14.1ms  max=35.1ms
  DB+in-process : avg=26.9ms  min=23.9ms  max=34.6ms

--- N=30 (replicated) ---
  OpenSearch    : avg=15.8ms  min=12.5ms  max=20.4ms
  DB+in-process : avg=116.8ms  min=106.5ms  max=138.7ms

----- Run 2 ----------

--- N=3 (real) ---
  OpenSearch    : avg=15.7ms  min=12.2ms  max=19.5ms
  DB+in-process : avg=25.4ms  min=22.3ms  max=30.0ms

--- N=30 (replicated) ---
  OpenSearch    : avg=15.0ms  min=12.2ms  max=19.3ms
  DB+in-process : avg=127.8ms  min=109.0ms  max=156.4ms

-----Run 3---------

--- N=3 (real) ---
  OpenSearch    : avg=15.5ms  min=12.7ms  max=29.8ms
  DB+in-process : avg=24.2ms  min=22.5ms  max=27.1ms

--- N=30 (replicated) ---
  OpenSearch    : avg=13.9ms  min=11.1ms  max=15.9ms
  DB+in-process : avg=119.5ms  min=107.8ms  max=136.5ms
  ```
  
  It seems that consistently, with an increase in requests, the performance of Opensearch seems consistently better.