### PR TITLE
schemaorg: map coverage dates to temporalCoverage

### DIFF
--- a/invenio_rdm_records/resources/serializers/schemaorg/schema.py
+++ b/invenio_rdm_records/resources/serializers/schemaorg/schema.py
@@ -178,6 +178,7 @@ class SchemaorgSchema(BaseSerializerSchema, CommonFieldsMixin):
     dateModified = fields.Method("get_modification_date")
     datePublished = fields.Method("get_publication_date")
     temporal = fields.Method("get_dates")
+    temporalCoverage = fields.Method("get_temporal_coverage")
     inLanguage = fields.Method("get_language")
     contentSize = fields.Method("get_size")
     size = fields.Method("get_size")
@@ -443,6 +444,24 @@ class SchemaorgSchema(BaseSerializerSchema, CommonFieldsMixin):
             except ParseException:
                 continue
         return dates or missing
+
+    def get_temporal_coverage(self, obj):
+        """Get the period the record's content is about.
+
+        Only dates of type ``coverage`` are returned, since schema.org's
+        ``temporalCoverage`` describes the period the content covers, unlike
+        ``temporal``, which carries every date on the record.
+        """
+        dates = []
+        for date in obj["metadata"].get("dates", []):
+            if py_.get(date, "type.id") != "coverage":
+                continue
+            try:
+                parsed_date = parse_edtf(date["date"])
+            except ParseException:
+                continue
+            dates.append(str(parsed_date))
+        return unwrap(dates) or missing
 
     def get_citation(self, obj):
         """Get citations of the record."""

--- a/tests/resources/serializers/test_schemaorg_serializer.py
+++ b/tests/resources/serializers/test_schemaorg_serializer.py
@@ -5,6 +5,8 @@
 
 """Resources serializers tests."""
 
+from copy import deepcopy
+
 from invenio_rdm_records.resources.serializers.schemaorg import (
     SchemaorgJSONLDSerializer,
 )
@@ -193,3 +195,42 @@ def test_schemaorg_serializer_empty_record(running_app, empty_record):
     serialized_record = serializer.dump_obj(empty_record)
 
     assert serialized_record == expected_data
+
+
+def test_schemaorg_serializer_temporal_coverage(running_app, full_record_to_dict):
+    """Test that only dates of type ``coverage`` reach ``temporalCoverage``."""
+
+    serializer = SchemaorgJSONLDSerializer()
+
+    # The full record's only date is of type "other", so the record has no
+    # temporalCoverage and "temporal" is unaffected.
+    without_coverage = serializer.dump_obj(full_record_to_dict)
+
+    assert "temporalCoverage" not in without_coverage
+    assert without_coverage["temporal"] == ["1939/1945"]
+
+    # A coverage date fills temporalCoverage, and "temporal" keeps carrying
+    # every date on the record as before.
+    record = deepcopy(full_record_to_dict)
+    record["metadata"]["dates"].append(
+        {
+            "date": "1815/1830",
+            "description": "The period the photographs are about",
+            "type": {"id": "coverage", "title": {"en": "Coverage"}},
+        }
+    )
+    with_coverage = serializer.dump_obj(record)
+
+    assert with_coverage["temporalCoverage"] == "1815/1830"
+    assert with_coverage["temporal"] == ["1939/1945", "1815/1830"]
+
+    # Several coverage dates are carried as a list.
+    record["metadata"]["dates"].append(
+        {
+            "date": "1900",
+            "type": {"id": "coverage", "title": {"en": "Coverage"}},
+        }
+    )
+    with_two = serializer.dump_obj(record)
+
+    assert with_two["temporalCoverage"] == ["1815/1830", "1900"]


### PR DESCRIPTION
Fixes #2175.

The schema.org serializer sends every date on a record to `temporal`, including dates that state the period the content is *about*. schema.org has a dedicated property for that period, [`temporalCoverage`](https://schema.org/temporalCoverage), and it is the one the [science-on-schema.org Dataset guide](https://github.com/ESIPFed/science-on-schema.org/blob/main/guides/Dataset.md#temporal-coverage) and Google's dataset structured-data documentation read. `temporalCoverage` did not appear anywhere in this repository before this change.

## What changed

`invenio_rdm_records/resources/serializers/schemaorg/schema.py`

- New field `temporalCoverage`, populated by a new `get_temporal_coverage()`.
- The filter is the date type `coverage` from `invenio_rdm_records/fixtures/data/vocabularies/date_types.yaml`, which maps to DataCite `Coverage`. That vocabulary holds twelve types — `accepted`, `available`, `collected`, `copyrighted`, `created`, `issued`, `other`, `submitted`, `updated`, `valid`, `withdrawn`, `coverage` — and `coverage` is the only one that states a period of content coverage, so no guessing between `collected` and `valid` is needed. When #2175 was written the DataCite vocabulary did not yet carry `Coverage`, which is why the issue proposes `valid` as a proxy; it does now, so the mapping is direct.
- A single coverage date serializes as a text value and several as a list, via the `unwrap` helper this file already uses.

## Additive, by construction

`temporal` and `get_dates()` are **untouched**. Every date, coverage ones included, keeps flowing to `temporal` exactly as before, so no existing serialized output moves — the assertion `"temporal": ["1939/1945"]` in `tests/resources/serializers/test_schemaorg_serializer.py` passes unchanged, and the new test asserts that explicitly rather than leaving it implied.

`spatialCoverage` remains commented out at line 189. The coverage family is still partly implemented after this change, and this PR does not try to finish it.

## Tests

A new `test_schemaorg_serializer_temporal_coverage` covers a record with no coverage date, one with a single coverage date, and one with two — asserting in each case both the new field and that `temporal` is unchanged.

I could not run `./run-tests.sh` here: it brings up postgresql, opensearch, rabbitmq and redis through `docker-services-cli`, which this machine does not have. `black`, `isort` and `pydocstyle` — the three hooks the pytest addopts apply — all pass on both changed files. Please treat CI as the real verdict on the test.

## Credit

The analysis is @ezwelty's in #2175, including the point that `temporal` and `temporalCoverage` are different properties and that discoverability depends on the latter.