### PR TITLE
oaiserver: anchor the setSpec validation

### DIFF
--- a/invenio_rdm_records/oaiserver/services/services.py
+++ b/invenio_rdm_records/oaiserver/services/services.py
@@ -102,8 +102,11 @@ class OAIPMHServerService(Service):
             )
 
         # See https://www.openarchives.org/OAI/openarchivesprotocol.html#Set
-        blop = re.compile(r"[-_.!~*'()\w]+")
-        if not bool(blop.match(spec)):
+        # A setSpec is a colon-separated hierarchy; each element must consist of
+        # the characters below and must not contain a colon. Anchor the match so
+        # the whole spec is validated, not just its leading characters.
+        blop = re.compile(r"[-_.!~*'()\w]+(:[-_.!~*'()\w]+)*")
+        if not bool(blop.fullmatch(spec)):
             raise ValidationError(
                 _(
                     "The spec must only consist of letters, numbers or {marks}.".format(

--- a/tests/services/test_oai_service.py
+++ b/tests/services/test_oai_service.py
@@ -75,6 +75,31 @@ def test_reserved_prefixes(running_app, search_clear, minimal_oai_set):
         service.create(superuser_identity, minimal_oai_set)
 
 
+def test_spec_is_validated_over_its_whole_length(
+    running_app, search_clear, minimal_oai_set
+):
+    """A spec is rejected on any invalid character, not just a leading one."""
+    superuser_identity = running_app.superuser_identity
+    service = current_oaipmh_server_service
+
+    # Each of these starts with a valid character but continues with an invalid
+    # one, so an unanchored match would accept them.
+    invalid = [
+        "spec with spaces",
+        "abc/def",
+        "abc<script>alert(1)</script>",
+        "a\nb",
+    ]
+    for spec in invalid:
+        with pytest.raises(ValidationError):
+            service.create(superuser_identity, {**minimal_oai_set, "spec": spec})
+
+    # A flat spec and a hierarchical (colon-separated) one both stay valid.
+    for spec in ["valid-spec", "parent:child"]:
+        oai_item = service.create(superuser_identity, {**minimal_oai_set, "spec": spec})
+        assert oai_item.to_dict()["spec"] == spec
+
+
 def test_rebuild_index(running_app, search_clear, minimal_oai_set):
     superuser_identity = running_app.superuser_identity
     service = current_oaipmh_server_service


### PR DESCRIPTION
`_validate_spec` builds `re.compile(r"[-_.!~*'()\w]+")` and then calls `.match(spec)`. `re.match` only anchors at the start of the string, so **any spec beginning with a single valid character passes validation, no matter what follows**. The error message, meanwhile, promises that the spec "must only consist of letters, numbers or -,_,.,!,~,*,',(,)".

### Specs accepted today

All four are accepted on `master`, because the pattern matches only their leading run:

| spec | what the regex actually matches |
|---|---|
| `spec with spaces` | `spec` |
| `abc/def` | `abc` |
| `abc<script>alert(1)</script>` | `abc` |
| `a\nb` | `a` |

### The change

`match` → `fullmatch`, plus the colon-separated hierarchy spelled out so hierarchical sets keep working.

The hierarchy is not a guess: OAI-PMH defines a setSpec as "a colon [:] separated list indicating the path from the root of the set hierarchy to the respective node", where "each element in the list is a string consisting of any valid URI unreserved characters, which must not contain any colons [:]". The official `OAI-PMH.xsd` encodes exactly that shape:

```xml
<simpleType name="setSpecType">
  <restriction base="string">
    <pattern value="([A-Za-z0-9\-_\.!~\*'\(\)])+(:[A-Za-z0-9\-_\.!~\*'\(\)]+)*"/>
  </restriction>
</simpleType>
```

`(:…)*` mirrors that. Note the schema pattern is implicitly fully anchored, which is the same property `fullmatch` restores here.

**The character class is deliberately left as-is.** This repo allows `\w` (so non-ASCII letters), which is wider than the XSD's ASCII-only class. Narrowing it would be a separate, behaviour-changing decision; this PR only fixes the anchoring.

### Tests

Added to `tests/services/test_oai_service.py`, next to `test_reserved_prefixes` which covers the other branch of the same method. It asserts the four strings above are rejected, and that a flat spec (`valid-spec`) and a hierarchical one (`parent:child`) still pass.

The existing cases in `test_create_set` / `test_create_set_invalid_data` are unaffected — I checked each one against both patterns, including `":"` alone, which stays invalid because the pattern requires a segment before any colon.

### Verification

`./run-tests.sh` needs Docker for the search and database services, which I do not have available here, **so the suite has not been run locally** — CI should be treated as the authority. What I did run:

- `black --check`, `isort --check-only`, `pydocstyle` on both changed files — all clean (these are the hooks in the pytest `addopts`).
- A standalone probe comparing the old pattern, the new pattern and the official XSD pattern across 26 specs — the four above, the six new test cases, and every string from the existing valid/invalid lists in `test_create_set*`. No regression: nothing that should stay valid becomes invalid, and the only behaviour change is the four strings above going from accepted to rejected.

### Conflicts

#2371 touches this same file, but its hunks are at lines 1-5, 56-71 and 247-259 (schema instantiation); `_validate_spec` is untouched there, so the two do not overlap.