### PR TITLE
fix: make record deletion more robust

### DIFF
--- a/invenio_rdm_records/requests/user_moderation/actions.py
+++ b/invenio_rdm_records/requests/user_moderation/actions.py
@@ -11,12 +11,12 @@ from invenio_vocabularies.proxies import current_service
 
 from ...proxies import current_rdm_records_service
 from .tasks import (
-    delete_record,
+    delete_record_group,
     restore_record,
     user_block_cleanup,
     user_restore_cleanup,
 )
-from .utils import get_user_records
+from .utils import get_user_records, get_user_records_grouped
 
 
 def on_block(user_id, uow=None, **kwargs):
@@ -46,8 +46,14 @@ def on_block(user_id, uow=None, **kwargs):
         tombstone_data["removed_by"] = {"user": str(actor_id)}
 
     # Soft-delete all the published records of that user
-    for recid in get_user_records(user_id):
-        uow.register(TaskOp(delete_record, recid=recid, tombstone_data=tombstone_data))
+    for record_and_versions in get_user_records_grouped(user_id):
+        uow.register(
+            TaskOp(
+                delete_record_group,
+                recids=record_and_versions,
+                tombstone_data=tombstone_data,
+            )
+        )
 
     # Send cleanup task to make sure all records are deleted
     uow.register(

--- a/invenio_rdm_records/requests/user_moderation/tasks.py
+++ b/invenio_rdm_records/requests/user_moderation/tasks.py
@@ -62,6 +62,24 @@ def delete_record(recid, tombstone_data):
         current_rdm_records_service.indexer.index(ex.record)
 
 
+@shared_task(
+    ignore_result=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    max_retries=2,
+)
+def delete_record_group(recids: list[str], tombstone_data: dict):
+    """Delete all versions of a record."""
+    for recid in recids:
+        try:
+            current_rdm_records_service.delete_record(
+                system_identity, recid, tombstone_data
+            )
+        except DeletionStatusException as ex:
+            # Record is already deleted; index it again to make sure search is up-to-date.
+            current_rdm_records_service.indexer.index(ex.record)
+
+
 @shared_task(ignore_result=True)
 def restore_record(recid):
     """Restore a single record."""

--- a/invenio_rdm_records/requests/user_moderation/utils.py
+++ b/invenio_rdm_records/requests/user_moderation/utils.py
@@ -42,3 +42,34 @@ def get_user_records(user_id, from_db=False, status=None):
             status = [s.value for s in status]
             search = search.filter("terms", deletion_status=status)
         return (hit["id"] for hit in search.scan())
+
+
+def get_user_records_grouped(user_id: str) -> list[list[str]]:
+    """
+    Returns all the ids of records of a user in an ordered way.
+
+    :result:
+    ```python
+    [
+        [record_v3.id, record_v2.id, record_v1.id],
+        [record_2_v1.id],
+        ...
+    ]
+    ```
+    """
+    record_cls = current_rdm_records_service.record_cls
+
+    search = (
+        RecordsSearchV2(index=record_cls.index._name)
+        .filter("term", **{"parent.access.owned_by.user": user_id})
+        .source(["id", "parent.id", "versions.index"])
+    )
+
+    groups = {}
+    for hit in search.scan():
+        groups.setdefault(hit.parent.id, []).append((hit.versions.index, hit.id))
+
+    return [
+        [record_id for _, record_id in sorted(versions, reverse=True)]
+        for versions in groups.values()
+    ]

--- a/invenio_rdm_records/services/components/pids.py
+++ b/invenio_rdm_records/services/components/pids.py
@@ -360,12 +360,12 @@ class ParentPIDsComponent(ServiceComponent):
             self.service.pids.parent_pid_manager.discard_all(
                 parent_pids, soft_delete=True, record=record
             )
-
-        # Async register/update tasks after transaction commit.
-        for scheme in parent_pids.keys():
-            self.uow.register(
-                TaskOp(register_or_update_pid, record["id"], scheme, parent=True)
-            )
+        else:
+            # Async register/update tasks after transaction commit.
+            for scheme in parent_pids.keys():
+                self.uow.register(
+                    TaskOp(register_or_update_pid, record["id"], scheme, parent=True)
+                )
 
     def restore_record(self, identity, record=None, uow=None):
         """Restore previously invalidated pids."""

--- a/tests/requests/test_user_moderation_utils.py
+++ b/tests/requests/test_user_moderation_utils.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 CERN.
+# SPDX-License-Identifier: MIT
+
+from invenio_rdm_records.proxies import current_rdm_records_service as records_service
+from invenio_rdm_records.requests.user_moderation.utils import get_user_records_grouped
+
+
+def test_get_user_records_grouped(
+    running_app, verified_user, search_clear, minimal_record
+):
+    """Should return ordered lists by versions of records of a user."""
+    identity = verified_user.identity
+
+    # Record 1 (with 2 versions)
+    draft = records_service.create(identity, minimal_record)
+    record_v1 = records_service.publish(id_=draft.id, identity=identity)
+
+    new_version = records_service.new_version(identity, id_=record_v1.id)
+    records_service.update_draft(identity, new_version.id, minimal_record)
+    record_v2 = records_service.publish(id_=new_version.id, identity=identity)
+
+    new_version = records_service.new_version(identity, id_=record_v2.id)
+    records_service.update_draft(identity, new_version.id, minimal_record)
+    record_v3 = records_service.publish(id_=new_version.id, identity=identity)
+
+    # Record 2: single version
+    draft_2 = records_service.create(identity, minimal_record)
+    record_2_v1 = records_service.publish(id_=draft_2.id, identity=identity)
+
+    records_service.indexer.process_bulk_queue()
+    records_service.record_cls.index.refresh()
+
+    groups = get_user_records_grouped(verified_user.id)
+
+    assert len(groups) == 2
+
+    record_1_group = next(g for g in groups if record_v1.id in g)
+    record_2_group = next(g for g in groups if record_2_v1.id in g)
+
+    assert record_1_group == [record_v3.id, record_v2.id, record_v1.id]
+    assert record_2_group == [record_2_v1.id]

--- a/tests/services/pids/test_pids_tasks.py
+++ b/tests/services/pids/test_pids_tasks.py
@@ -498,46 +498,18 @@ def test_invalidate_pid(
     assert parent_pid.status == PIDStatus.REGISTERED
 
     tombstone_info = {"note": "no specific reason, tbh"}
+    hide_call_count = mock_datacite_client.api.hide_doi.call_count
+    update_call_count = mock_datacite_client.api.update_doi.call_count
 
     record = service.delete_record(
         superuser_identity, id_=record.id, data=tombstone_info
     )
 
-    assert mock_datacite_client.api.hide_doi.called is True
-    assert mock_datacite_client.api.update_doi.called is True
-    mock_datacite_client.api.update_doi.assert_has_calls(
-        [
-            mock.call(
-                metadata={
-                    "event": "publish",
-                    "schemaVersion": "http://datacite.org/schema/kernel-4",
-                    "types": {"resourceTypeGeneral": "Image", "resourceType": "Photo"},
-                    "creators": [
-                        {
-                            "name": "Brown, Troy",
-                            "familyName": "Brown",
-                            "nameIdentifiers": [],
-                            "nameType": "Personal",
-                            "givenName": "Troy",
-                        },
-                        {
-                            "familyName": "Troy Inc.",
-                            "name": "Troy Inc.",
-                            "nameIdentifiers": [],
-                            "nameType": "Organizational",
-                        },
-                    ],
-                    "titles": [{"title": "A Romans story"}],
-                    "dates": [{"date": "2020-06-01", "dateType": "Issued"}],
-                    "doi": parent_doi,
-                    "publicationYear": "2020",
-                    "publisher": {"name": "Acme Inc"},
-                },
-                doi=parent_doi,
-                url=f"https://127.0.0.1:5000/doi/{parent_doi}",
-            ),
-        ]
-    )
+    assert mock_datacite_client.api.hide_doi.call_args_list[hide_call_count:] == [
+        mock.call(doi),
+        mock.call(parent_doi),
+    ]
+    assert mock_datacite_client.api.update_doi.call_args_list[update_call_count:] == []
 
     # make sure we still have the PID registered for tombstone
     assert record._record.pid.status == PIDStatus.REGISTERED
@@ -669,45 +641,15 @@ def test_invalidate_versions_pid(
     assert record._record.pid.status == PIDStatus.REGISTERED
 
     # DELETE THE SECOND VERSION
-    service.delete_record(
-        superuser_identity, id_=record_v2.id, data=tombstone_info
-    )  # record_v2_del entfernt, da ungenutzt
+    hide_call_count = mock_datacite_client.api.hide_doi.call_count
+    update_call_count = mock_datacite_client.api.update_doi.call_count
+    service.delete_record(superuser_identity, id_=record_v2.id, data=tombstone_info)
 
-    mock_datacite_client.api.update_doi.assert_has_calls(
-        expected_calls
-        + [
-            # REMOVE LAST VERSION FROM THE PARENT
-            mock.call(
-                metadata={
-                    "event": "publish",
-                    "schemaVersion": "http://datacite.org/schema/kernel-4",
-                    "types": {"resourceTypeGeneral": "Image", "resourceType": "Photo"},
-                    "creators": [
-                        {
-                            "name": "Brown, Troy",
-                            "familyName": "Brown",
-                            "nameIdentifiers": [],
-                            "nameType": "Personal",
-                            "givenName": "Troy",
-                        },
-                        {
-                            "name": "Troy Inc.",
-                            "familyName": "Troy Inc.",
-                            "nameIdentifiers": [],
-                            "nameType": "Organizational",
-                        },
-                    ],
-                    "titles": [{"title": "A Romans story v2"}],
-                    "dates": [{"date": "2020-06-01", "dateType": "Issued"}],
-                    "doi": parent_doi,
-                    "publicationYear": "2020",
-                    "publisher": {"name": "Acme Inc"},
-                },
-                doi=parent_doi,
-                url=f"https://127.0.0.1:5000/doi/{parent_doi}",
-            ),
-        ],
-    )
+    assert mock_datacite_client.api.hide_doi.call_args_list[hide_call_count:] == [
+        mock.call(record_v2_doi),
+        mock.call(parent_doi),
+    ]
+    assert mock_datacite_client.api.update_doi.call_args_list[update_call_count:] == []
 
 
 def test_restore_pid(
@@ -734,15 +676,32 @@ def test_restore_pid(
     assert parent_pid.status == PIDStatus.REGISTERED
 
     tombstone_info = {"note": "no specific reason, tbh"}
+    hide_call_count = mock_datacite_client.api.hide_doi.call_count
+    update_call_count = mock_datacite_client.api.update_doi.call_count
+    show_call_count = mock_datacite_client.api.show_doi.call_count
 
     record = service.delete_record(
         superuser_identity, id_=record.id, data=tombstone_info
     )
 
-    assert mock_datacite_client.api.hide_doi.called is True
-    assert mock_datacite_client.api.update_doi.called is True
+    assert mock_datacite_client.api.hide_doi.call_args_list[hide_call_count:] == [
+        mock.call(doi),
+        mock.call(parent_doi),
+    ]
+    assert mock_datacite_client.api.update_doi.call_args_list[update_call_count:] == []
 
-    expected_calls = [
+    # make sure we still have the PID registered for tombstone
+    assert record._record.pid.status == PIDStatus.REGISTERED
+
+    restored_rec = service.restore_record(superuser_identity, record.id)
+
+    # once for parent + once for the record
+    assert mock_datacite_client.api.show_doi.call_args_list[show_call_count:] == [
+        mock.call(doi),
+        mock.call(parent_doi),
+    ]
+
+    assert mock_datacite_client.api.update_doi.call_args_list[update_call_count:] == [
         mock.call(
             metadata={
                 "event": "publish",
@@ -757,10 +716,17 @@ def test_restore_pid(
                         "givenName": "Troy",
                     },
                     {
-                        "familyName": "Troy Inc.",
                         "name": "Troy Inc.",
+                        "familyName": "Troy Inc.",
                         "nameIdentifiers": [],
                         "nameType": "Organizational",
+                    },
+                ],
+                "relatedIdentifiers": [
+                    {
+                        "relatedIdentifier": doi,
+                        "relationType": "HasVersion",
+                        "relatedIdentifierType": "DOI",
                     },
                 ],
                 "titles": [{"title": "A Romans story"}],
@@ -773,57 +739,6 @@ def test_restore_pid(
             url=f"https://127.0.0.1:5000/doi/{parent_doi}",
         ),
     ]
-    mock_datacite_client.api.update_doi.assert_has_calls(expected_calls)
-
-    # make sure we still have the PID registered for tombstone
-    assert record._record.pid.status == PIDStatus.REGISTERED
-
-    restored_rec = service.restore_record(superuser_identity, record.id)
-
-    # once for parent + once for the record
-    assert mock_datacite_client.api.show_doi.call_count == 2
-
-    mock_datacite_client.api.update_doi.assert_has_calls(
-        expected_calls
-        + [
-            mock.call(
-                metadata={
-                    "event": "publish",
-                    "schemaVersion": "http://datacite.org/schema/kernel-4",
-                    "types": {"resourceTypeGeneral": "Image", "resourceType": "Photo"},
-                    "creators": [
-                        {
-                            "name": "Brown, Troy",
-                            "familyName": "Brown",
-                            "nameIdentifiers": [],
-                            "nameType": "Personal",
-                            "givenName": "Troy",
-                        },
-                        {
-                            "name": "Troy Inc.",
-                            "familyName": "Troy Inc.",
-                            "nameIdentifiers": [],
-                            "nameType": "Organizational",
-                        },
-                    ],
-                    "relatedIdentifiers": [
-                        {
-                            "relatedIdentifier": doi,  # restored version DOI
-                            "relationType": "HasVersion",
-                            "relatedIdentifierType": "DOI",
-                        },
-                    ],
-                    "titles": [{"title": "A Romans story"}],
-                    "dates": [{"date": "2020-06-01", "dateType": "Issued"}],
-                    "doi": parent_doi,
-                    "publicationYear": "2020",
-                    "publisher": {"name": "Acme Inc"},
-                },
-                doi=parent_doi,
-                url=f"https://127.0.0.1:5000/doi/{parent_doi}",
-            ),
-        ]
-    )
 
     assert restored_rec._obj.deletion_status == RecordDeletionStatusEnum.PUBLISHED
 


### PR DESCRIPTION
### Description

Closes: https://github.com/zenodo/ops/issues/534
Implements: https://github.com/inveniosoftware/invenio-rdm-records/pull/2436

* When blocking users all records and versions where deleting concurrently
* That created DeadLocks and other problems
* Now we serialize the transactions to avoid that



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
